### PR TITLE
feat: Duration Class

### DIFF
--- a/src/hiero_sdk_python/Duration.py
+++ b/src/hiero_sdk_python/Duration.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from hiero_sdk_python.hapi.services.duration_pb2 import Duration as proto_Duration
+
+@dataclass(frozen=True, init=True)
+class Duration:
+    """A frozen dataclass representing a duration in seconds."""
+    seconds: int
+
+    def __post_init__(self) -> None:
+        """Validate types after initialization."""
+        if not isinstance(self.seconds, int):
+            raise TypeError(f"seconds must be an integer, got {type(self.seconds).__name__}")
+
+    def to_proto(self) -> proto_Duration:
+        return proto_Duration(seconds=self.seconds)
+
+    @classmethod
+    def from_proto(cls, proto: proto_Duration) -> 'Duration':
+        if isinstance(proto, Duration):
+            raise ValueError("Invalid duration proto")
+        return cls(seconds=proto.seconds)
+
+    def __str__(self) -> str:
+        return f"Duration of {self.seconds} seconds."
+
+    def __repr__(self) -> str:
+        return f"Duration(seconds={self.seconds})"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Duration):
+            return False
+        return self.seconds == other.seconds

--- a/src/hiero_sdk_python/__init__.py
+++ b/src/hiero_sdk_python/__init__.py
@@ -33,6 +33,9 @@ from .hbar import Hbar
 # Timestamp
 from .timestamp import Timestamp
 
+# Duration
+from .Duration import Duration
+
 # Consensus
 from .consensus.topic_create_transaction import TopicCreateTransaction
 from .consensus.topic_message_submit_transaction import TopicMessageSubmitTransaction

--- a/src/hiero_sdk_python/account/account_create_transaction.py
+++ b/src/hiero_sdk_python/account/account_create_transaction.py
@@ -1,5 +1,6 @@
 from typing import Union
 
+from hiero_sdk_python.Duration import Duration
 from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.hapi.services import crypto_create_pb2, duration_pb2
 from hiero_sdk_python.response_code import ResponseCode
@@ -17,7 +18,7 @@ class AccountCreateTransaction(Transaction):
         key: PublicKey = None,
         initial_balance: Union[Hbar, int] = 0,
         receiver_signature_required: bool = False,
-        auto_renew_period: int = 7890000,  # 90 days in seconds
+        auto_renew_period: Duration = Duration(7890000),  # 90 days in seconds
         memo: str = ""
     ):
         """
@@ -84,7 +85,7 @@ class AccountCreateTransaction(Transaction):
         self.receiver_signature_required = required
         return self
 
-    def set_auto_renew_period(self, seconds: int):
+    def set_auto_renew_period(self, seconds: int | Duration):
         """
         Sets the auto-renew period in seconds.
 
@@ -95,8 +96,13 @@ class AccountCreateTransaction(Transaction):
             AccountCreateTransaction: The current transaction instance for method chaining.
         """
         self._require_not_frozen()
-        self.auto_renew_period = seconds
-        return self
+        if isinstance(seconds, int):
+            self.auto_renew_period = Duration(seconds)
+        elif isinstance(seconds, Duration):
+            self.auto_renew_period = seconds
+        else:
+            raise TypeError("Duration of invalid type")
+
 
     def set_account_memo(self, memo: str):
         """
@@ -137,7 +143,7 @@ class AccountCreateTransaction(Transaction):
             key=self.key.to_proto(),
             initialBalance=initial_balance_tinybars,
             receiverSigRequired=self.receiver_signature_required,
-            autoRenewPeriod=duration_pb2.Duration(seconds=self.auto_renew_period),
+            autoRenewPeriod=duration_pb2.Duration(seconds=self.auto_renew_period.seconds),
             memo=self.account_memo
         )
 

--- a/src/hiero_sdk_python/consensus/topic_create_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_create_transaction.py
@@ -1,14 +1,15 @@
+from hiero_sdk_python.Duration import Duration
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.hapi.services import consensus_create_topic_pb2, duration_pb2
 
 class TopicCreateTransaction(Transaction):
-    def __init__(self, memo=None, admin_key=None, submit_key=None, auto_renew_period=None, auto_renew_account=None):
+    def __init__(self, memo=None, admin_key=None, submit_key=None, auto_renew_period: Duration=None, auto_renew_account=None):
         super().__init__()
         self.memo = memo or ""
         self.admin_key = admin_key
         self.submit_key = submit_key
-        self.auto_renew_period = auto_renew_period or 7890000 
+        self.auto_renew_period: Duration = auto_renew_period or Duration(7890000)
         self.auto_renew_account = auto_renew_account
         self.transaction_fee = 10_000_000
 
@@ -27,9 +28,14 @@ class TopicCreateTransaction(Transaction):
         self.submit_key = key
         return self
 
-    def set_auto_renew_period(self, seconds):
+    def set_auto_renew_period(self, seconds: Duration | int):
         self._require_not_frozen()
-        self.auto_renew_period = seconds
+        if isinstance(seconds, int):
+            self.auto_renew_period = Duration(seconds)
+        elif isinstance(seconds, Duration):
+            self.auto_renew_period = seconds
+        else:
+            raise TypeError("Duration of invalid type")
         return self
 
     def set_auto_renew_account(self, account_id):
@@ -51,7 +57,7 @@ class TopicCreateTransaction(Transaction):
         transaction_body.consensusCreateTopic.CopyFrom(consensus_create_topic_pb2.ConsensusCreateTopicTransactionBody(
             adminKey=self.admin_key.to_proto() if self.admin_key is not None else None,
             submitKey=self.submit_key.to_proto() if self.submit_key is not None else None,
-            autoRenewPeriod=duration_pb2.Duration(seconds=self.auto_renew_period),
+            autoRenewPeriod=duration_pb2.Duration(seconds=self.auto_renew_period.seconds),
             autoRenewAccount=self.auto_renew_account.to_proto() if self.auto_renew_account is not None else None,
             memo=self.memo
         ))

--- a/src/hiero_sdk_python/consensus/topic_create_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_create_transaction.py
@@ -1,7 +1,7 @@
 from hiero_sdk_python.Duration import Duration
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.transaction.transaction import Transaction
-from hiero_sdk_python.hapi.services import consensus_create_topic_pb2, duration_pb2
+from hiero_sdk_python.hapi.services import consensus_create_topic_pb2
 
 class TopicCreateTransaction(Transaction):
     def __init__(self, memo=None, admin_key=None, submit_key=None, auto_renew_period: Duration=None, auto_renew_account=None):
@@ -57,7 +57,7 @@ class TopicCreateTransaction(Transaction):
         transaction_body.consensusCreateTopic.CopyFrom(consensus_create_topic_pb2.ConsensusCreateTopicTransactionBody(
             adminKey=self.admin_key.to_proto() if self.admin_key is not None else None,
             submitKey=self.submit_key.to_proto() if self.submit_key is not None else None,
-            autoRenewPeriod=duration_pb2.Duration(seconds=self.auto_renew_period.seconds),
+            autoRenewPeriod=self.auto_renew_period.to_proto() if self.auto_renew_period is not None else None,
             autoRenewAccount=self.auto_renew_account.to_proto() if self.auto_renew_account is not None else None,
             memo=self.memo
         ))

--- a/src/hiero_sdk_python/consensus/topic_info.py
+++ b/src/hiero_sdk_python/consensus/topic_info.py
@@ -49,7 +49,7 @@ class TopicInfo:
                 if topic_info_proto.HasField("submitKey") else None
             ),
             auto_renew_period=(
-                Duration.from_proto(proto=topic_info_proto.autoRenewPeriod) # Warning: Not sure why my ide says this method doesnt exist, it does, the topic_info_proto.autoRenewPeriod is the same type as required by the from_proto method as well...
+                Duration.from_proto(proto=topic_info_proto.autoRenewPeriod)
                 if topic_info_proto.HasField("autoRenewPeriod") else None
             ),
             auto_renew_account=(

--- a/src/hiero_sdk_python/consensus/topic_info.py
+++ b/src/hiero_sdk_python/consensus/topic_info.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from hiero_sdk_python.hapi.services.basic_types_pb2 import Key, AccountID
 from hiero_sdk_python.hapi.services.timestamp_pb2 import Timestamp
-from hiero_sdk_python.hapi.services.duration_pb2 import Duration
+from hiero_sdk_python import Duration
 from hiero_sdk_python.utils.key_format import format_key
 
 class TopicInfo:
@@ -23,7 +23,7 @@ class TopicInfo:
         self.expiration_time = expiration_time
         self.admin_key = admin_key
         self.submit_key = submit_key
-        self.auto_renew_period = auto_renew_period
+        self.auto_renew_period: Duration = auto_renew_period
         self.auto_renew_account = auto_renew_account
         self.ledger_id = ledger_id
 
@@ -49,7 +49,7 @@ class TopicInfo:
                 if topic_info_proto.HasField("submitKey") else None
             ),
             auto_renew_period=(
-                topic_info_proto.autoRenewPeriod 
+                Duration.from_proto(proto=topic_info_proto.autoRenewPeriod) # Warning: Not sure why my ide says this method doesnt exist, it does, the topic_info_proto.autoRenewPeriod is the same type as required by the from_proto method as well...
                 if topic_info_proto.HasField("autoRenewPeriod") else None
             ),
             auto_renew_account=(
@@ -84,7 +84,7 @@ class TopicInfo:
             f"  expiration_time={exp_dt},\n"
             f"  admin_key={format_key(self.admin_key)},\n"
             f"  submit_key={format_key(self.submit_key)},\n"
-            f"  auto_renew_period={self.auto_renew_period},\n"
+            f"  auto_renew_period={self.auto_renew_period.seconds},\n"
             f"  auto_renew_account={self.auto_renew_account},\n"
             f"  ledger_id={self.ledger_id}\n"
             ")"

--- a/src/hiero_sdk_python/consensus/topic_update_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_update_transaction.py
@@ -1,3 +1,4 @@
+from hiero_sdk_python.Duration import Duration
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.hapi.services import consensus_update_topic_pb2, duration_pb2
@@ -10,7 +11,7 @@ class TopicUpdateTransaction(Transaction):
         memo=None,
         admin_key=None,
         submit_key=None,
-        auto_renew_period=7890000,
+        auto_renew_period: Duration = Duration(7890000),
         auto_renew_account=None,
         expiration_time=None,
     ):
@@ -19,7 +20,7 @@ class TopicUpdateTransaction(Transaction):
         self.memo = memo or ""
         self.admin_key = admin_key
         self.submit_key = submit_key
-        self.auto_renew_period = auto_renew_period
+        self.auto_renew_period:Duration = auto_renew_period
         self.auto_renew_account = auto_renew_account
         self.expiration_time = expiration_time
         self.transaction_fee = 10_000_000
@@ -80,7 +81,7 @@ class TopicUpdateTransaction(Transaction):
         self.submit_key = key
         return self
 
-    def set_auto_renew_period(self, seconds):
+    def set_auto_renew_period(self, seconds: Duration | int):
         """
         Sets the auto-renew period for the topic.
 
@@ -91,7 +92,12 @@ class TopicUpdateTransaction(Transaction):
             TopicUpdateTransaction: Returns the instance for method chaining.
         """
         self._require_not_frozen()
-        self.auto_renew_period = seconds
+        if isinstance(seconds, int):
+            self.auto_renew_period = Duration(seconds)
+        elif isinstance(seconds, Duration):
+            self.auto_renew_period = seconds
+        else:
+            raise TypeError("Duration of invalid type")
         return self
 
     def set_auto_renew_account(self, account_id):
@@ -140,7 +146,7 @@ class TopicUpdateTransaction(Transaction):
             topicID=self.topic_id.to_proto(),
             adminKey=self.admin_key.to_proto() if self.admin_key else None,
             submitKey=self.submit_key.to_proto() if self.submit_key else None,
-            autoRenewPeriod=duration_pb2.Duration(seconds=self.auto_renew_period) if self.auto_renew_period else None,
+            autoRenewPeriod=duration_pb2.Duration(seconds=self.auto_renew_period.seconds) if self.auto_renew_period else None,
             autoRenewAccount=self.auto_renew_account.to_proto() if self.auto_renew_account else None,
             expirationTime=self.expiration_time.to_proto() if self.expiration_time else None,
             memo=_wrappers_pb2.StringValue(value=self.memo) if self.memo else None


### PR DESCRIPTION
**Description**:
Introduce a `Duration` class to represent time durations in seconds, a wrapper for the protobuf Duration class.

- Add `Duration` class with `seconds` attribute
- Implement validation to ensure `seconds` is an integer
- Add `to_proto` method to convert to `proto_Duration`
- Add `from_proto` class method to create `Duration` from `proto_Duration`
- Implement `__str__` and `__repr__` for string representations
- Implement `__eq__` for equality comparison

**Checklist**:
- [x] Documented (Code comments)
- [x] Tested (basic testing for type safety)
