### PR TITLE
Publish pipeline fix to address Issue 44

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Upgrade pip
         run: pip install --upgrade pip
 
-      - name: Install build & pdm-backend
-        run: pip install build pdm-backend
+      - name: Install build, pdm-backend, and grpcio-tools
+        run: pip install build pdm-backend grpcio-tools
 
       - name: Generate Protobuf (if needed)
         run: bash ./generate_proto.sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,9 +20,9 @@ jobs:
         run: pip install --upgrade pip
 
       - name: Install build, pdm-backend, and grpcio-tools
-        run: pip install build pdm-backend grpcio-tools
+        run: pip install build pdm-backend "grpcio-tools==1.68.1"
 
-      - name: Generate Protobuf (if needed)
+      - name: Generate Protobuf
         run: bash ./generate_proto.sh
 
       - name: Build wheel and sdist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Hedera Solo Integration Tests
+name: Hiero Solo Integration Tests
 
 on:
   push:
@@ -27,7 +27,7 @@ jobs:
       - name: Generate Proto Files
         run: bash ./generate_proto.sh
 
-      - name: Prepare Hedera Solo
+      - name: Prepare Hiero Solo
         id: solo
         uses: OpenElements/hedera-solo-action@v0.4
 

--- a/generate_proto.sh
+++ b/generate_proto.sh
@@ -21,7 +21,7 @@ touch $services_dir/__init__.py
 touch $mirror_dir/__init__.py
 
 # Step 2: Download and extract protobuf files
-echo "Downloading Hedera protobufs version $hapi_version..."
+echo "Downloading Hiero protobufs version $hapi_version..."
 curl -sL "https://github.com/hashgraph/hedera-protobufs/archive/refs/tags/${hapi_version}.tar.gz" | tar -xz -C $protos_dir --strip-components=1
 # Keep 'platform', 'services', and 'mirror', remove everything else
 find "$protos_dir" -mindepth 1 -maxdepth 1 ! -name platform ! -name services ! -name mirror -exec rm -r {} +


### PR DESCRIPTION
This is the fix for the following issue:
https://github.com/hiero-ledger/hiero-sdk-python/issues/44

This PR is adding grpc into the publish pipeline. It also renames Hedera to Hiero - however, a subsequent PR will have to point to hiero-solo and hiero-protobufs after these repositories have been transferred. 

Successful pipeline run:
https://github.com/hiero-ledger/hiero-sdk-python/actions/runs/13136982482/job/36654596492

deployed package:
https://pypi.org/project/hiero-sdk-python/0.0.0.dev2/#files