### PR TITLE
fix(datetime): replace datetime.utcnow() with datetime.now(timezone.u…

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -460,7 +460,7 @@ print(topic_info)
 ```
 query = TopicMessageQuery(
     topic_id=topic_id,
-    start_time=datetime.utcnow(),
+    start_time=datetime.now(timezone.utc),
     chunking_enabled=True,
     limit=0
 )
@@ -473,7 +473,7 @@ query.subscribe(client)
 query = (
     TopicMessageQuery()
     .set_topic_id(topic_id) 
-    .set_start_time(datetime.utcnow()) 
+    .set_start_time(datetime.now(timezone.utc)) 
     .set_chunking_enabled(True) 
     .set_limit(0) 
     )

--- a/examples/query_topic_message.py
+++ b/examples/query_topic_message.py
@@ -1,6 +1,6 @@
 import os
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from dotenv import load_dotenv
 
 from hiero_sdk_python import Network, Client, TopicMessageQuery
@@ -19,7 +19,8 @@ def query_topic_messages():
 
     query = TopicMessageQuery(
         topic_id=os.getenv('TOPIC_ID'),
-        start_time=datetime.utcnow(),
+        start_time=datetime.now(timezone.utc),
+
         limit=0,
         chunking_enabled=True
     )

--- a/tests/test_topic_message_query.py
+++ b/tests/test_topic_message_query.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import MagicMock, patch
-from datetime import datetime
+from datetime import datetime, timezone
 from hiero_sdk_python.query.topic_message_query import TopicMessageQuery
 from hiero_sdk_python.client.client import Client
 from hiero_sdk_python.consensus.topic_id import TopicId
@@ -37,7 +37,7 @@ def test_topic_message_query_subscription(mock_client, mock_topic_id, mock_subsc
     """
     Test subscribing to topic messages using TopicMessageQuery.
     """
-    query = TopicMessageQuery().set_topic_id(mock_topic_id).set_start_time(datetime.utcnow())
+    query = TopicMessageQuery().set_topic_id(mock_topic_id).set_start_time(datetime.now(timezone.utc))
 
     with patch("hiero_sdk_python.query.topic_message_query.TopicMessageQuery.subscribe") as mock_subscribe:
         def side_effect(client, on_message, on_error):


### PR DESCRIPTION
fix(datetime): replace datetime.utcnow()

**Description**:
Local tests had a minor error flagging datetime.utcnow() was deprecated.
Investigations revealed subsequent python releases have worked continually on this.



<!--
Add support for ...
* datetime.now(timezone.utc)
-->

**Notes for reviewer**:
Current use has been upgraded to use datetime.now(timezone.utc).
Python 3.10 https://docs.python.org/3.10/library/datetime.html?highlight=utc#datetime.timezone.utc
recommends datetime.now(timezone.utc). 

**Checklist**
- [X] Documented (Code comments, README, etc.) - ReadME updated, imports updated
- [X] Tested (unit, integration, etc) - existing tests now pass 
