### PR TITLE
fix: misnamed parameter

### DIFF
--- a/src/hiero_sdk_python/crypto/public_key.py
+++ b/src/hiero_sdk_python/crypto/public_key.py
@@ -142,7 +142,7 @@ class PublicKey:
         if self.is_ed25519():
             return basic_types_pb2.Key(ed25519=pub_bytes)
         else:
-            return basic_types_pb2.Key(ECDSASecp256k1=pub_bytes)
+            return basic_types_pb2.Key(ECDSA_secp256k1=pub_bytes)
 
     def is_ed25519(self) -> bool:
         """


### PR DESCRIPTION
fixes #62

Changed ECDSASecp256k1 to ECDSA_secp256k1 to conform with basic_types_pb2's declaration of the Key object initialization parameters.