### PR TITLE
fix: PRCheck write

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,7 +1,7 @@
 name: 'PR Formatting'
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened
@@ -14,6 +14,8 @@ defaults:
 
 permissions:
   contents: read
+  checks: write
+  statuses: write
 
 concurrency:
   group: pr-checks-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -25,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.base.repo.fork }}
     permissions:
+      checks: write
       statuses: write
     steps:
       - name: Check PR Title


### PR DESCRIPTION
Prior: 
Error: Resource not accessible by integration

Consequence:
PR title checks were not checking

Approach:
Added status write permission
Added pull_request_target

I believe this is correct, but am new to this, links:
https://github.com/step-security/conventional-pr-title-action/tree/19fb561b33015fd2184055a05ce5a3bcf2ba3f54/
https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target

