### PR TITLE
fix: ed25519 key ambiguity

### DIFF
--- a/examples/account_create.py
+++ b/examples/account_create.py
@@ -18,10 +18,10 @@ def create_new_account():
     client = Client(network)
 
     operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+    operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
     client.set_operator(operator_id, operator_key)
 
-    new_account_private_key = PrivateKey.generate()
+    new_account_private_key = PrivateKey.generate("ed25519")
     new_account_public_key = new_account_private_key.public_key()
 
     transaction = (

--- a/examples/keys_private_der.py
+++ b/examples/keys_private_der.py
@@ -1,0 +1,57 @@
+"""
+Example file: Demonstrating how to serialize a PrivateKey to DER (hex)
+and then load it back.
+*WARNING* DER‐encoded private keys should not be printed or exposed in a real-world scenario.
+"""
+
+from cryptography.exceptions import InvalidSignature
+from hiero_sdk_python.crypto.private_key import PrivateKey
+
+def example_serialize_ed25519_der() -> None:
+    print("=== Ed25519: Serialize to DER ===")
+    
+    privkey = PrivateKey.generate("ed25519")
+    print("Generated Ed25519 key:", privkey)
+    
+    # This emits Traditional Open SSL DER by default
+    der_bytes = privkey.to_bytes_der()
+    print("DER bytes length =", len(der_bytes))
+
+    der_hex = der_bytes.hex()
+    print("DER hex =", der_hex)
+
+    # Load it back from hex
+    privkey2 = PrivateKey.from_string_der(der_hex)
+    print("Loaded back from DER:", privkey2)
+
+    # Sign & verify
+    signature = privkey2.sign(b"test")
+    privkey2.public_key().verify(signature, b"test")
+    print("Ed25519 DER reload: Verified signature OK.\n")
+
+def example_serialize_ecdsa_der() -> None:
+    print("=== ECDSA: Serialize to DER ===")
+    
+    # use generate("ecdsa")
+    privkey = PrivateKey.generate("ecdsa")
+    print("Generated ECDSA key:", privkey)
+    
+    der_bytes = privkey.to_bytes_der()
+    print("DER bytes length =", len(der_bytes))
+
+    der_hex = der_bytes.hex()
+    print("DER hex =", der_hex)
+
+    privkey2 = PrivateKey.from_string_der(der_hex)
+    print("Loaded back from DER:", privkey2)
+
+    signature = privkey2.sign(b"hello ECDSA serialization")
+    privkey2.public_key().verify(signature, b"hello ECDSA serialization")
+    print("ECDSA DER reload: Verified signature OK.\n")
+
+def main():
+    example_serialize_ed25519_der()
+    example_serialize_ecdsa_der()
+
+if __name__ == "__main__":
+    main()

--- a/examples/keys_private_ecdsa.py
+++ b/examples/keys_private_ecdsa.py
@@ -1,0 +1,126 @@
+"""
+Example file: Working with ECDSA (secp256k1) PrivateKey using the PrivateKey class
+*WARNING* ECDSA seeds should not be printed or exposed in a real‑world scenario
+"""
+from cryptography.exceptions import InvalidSignature
+from hiero_sdk_python.crypto.private_key import PrivateKey
+
+def example_generate_ecdsa() -> None:
+    """
+    Demonstrates generating a new ECDSA (secp256k1) PrivateKey,
+    signing data, and verifying with the associated PublicKey.
+    """
+    print("=== ECDSA: Generate & Sign ===")
+    # 1) Generate ECDSA
+    privkey = PrivateKey.generate("ecdsa")
+    print("Generated ECDSA PrivateKey (hex) =", privkey)
+    
+    # 2) Get the public key
+    pubkey = privkey.public_key()
+    print("Derived public key =", pubkey)
+
+    # 3) Sign data
+    data = b"hello ECDSA!"
+    signature = privkey.sign(data)
+    print("Signature (hex) =", signature.hex())
+
+    # 4) Verify signature using the public key
+    try:
+        pubkey.verify(signature, data)
+        print("Signature is VALID (ECDSA)!")
+    except InvalidSignature:
+        print("Signature is INVALID (ECDSA)!")
+    print()
+
+def example_load_ecdsa_raw() -> None:
+    """
+    Demonstrates creating an ECDSA (secp256k1) PrivateKey from raw 32 bytes (a scalar).
+    Then signs and verifies.
+    """
+    print("=== ECDSA: Load from Raw ===")
+    # 32 bytes. Example: 0xAB repeated.
+    raw_scalar_hex = "ab" * 32
+    raw_scalar = bytes.fromhex(raw_scalar_hex)
+
+    # 1) Generate ECDSA
+    privkey = PrivateKey.from_bytes_ecdsa(raw_scalar)
+    print("Loaded ECDSA PrivateKey from raw scalar =", privkey)
+
+    # 2) Get the public key
+    pubkey = privkey.public_key()
+
+    # 3) Sign/Verify
+    data = b"ECDSA from raw scalar"
+    signature = privkey.sign(data)
+    try:
+        pubkey.verify(signature, data)
+        print("ECDSA signature valid with raw scalar!")
+    except InvalidSignature:
+        print("Signature invalid?!")
+    print()
+
+def example_load_ecdsa_from_hex() -> None:
+    """
+    Demonstrates creating an ECDSA (secp256k1) PrivateKey from a hex-encoded 32-byte scalar.
+    """
+    print("=== ECDSA: Load from Hex ===")
+    # 32-byte scalar in hex. Must not be zero; example:
+    ecdsa_hex = "abcdef0000000000000000000000000000000000000000000000000000000001"
+    
+    # 1) Generate ECDSA
+    privkey = PrivateKey.from_string_ecdsa(ecdsa_hex)
+    print("Loaded ECDSA PrivateKey from hex =", privkey)
+
+    # 2) Get the public key
+    pubkey = privkey.public_key()
+
+    # 3) Quick sign/verify
+    data = b"Testing ECDSA hex load"
+    signature = privkey.sign(data)
+    try:
+        pubkey.verify(signature, data)
+        print("ECDSA signature valid with hex-loaded key!")
+    except InvalidSignature:
+        print("Signature invalid?!")
+    print()
+
+def example_load_ecdsa_der() -> None:
+    """
+    Demonstrates loading an ECDSA (secp256k1) private key from DER bytes.
+    TraditionalOpenSSL in hex form for demonstration.
+    """
+    print("=== ECDSA: Load from DER ===")
+    # Example TraditionalOpenSSL DER-encoded key (for scalar=1).
+    # (Truncated for demonstration)
+    der_hex = (
+        "304e02010104"
+        "200100000000000000000000000000000000000000000000000000000000000000"
+        "a00706052b8104000aa1440342000479be667ef9dcbbac55a06295ce870b07029bfcdb"
+        "2dce28d959f2815b16f8179842a2f1423fc2440aeddc92f8cd3dfff65d61b2334fa1dafc519e6b9f3"
+    )
+    
+    # 1) Generate DER
+    privkey = PrivateKey.from_string_der(der_hex)
+    print("Loaded ECDSA PrivateKey from DER =", privkey)
+
+    # 2) Get the public key
+    pubkey = privkey.public_key()
+
+    # 3) Sign/Verify
+    data = b"DER-based ECDSA"
+    signature = privkey.sign(data)
+    try:
+        pubkey.verify(signature, data)
+        print("ECDSA signature valid using DER-loaded key!")
+    except InvalidSignature:
+        print("Signature invalid?!")
+    print()
+
+def main_ecdsa():
+    example_generate_ecdsa()
+    example_load_ecdsa_raw()
+    example_load_ecdsa_from_hex()
+    example_load_ecdsa_der()
+
+if __name__ == "__main__":
+    main_ecdsa()

--- a/examples/keys_private_ed25519.py
+++ b/examples/keys_private_ed25519.py
@@ -1,0 +1,124 @@
+"""
+Example file: Working with Ed25519 PrivateKey using the PrivateKey class
+*WARNING* Ed25519 seeds should not be printed or exposed in a real‑world scenario
+"""
+from cryptography.exceptions import InvalidSignature
+from hiero_sdk_python.crypto.private_key import PrivateKey
+
+def example_generate_ed25519() -> None:
+    """
+    Demonstrates generating a brand new Ed25519 PrivateKey, signing data,
+    and verifying the signature with its corresponding PublicKey.
+    """
+    print("=== Ed25519: Generate & Sign ===")
+    # 1) Generate Ed25519 by specifying in "'"
+    privkey = PrivateKey.generate("ed25519")
+    print("Generated Ed25519 PrivateKey (hex) =", privkey)
+    
+    # 2) Get the public key for this ed25519 private key
+    pubkey = privkey.public_key()
+    print("Derived public key =", pubkey)
+
+    # 3) Sign data
+    data = b"hello ed25519!"
+    signature = privkey.sign(data)
+    print("Signature (hex) =", signature.hex())
+    # 4) Verify signature using the public key
+    try:
+        pubkey.verify(signature, data)
+        print("Signature is VALID (Ed25519)!")
+    except InvalidSignature:
+        print("Signature is INVALID (Ed25519)!")
+    print()
+
+def example_load_ed25519_raw() -> None:
+    """
+    Demonstrates creating a PrivateKey from a 32-byte raw Ed25519 seed.
+    Then uses it for signing and verifying.
+    """
+    print("=== Ed25519: Load from Raw ===")
+    raw_seed_hex = "01" * 32  # Example 32 bytes
+
+    # Now this becomes a raw seed
+    raw_seed = bytes.fromhex(raw_seed_hex)
+
+    # Create private ed25519 key from ed25519 seed.
+    privkey = PrivateKey.from_bytes_ed25519(raw_seed)
+    print("Loaded Ed25519 PrivateKey from raw seed =", privkey)
+
+    # Derive the public key
+    pubkey = privkey.public_key()
+
+    # Sign & verify
+    data = b"Ed25519 from raw"
+    signature = privkey.sign(data)
+    try:
+        pubkey.verify(signature, data)
+        print("Signature valid with Ed25519 from raw seed!")
+    except InvalidSignature:
+        print("Signature invalid?!")
+    print()
+
+def example_load_ed25519_from_hex() -> None:
+    """
+    Demonstrates creating a PrivateKey from a hex-encoded string for Ed25519.
+    Must be 32 bytes in total, i.e. 64 hex characters.
+    """
+    print("=== Ed25519: Load from Hex ===")
+    # A random 32-byte example:
+    ed_hex = "a1" * 16 + "b2" * 16  # => 64 hex characters => 32 bytes
+
+    # Create private ed25519 key from hex.
+    privkey = PrivateKey.from_string_ed25519(ed_hex)
+    print("Loaded Ed25519 PrivateKey from hex =", privkey)
+
+    # Derive the public key
+    pubkey = privkey.public_key()
+
+    # Sign & verify
+    data = b"Test data"
+    signature = privkey.sign(data)
+    try:
+        pubkey.verify(signature, data)
+        print("Ed25519 signature valid with hex-loaded key!")
+    except InvalidSignature:
+        print("Signature invalid?!")
+    print()
+
+def example_load_ed25519_der() -> None:
+    """
+    Demonstrates loading an Ed25519 private key from DER bytes (hex form).
+    In actual usage, you might read the raw DER bytes from a file (binary),
+    then call from_der(...) or from_string_der(...).
+    """
+    print("=== Ed25519: Load from DER ===")
+    # This DER encodes a small example Ed25519 key whose raw seed might be all 0x01.
+    # 46 bytes in total; for demonstration only.
+    der_hex = (
+        "302e020100300506032b657004220420"
+        "0101010101010101010101010101010101010101010101010101010101010101"
+    )
+    
+    # Create private and public key
+    privkey = PrivateKey.from_string_der(der_hex)
+    print("Loaded Ed25519 PrivateKey from DER =", privkey)
+    pubkey = privkey.public_key()
+
+    # Sign/Verify
+    data = b"DER-based Ed25519"
+    signature = privkey.sign(data)
+    try:
+        pubkey.verify(signature, data)
+        print("Ed25519 signature valid using DER-loaded key!")
+    except InvalidSignature:
+        print("Signature invalid?!")
+    print()
+
+def main_ed25519():
+    example_generate_ed25519()
+    example_load_ed25519_raw()
+    example_load_ed25519_from_hex()
+    example_load_ed25519_der()
+
+if __name__ == "__main__":
+    main_ed25519()

--- a/examples/keys_public_der.py
+++ b/examples/keys_public_der.py
@@ -1,0 +1,86 @@
+"""
+Example file: Working with DER-encoded SubjectPublicKeyInfo (SPKI) public keys.
+"""
+
+from cryptography.hazmat.primitives.asymmetric import ec, ed25519
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.exceptions import InvalidSignature
+from hiero_sdk_python.crypto.public_key import PublicKey
+
+def example_load_ecdsa_der() -> None:
+    """
+    Demonstrate creating a secp256k1 ECDSA PublicKey from DER-encoded bytes.
+    """
+    # Generate a ECDSA key pair.
+    private_key = ec.generate_private_key(ec.SECP256K1())
+    public_key = private_key.public_key()
+    
+    # Export public key to DER format (SubjectPublicKeyInfo)
+    der_bytes = public_key.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    
+    # 1) Create via from_der()
+    pubk_obj = PublicKey.from_der(der_bytes)
+    print("Loaded ECDSA secp256k1 from DER:", pubk_obj)
+    
+    # 2) Convert back to DER hex:
+    der_hex = pubk_obj.to_string_der()
+    print("DER-encoded hex:", der_hex)
+
+def example_load_ed25519_der() -> None:
+    """
+    Demonstrate creating an Ed25519 PublicKey from DER-encoded bytes.
+    """
+    # Generate a Ed25519 key pair.
+    private_key = ed25519.Ed25519PrivateKey.generate()
+    public_key = private_key.public_key()
+
+    # Export public key to DER format (SubjectPublicKeyInfo)
+    der_bytes = public_key.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    
+    # 1) Create via from_der
+    pubk_obj = PublicKey.from_der(der_bytes)
+    print("Loaded Ed25519 from DER:", pubk_obj)
+
+    # 2) Convert back to hex
+    der_hex = pubk_obj.to_string_der()
+    print("Ed25519 DER hex:", der_hex)
+
+def example_verify_der_signature() -> None:
+    """
+    Demonstrate verifying an ECDSA signature using a DER-encoded public key.
+    """
+    private_key = ec.generate_private_key(ec.SECP256K1())
+    public_key = private_key.public_key()
+
+    der_bytes = public_key.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+
+    # Wrap into public key object from DER
+    pubk_obj = PublicKey.from_der(der_bytes)
+
+    # Sign and verify, specifying hash algorithm for ECDSA
+    data = b"Hello DER"
+    signature = private_key.sign(data, ec.ECDSA(hashes.SHA256()))
+    try:
+        pubk_obj.verify(signature, data)
+        print("DER: ECDSA signature verified!")
+    except InvalidSignature:
+        print("DER: ECDSA signature invalid.")
+
+def main():
+    example_load_ecdsa_der()
+    print("-----")
+    example_load_ed25519_der()
+    print("-----")
+    example_verify_der_signature()
+
+if __name__ == "__main__":
+    main()

--- a/examples/keys_public_ecdsa.py
+++ b/examples/keys_public_ecdsa.py
@@ -1,0 +1,73 @@
+"""
+Example file: Working with an ECDSA (secp256k1) PublicKey using the PublicKey class.
+"""
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives import hashes
+from cryptography.exceptions import InvalidSignature
+from hiero_sdk_python.crypto.public_key import PublicKey
+
+def example_load_compressed_ecdsa() -> None:
+    """
+    Demonstrate creating a PublicKey object from a compressed 33-byte ECDSA hex.
+    """
+    # A mock 33-byte compressed hex:
+    compressed_pubkey = bytes.fromhex("0281c2e57fecef82ff4f546dece3684acb6e2fe12a97af066348de81ccaf05d0a4")
+    
+    # 1) Construct via the specialized from_bytes_ecdsa()
+    pubk_obj = PublicKey.from_bytes_ecdsa(compressed_pubkey) # or from_bytes
+    print("Loaded ECDSA PublicKey (compressed) =", pubk_obj)
+    
+    # 2) Convert it back to compressed hex
+    compressed_hex = pubk_obj.to_string_ecdsa()
+    print("Back to compressed hex:", compressed_hex)
+    
+def example_load_uncompressed_ecdsa_from_hex() -> None:
+    """
+    Demonstrate creating an ECDSA (secp256k1) public key from an uncompressed 65-byte hex string.
+    """
+    # Uncompressed secp256k1 public keys start with 0x04 and are 65 bytes total.
+    uncompressed_hex = (
+        "04"
+        "18a5fcc2a9af70f6248efa1a2b0cc7d6cf973f43ae6c041ff35a1a3f7d947ba6"
+        "15ba91825331ad2ce55d44469d4e874a997e3888e20e2d50322d52c365cad7f3e"
+    )
+    
+    # 1) Load directly from a hex string using the specialized from_string_ecdsa().
+    pubk_obj = PublicKey.from_string_ecdsa(uncompressed_hex) # or from_string
+    print("Loaded uncompressed ECDSA PublicKey from hex:", pubk_obj)
+    
+    # 2) Convert to compressed raw bytes or hex:
+    compressed_bytes = pubk_obj.to_bytes_ecdsa() #or to_bytes_raw
+    print("Compressed ECDSA bytes (len={}):".format(len(compressed_bytes)), compressed_bytes.hex())
+
+def example_verify_ecdsa_signature() -> None:
+    """
+    Demonstrate verifying a signature with an ECDSA secp256k1 public key.
+    """
+    # Generate a key pair to be able to sign
+    private_key = ec.generate_private_key(ec.SECP256K1())
+    public_key = private_key.public_key()
+
+    # 1) Wrap in the PublicKey class
+    pubk_obj = PublicKey(public_key)
+    
+    # 2) Sign some data
+    data = b"Hello ECDSA"
+    signature = private_key.sign(data, ec.ECDSA(hashes.SHA256()))
+    
+    # 3) Verify with pubk_obj
+    try:
+        pubk_obj.verify(signature, data)
+        print("ECDSA signature is valid!")
+    except InvalidSignature:
+        print("ECDSA signature is INVALID!")
+
+def main():
+    example_load_compressed_ecdsa()
+    print("-----")
+    example_load_uncompressed_ecdsa_from_hex()
+    print("-----")
+    example_verify_ecdsa_signature()
+
+if __name__ == "__main__":
+    main()

--- a/examples/keys_public_ed25519.py
+++ b/examples/keys_public_ed25519.py
@@ -1,0 +1,71 @@
+"""
+Example file: Working with an Ed25519 PublicKey using the PublicKey class
+"""
+
+from cryptography.hazmat.primitives.asymmetric import ed25519
+from cryptography.exceptions import InvalidSignature
+from hiero_sdk_python.crypto.public_key import PublicKey
+
+def example_load_ed25519_from_raw() -> None:
+    """
+    Demonstrate creating a PublicKey object from a 32-byte Ed25519 public key.
+    Please ensure to pass a public key not a private key.
+    """
+    # Ed25519 public key bytes are always 32 bytes. 
+    # Most random 32 bytes will be a valid key, so here is a random example:
+    raw_pub = bytes.fromhex(
+        "8baa5f735dbf40f275283bed504cb752b1ce58a7118476d28f528ecd265c5f58"
+    )
+    
+    # 1) Construct via from_bytes_ed25519
+    pubk_obj = PublicKey.from_bytes_ed25519(raw_pub) #or from_bytes
+    print("Loaded Ed25519 PublicKey from raw bytes =", pubk_obj)
+    
+    # 2) Convert back to raw hex
+    back_to_hex = pubk_obj.to_string_ed25519() #or to_string
+    print("Back to Ed25519 hex:", back_to_hex)
+
+def example_load_ed25519_from_hex() -> None:
+    """
+    Demonstrate creating a PublicKey object from a 32-byte hex string 
+    representing an Ed25519 public key.
+    """
+    # Must be 64 hex characters e.g.
+    hex_str = "09fe6e485c1fb4e24c80b591fc79103c28006d549428a0d3ccb2a88412f2bda8"
+    
+    # Construct using from_string_ed25519
+    pubk_obj = PublicKey.from_string_ed25519(hex_str) #or from_string
+    print("Loaded Ed25519 PublicKey from hex:", pubk_obj)
+    
+def example_verify_ed25519_signature() -> None:
+    """
+    Demonstrate verifying an Ed25519 signature.
+    """
+    # Ed25519 is "EdDSA over Curve25519". 
+    # Key pair:
+    private_key = ed25519.Ed25519PrivateKey.generate()
+    public_key = private_key.public_key()
+
+    # Wrap in the PublicKey class
+    pubk_obj = PublicKey(public_key)
+    
+    # Sign data
+    data = b"Hello Ed25519"
+    signature = private_key.sign(data)
+    
+    # Verify
+    try:
+        pubk_obj.verify(signature, data)
+        print("Ed25519 signature is valid!")
+    except InvalidSignature:
+        print("Ed25519 signature is INVALID!")
+
+def main():
+    example_load_ed25519_from_raw()
+    print("-----")
+    example_load_ed25519_from_hex()
+    print("-----")
+    example_verify_ed25519_signature()
+
+if __name__ == "__main__":
+    main()

--- a/examples/query_balance.py
+++ b/examples/query_balance.py
@@ -22,11 +22,11 @@ def create_account_and_transfer():
     client = Client(network)
 
     operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+    operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
     client.set_operator(operator_id, operator_key)
 
     # Create new account
-    new_account_private_key = PrivateKey.generate()
+    new_account_private_key = PrivateKey.generate("ed25519")
     new_account_public_key = new_account_private_key.public_key()
     transaction = AccountCreateTransaction(
         key=new_account_public_key,

--- a/examples/query_receipt.py
+++ b/examples/query_receipt.py
@@ -20,7 +20,7 @@ def query_receipt():
     client = Client(network)
 
     operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+    operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
     recipient_id = AccountId.from_string(os.getenv('RECIPIENT_ID'))
     amount = 10
 

--- a/examples/query_topic_info.py
+++ b/examples/query_topic_info.py
@@ -14,7 +14,7 @@ load_dotenv()
 
 def query_topic_info():
     operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+    operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
     topic_id = TopicId.from_string(os.getenv('TOPIC_ID'))
 
     network = Network(network='testnet')

--- a/examples/token_associate.py
+++ b/examples/token_associate.py
@@ -18,7 +18,7 @@ def associate_token():
     client = Client(network)
 
     recipient_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    recipient_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+    recipient_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
     token_id = TokenId.from_string('TOKEN_ID')  # Update as needed
 
     client.set_operator(recipient_id, recipient_key)

--- a/examples/token_create_fungible_finite.py
+++ b/examples/token_create_fungible_finite.py
@@ -41,12 +41,12 @@ def create_token_fungible_finite():
 
     # Operator credentials (must be present)
     operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+    operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
 
     # Optional Token Keys
-    admin_key = PrivateKey.from_string(os.getenv('ADMIN_KEY'))# Optional
-    supply_key = PrivateKey.from_string(os.getenv('SUPPLY_KEY')) # Optional
-    freeze_key = PrivateKey.from_string(os.getenv('FREEZE_KEY')) # Optional
+    admin_key = PrivateKey.from_string_ed25519(os.getenv('ADMIN_KEY'))# Optional
+    supply_key = PrivateKey.from_string_ed25519(os.getenv('SUPPLY_KEY'))# Optional
+    freeze_key = PrivateKey.from_string_ed25519(os.getenv('FREEZE_KEY'))# Optional
 
     # Set the operator for the client
     client.set_operator(operator_id, operator_key)

--- a/examples/token_create_fungible_infinite.py
+++ b/examples/token_create_fungible_infinite.py
@@ -41,12 +41,12 @@ def create_token_fungible_infinite():
 
     # Operator credentials (must be present)
     operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+    operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
 
     # Optional Token Keys
-    admin_key = PrivateKey.from_string(os.getenv('ADMIN_KEY'))# Optional
-    supply_key = PrivateKey.from_string(os.getenv('SUPPLY_KEY')) # Optional
-    freeze_key = PrivateKey.from_string(os.getenv('FREEZE_KEY')) # Optional
+    admin_key = PrivateKey.from_string_ed25519(os.getenv('ADMIN_KEY'))# Optional
+    supply_key = PrivateKey.from_string_ed25519(os.getenv('SUPPLY_KEY'))# Optional
+    freeze_key = PrivateKey.from_string_ed25519(os.getenv('FREEZE_KEY'))# Optional
 
     # Set the operator for the client
     client.set_operator(operator_id, operator_key)

--- a/examples/token_create_nft_finite.py
+++ b/examples/token_create_nft_finite.py
@@ -41,12 +41,12 @@ def create_token_nft():
 
     # Operator credentials (must be present)
     operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+    operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
 
     # Optional Token Keys
-    admin_key = PrivateKey.from_string(os.getenv('ADMIN_KEY'))# Optional
-    supply_key = PrivateKey.from_string(os.getenv('SUPPLY_KEY')) # Optional
-    freeze_key = PrivateKey.from_string(os.getenv('FREEZE_KEY')) # Optional
+    admin_key = PrivateKey.from_string_ed25519(os.getenv('ADMIN_KEY'))# Optional
+    supply_key = PrivateKey.from_string_ed25519(os.getenv('SUPPLY_KEY'))# Optional
+    freeze_key = PrivateKey.from_string_ed25519(os.getenv('FREEZE_KEY'))# Optional
 
     # Set the operator for the client
     client.set_operator(operator_id, operator_key)

--- a/examples/token_create_nft_infinite.py
+++ b/examples/token_create_nft_infinite.py
@@ -41,12 +41,12 @@ def create_token_nft_infinite():
 
     # Operator credentials (must be present)
     operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+    operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
 
     # Optional Token Keys
-    admin_key = PrivateKey.from_string(os.getenv('ADMIN_KEY'))# Optional
-    supply_key = PrivateKey.from_string(os.getenv('SUPPLY_KEY')) # Optional
-    freeze_key = PrivateKey.from_string(os.getenv('FREEZE_KEY')) # Optional
+    admin_key = PrivateKey.from_string_ed25519(os.getenv('ADMIN_KEY'))# Optional
+    supply_key = PrivateKey.from_string_ed25519(os.getenv('SUPPLY_KEY'))# Optional
+    freeze_key = PrivateKey.from_string_ed25519(os.getenv('FREEZE_KEY'))# Optional
 
     # Set the operator for the client
     client.set_operator(operator_id, operator_key)

--- a/examples/token_delete.py
+++ b/examples/token_delete.py
@@ -18,8 +18,8 @@ def delete_token():
     client = Client(network)
 
     operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
-    admin_key = PrivateKey.from_string(os.getenv('ADMIN_KEY'))
+    operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
+    admin_key = PrivateKey.from_string_ed25519(os.getenv('ADMIN_KEY'))
     token_id = TokenId.from_string(os.getenv('TOKEN_ID'))
 
     client.set_operator(operator_id, operator_key)

--- a/examples/token_dissociate.py
+++ b/examples/token_dissociate.py
@@ -18,7 +18,7 @@ def dissociate_token(): #Single token
     client = Client(network)
 
     recipient_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    recipient_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+    recipient_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
     token_id = TokenId.from_string('TOKEN_ID')
 
     client.set_operator(recipient_id, recipient_key)
@@ -43,7 +43,7 @@ def dissociate_tokens():  # Multiple tokens
     client = Client(network)
 
     recipient_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    recipient_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+    recipient_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
     token_ids = [TokenId.from_string('TOKEN_ID_1'), TokenId.from_string('TOKEN_ID_2')]  
 
     client.set_operator(recipient_id, recipient_key)

--- a/examples/token_freeze.py
+++ b/examples/token_freeze.py
@@ -18,8 +18,8 @@ def freeze_token():
     client = Client(network)
 
     operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
-    freeze_key = PrivateKey.from_string(os.getenv('FREEZE_KEY'))
+    operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
+    freeze_key = PrivateKey.from_string_ed25519(os.getenv('FREEZE_KEY'))
     token_id = TokenId.from_string(os.getenv('TOKEN_ID'))
     account_id = AccountId.from_string(os.getenv('FREEZE_ACCOUNT_ID'))
 

--- a/examples/token_mint_fungible.py
+++ b/examples/token_mint_fungible.py
@@ -27,8 +27,8 @@ def fungible_token_mint():
     client = Client(network)
 
     payer_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    payer_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
-    supply_key = PrivateKey.from_string(os.getenv('SUPPLY_KEY'))
+    payer_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
+    supply_key = PrivateKey.from_string_ed25519(os.getenv('SUPPLY_KEY'))
     token_id = TokenId.from_string(os.getenv('TOKEN_ID'))
 
     client.set_operator(payer_id, payer_key)

--- a/examples/token_mint_non_fungible.py
+++ b/examples/token_mint_non_fungible.py
@@ -27,8 +27,8 @@ def nft_token_mint(metadata):
     client = Client(network)
 
     payer_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    payer_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
-    supply_key = PrivateKey.from_string(os.getenv('SUPPLY_KEY'))
+    payer_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
+    supply_key = PrivateKey.from_string_ed25519(os.getenv('SUPPLY_KEY'))
     token_id = TokenId.from_string(os.getenv('TOKEN_ID'))
 
     client.set_operator(payer_id, payer_key)

--- a/examples/token_unfreeze.py
+++ b/examples/token_unfreeze.py
@@ -16,8 +16,8 @@ def unfreeze_token(): # Single Token
     client = Client(network)
 
     operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
-    freeze_key = PrivateKey.from_string(os.getenv('FREEZE_KEY'))
+    operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
+    freeze_key = PrivateKey.from_string_ed25519(os.getenv('FREEZE_KEY'))
     token_id = TokenId.from_string(os.getenv('TOKEN_ID'))
     account_id = AccountId.from_string(os.getenv('FREEZE_ACCOUNT_ID'))
 

--- a/examples/topic_create.py
+++ b/examples/topic_create.py
@@ -17,7 +17,7 @@ def create_topic():
     client = Client(network)
 
     operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+    operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
 
     client.set_operator(operator_id, operator_key)
 

--- a/examples/topic_delete.py
+++ b/examples/topic_delete.py
@@ -18,7 +18,7 @@ def delete_topic():
     client = Client(network)
 
     operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+    operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
     topic_id = TopicId.from_string(os.getenv('TOPIC_ID'))
 
     client.set_operator(operator_id, operator_key)

--- a/examples/topic_message_submit.py
+++ b/examples/topic_message_submit.py
@@ -18,7 +18,7 @@ def submit_message(message):
     client = Client(network)
 
     operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+    operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
     topic_id = TopicId.from_string(os.getenv('TOPIC_ID'))
 
     client.set_operator(operator_id, operator_key)

--- a/examples/topic_update.py
+++ b/examples/topic_update.py
@@ -18,7 +18,7 @@ def update_topic(new_memo):
     client = Client(network)
 
     operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+    operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
     topic_id = TopicId.from_string(os.getenv('TOPIC_ID'))
 
     client.set_operator(operator_id, operator_key)

--- a/examples/transfer_hbar.py
+++ b/examples/transfer_hbar.py
@@ -17,7 +17,7 @@ def transfer_hbar():
     client = Client(network)
 
     operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+    operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
     recipient_id = AccountId.from_string(os.getenv('RECIPIENT_ID'))
     client.set_operator(operator_id, operator_key)
 

--- a/examples/transfer_token.py
+++ b/examples/transfer_token.py
@@ -18,7 +18,7 @@ def transfer_tokens():
     client = Client(network)
 
     operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+    operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
     recipient_id = AccountId.from_string(os.getenv('RECIPIENT_ID'))
     token_id = TokenId.from_string(os.getenv('TOKEN_ID'))
     amount = 1

--- a/src/hiero_sdk_python/crypto/private_key.py
+++ b/src/hiero_sdk_python/crypto/private_key.py
@@ -1,12 +1,15 @@
-from cryptography.hazmat.primitives.asymmetric import ed25519, ec
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.backends import default_backend
+import warnings
 from typing import Optional, Union
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519, ec
 from hiero_sdk_python.crypto.public_key import PublicKey
 
 class PrivateKey:
     """
     Represents a private key that can be either Ed25519 or ECDSA (secp256k1).
+    Can load from raw 32-byte seeds/scalars or DER-encoded keys.
+    Allows generation, signing, and public key derivation.
     """
 
     def __init__(
@@ -16,9 +19,16 @@ class PrivateKey:
         """
         self._private_key = private_key
 
+    #
+    # ---------------------------------
+    # Hex-string loaders
+    # ---------------------------------
+    #
+
     @classmethod
     def from_string(cls, key_str: str) -> "PrivateKey":
         """
+        Catch all method.
         Load a private key from a hex-encoded string.
         - If key_str starts with '0x', that prefix is removed.
         - Then the remainder is decoded as hex -> bytes.
@@ -36,7 +46,55 @@ class PrivateKey:
         return cls.from_bytes(key_bytes)
 
     @classmethod
-    def generate(cls, key_type: str = "ed25519"):
+    def from_string_ed25519(cls, hex_str: str) -> "PrivateKey":
+        """
+        Interpret the given string as hex-encoded 32-byte Ed25519 private seed.
+        Specific method to aid clarity.
+        """
+        hex_str = hex_str.removeprefix("0x")
+        try:
+            key_bytes = bytes.fromhex(hex_str)
+        except ValueError:
+            raise ValueError(f"Invalid hex string for Ed25519 private key: {hex_str}")
+        return cls.from_bytes_ed25519(key_bytes)
+
+    @classmethod
+    def from_string_ecdsa(cls, hex_str: str) -> "PrivateKey":
+        """
+        Interpret the given string as hex-encoded 32-byte ECDSA (secp256k1) private scalar.
+        Specific method to aid clarity.
+        """
+        hex_str = hex_str.removeprefix("0x")
+        try:
+            key_bytes = bytes.fromhex(hex_str)
+        except ValueError:
+            raise ValueError(f"Invalid hex string for ECDSA private key: {hex_str}")
+        return cls.from_bytes_ecdsa(key_bytes)
+
+    @classmethod
+    def from_string_der(cls, hex_str: str) -> "PrivateKey":
+        """
+        Interpret the given string as hex-encoded DER data.
+        Specific method to aid clarity.
+        """
+        hex_str = hex_str.removeprefix("0x")
+        try:
+            der_data = bytes.fromhex(hex_str)
+        except ValueError:
+            raise ValueError(f"Invalid hex string for DER private key: {hex_str}")
+        return cls.from_der(der_data)
+    
+    #
+    # ---------------------------------
+    # Generation
+    # ---------------------------------
+    #    
+
+    @classmethod
+    def generate(cls, key_type: str = "ed25519") -> "PrivateKey":
+        """
+        Generate a new private key, defaulting to ed25519. key_type can be "ed25519" or "ecdsa".
+        """
         if key_type.lower() == "ed25519":
             return cls.generate_ed25519()
         elif key_type.lower() == "ecdsa":
@@ -50,17 +108,33 @@ class PrivateKey:
 
     @classmethod
     def generate_ecdsa(cls):
-        private_key = ec.generate_private_key(ec.SECP256K1(), default_backend())
+        private_key = ec.generate_private_key(ec.SECP256K1())
         return cls(private_key)
+
+    #
+    # ---------------------------------
+    # Binary loaders: from_bytes, from_bytes_ed25519, from_bytes_ecdsa, from_der
+    # ---------------------------------
+    #
 
     @classmethod
     def from_bytes(cls, key_bytes: bytes) -> "PrivateKey":
         """
-        Load a private key from bytes. For Ed25519, expects 32 bytes (raw).
-        For ECDSA (secp256k1), also expects 32 bytes (raw scalar).
-        If the key is DER-encoded, tries to parse Ed25519 vs ECDSA.
+        Attempt to load a private key from:
+          - 32-byte Ed25519 seed
+          - 32-byte ECDSA scalar
+          - DER-encoded private key
         """
+        # If exactly 32 bytes, we have an ambiguity. Let's try Ed25519, then ECDSA, then DER.
         if len(key_bytes) == 32:
+            warnings.warn(
+                "from_bytes() will try Ed25519 (seed) first, then ECDSA, then DER. "
+                "If your data is 32 bytes, there's no guaranteed way to distinguish which type. "
+                "Consider using from_bytes_ed25519() or from_bytes_ecdsa() for clarity.",
+                UserWarning,
+                stacklevel=2
+            )
+
             ed_priv = cls._try_load_ed25519(key_bytes)
             if ed_priv:
                 return cls(ed_priv)
@@ -69,14 +143,20 @@ class PrivateKey:
             if ec_priv:
                 return cls(ec_priv)
 
+        # If not 32 bytes or attempts above failed, try DER
         der_key = cls._try_load_der(key_bytes)
         if der_key:
             return cls(der_key)
 
-        raise ValueError("Failed to load private key from bytes.")
+        # If all attempts failed, raise an error
+        raise ValueError("Failed to load private key from bytes (not Ed25519 seed, ECDSA scalar, or valid DER).")
 
     @staticmethod
     def _try_load_ed25519(key_bytes: bytes) -> Optional[ed25519.Ed25519PrivateKey]:
+        """
+        Attempt to interpret the given 32 bytes as an Ed25519 private seed.
+        Return the key object on success, or None on failure.
+        """
         try:
             return ed25519.Ed25519PrivateKey.from_private_bytes(key_bytes)
         except Exception:
@@ -84,41 +164,178 @@ class PrivateKey:
 
     @staticmethod
     def _try_load_ecdsa(key_bytes: bytes) -> Optional[ec.EllipticCurvePrivateKey]:
+        """
+        Attempt to interpret the given 32 bytes as an ECDSA (secp256k1) private scalar.
+        Return the key object on success, or None on failure.
+        """
         try:
             private_int = int.from_bytes(key_bytes, "big")
-            return ec.derive_private_key(private_int, ec.SECP256K1(), default_backend())
+            if private_int == 0:
+                return None
+            return ec.derive_private_key(private_int, ec.SECP256K1())
         except Exception:
             return None
 
     @staticmethod
     def _try_load_der(key_bytes: bytes) -> Optional[Union[ed25519.Ed25519PrivateKey, ec.EllipticCurvePrivateKey]]:
+        """
+        Attempt to parse the bytes as a DER-encoded private key.
+        Auto-detect Ed25519 vs. ECDSA(secp256k1). Return None on failure.
+        """
         try:
             private_key = serialization.load_der_private_key(key_bytes, password=None)
+            # Check Ed25519
             if isinstance(private_key, ed25519.Ed25519PrivateKey):
                 return private_key
+            # Check ECDSA (secp256k1 only)
             if isinstance(private_key, ec.EllipticCurvePrivateKey):
-                if not isinstance(private_key.curve, ec.SECP256K1):
-                    raise ValueError("Only secp256k1 ECDSA is supported.")
-                return private_key
+                if isinstance(private_key.curve, ec.SECP256K1):
+                    return private_key
             return None
         except Exception:
             return None
 
+    @classmethod
+    def from_bytes_ed25519(cls, seed_32: bytes) -> "PrivateKey":
+        """
+        Interpret 32 bytes as an Ed25519 seed.
+        """
+        if len(seed_32) != 32:
+            raise ValueError("Ed25519 private key seed must be 32 bytes.")
+        try:
+            return cls(ed25519.Ed25519PrivateKey.from_private_bytes(seed_32))
+        except Exception as e:
+            raise ValueError(f"Could not load Ed25519 private key from seed: {e}")
+
+    @classmethod
+    def from_bytes_ecdsa(cls, scalar_32: bytes) -> "PrivateKey":
+        """
+        Interpret 32 bytes as an ECDSA secp256k1 private scalar.
+        """
+        if len(scalar_32) != 32:
+            raise ValueError("ECDSA private key scalar must be 32 bytes.")
+        try:
+            private_int = int.from_bytes(scalar_32, "big")
+            if private_int == 0:
+                raise ValueError("ECDSA private key scalar cannot be zero.")
+
+            ec_priv = ec.derive_private_key(private_int, ec.SECP256K1())
+            return cls(ec_priv)
+        except Exception as e:
+            raise ValueError(f"Could not load ECDSA private key from scalar: {e}")
+
+    @classmethod
+    def from_der(cls, der_data: bytes) -> "PrivateKey":
+        """
+        Interpret bytes as a DER-encoded private key.
+        Auto-detect Ed25519 vs. ECDSA(secp256k1).
+        """
+        try:
+            private_key = serialization.load_der_private_key(der_data, password=None)
+        except Exception as e:
+            raise ValueError(f"Could not parse DER private key: {e}")
+
+        if isinstance(private_key, ed25519.Ed25519PrivateKey):
+            return cls(private_key)
+
+        if isinstance(private_key, ec.EllipticCurvePrivateKey):
+            if not isinstance(private_key.curve, ec.SECP256K1):
+                raise ValueError("Only secp256k1 ECDSA is supported.")
+            return cls(private_key)
+
+        raise ValueError("Unsupported private key type (not Ed25519 or secp256k1).")
+
+    #
+    # ---------------------------------
+    # Signatures and Public Key
+    # ---------------------------------
+    #
     def sign(self, data: bytes) -> bytes:
-        return self._private_key.sign(data)
+        """
+        Sign the given data using this private key.
+
+        - If Ed25519, the signature is produced using Ed25519's library.
+        - If ECDSA (secp256k1), the signature uses ECDSA with SHA-256.
+        """
+        if isinstance(self._private_key, ed25519.Ed25519PrivateKey):
+            # Ed25519 automatically handles the hashing internally
+            return self._private_key.sign(data)
+        else:
+            # ECDSA requires specifying a hash algorithm
+            return self._private_key.sign(data, ec.ECDSA(hashes.SHA256()))
 
     def public_key(self) -> PublicKey:
         return PublicKey(self._private_key.public_key())
 
+ 
+    #
+    # ---------------------------------
+    # Serialization
+    # ---------------------------------
+    #
+
     def to_bytes_raw(self) -> bytes:
+        """
+        Return the raw 32-byte seed (Ed25519) or 32-byte scalar (ECDSA).
+        """
         if self.is_ed25519():
+            return self.to_bytes_ed25519_raw()
+        elif self.is_ecdsa():
+            return self.to_bytes_ecdsa_raw()
+        else:
+            raise ValueError("Unknown key type; cannot extract raw bytes.")
+
+    def to_bytes_ed25519_raw(self) -> bytes:
+        """
+        Return the raw 32-byte Ed25519 seed.
+        """
+        if not self.is_ed25519():
+            raise ValueError("Not an Ed25519 key.")
+        return self._private_key.private_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PrivateFormat.Raw,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+
+    def to_bytes_ecdsa_raw(self) -> bytes:
+        """
+        Return the raw 32-byte ECDSA (secp256k1) scalar.
+        """
+        if not self.is_ecdsa():
+            raise ValueError("Not an ECDSA key.")
+        return self._private_key.private_numbers()\
+                   .private_value.to_bytes(32, "big")
+    
+    def to_bytes_der(self) -> bytes:
+        """
+        Return the DER-encoded private key.
+        """
+        if self.is_ed25519():
+            # Ed25519 only supports PKCS#8 for DER exports
             return self._private_key.private_bytes(
-                encoding=serialization.Encoding.Raw,
-                format=serialization.PrivateFormat.Raw,
+                encoding=serialization.Encoding.DER,
+                format=serialization.PrivateFormat.PKCS8,
                 encryption_algorithm=serialization.NoEncryption()
             )
         else:
-            return self._private_key.private_numbers().private_value.to_bytes(32, "big")
+            # ECDSA can be exported in Traditional OpenSSL or PKCS#8
+            return self._private_key.private_bytes(
+                encoding=serialization.Encoding.DER,
+                format=serialization.PrivateFormat.TraditionalOpenSSL,
+                encryption_algorithm=serialization.NoEncryption()
+            )
+
+    def to_string_raw(self) -> str:
+        return self.to_bytes_raw().hex()
+
+    def to_string_ed25519_raw(self) -> str:
+        return self.to_bytes_ed25519_raw().hex()
+
+    def to_string_ecdsa_raw(self) -> str:
+        return self.to_bytes_ecdsa_raw().hex()
+        
+    def to_string_der(self) -> str:
+        return self.to_bytes_der().hex()
 
     def to_string(self) -> str:
         """
@@ -126,20 +343,12 @@ class PrivateKey:
         Matches old usage that calls to_string().
         """
         return self.to_string_raw()
-
-    def to_string_raw(self) -> str:
-        return self.to_bytes_raw().hex()
-
-    def to_bytes_der(self) -> bytes:
-        return self._private_key.private_bytes(
-            encoding=serialization.Encoding.DER,
-            format=serialization.PrivateFormat.TraditionalOpenSSL,
-            encryption_algorithm=serialization.NoEncryption()
-        )
-
-    def to_string_der(self) -> str:
-        return self.to_bytes_der().hex()
-
+    #
+    # ---------------------------------
+    # is_ed25519 / is_ecdsa checks
+    # ---------------------------------
+    #
+    
     def is_ed25519(self) -> bool:
         return isinstance(self._private_key, ed25519.Ed25519PrivateKey)
 

--- a/src/hiero_sdk_python/crypto/public_key.py
+++ b/src/hiero_sdk_python/crypto/public_key.py
@@ -1,11 +1,23 @@
-from cryptography.hazmat.primitives.asymmetric import ed25519, ec
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.backends import default_backend
+import warnings
 from typing import Union
+
+from cryptography.hazmat.primitives.asymmetric import ed25519, ec
+from cryptography.hazmat.primitives import serialization, hashes
+from hiero_sdk_python.hapi.services.basic_types_pb2 import Key
+
+def _warn_ed25519_ambiguity(caller_name: str) -> None:
+    warnings.warn(
+        f"{caller_name}: cannot distinguish Ed25519 private seeds from public keys. "
+        "If using Ed25519, ensure you truly have a public key.",
+        UserWarning,
+        stacklevel=3
+    )
 
 class PublicKey:
     """
-    Represents a public key that can be either Ed25519 or ECDSA (secp256k1).
+    Represents a public key.
+    Supports multiple key formats: raw bytes, DER-encoded keys, hex strings, and a protobuf (“proto”) representation.
+    
     """
 
     def __init__(self, public_key: Union[ec.EllipticCurvePublicKey, ed25519.Ed25519PublicKey]):
@@ -14,70 +26,398 @@ class PublicKey:
         """
         self._public_key = public_key
 
-    @classmethod
-    def from_bytes(cls, key_bytes: bytes):
-        """
-        Load a public key from bytes.
-        For Ed25519, expects 32 bytes (raw).
-        For ECDSA, can interpret 33 or 65 bytes (compressed or uncompressed).
-        If not recognized, tries DER for either Ed25519 or ECDSA.
-
-        Args:
-            key_bytes (bytes): Public key bytes.
-
-        Returns:
-            PublicKey: A new instance of PublicKey.
-
-        Raises:
-            ValueError: If the key is invalid or unsupported.
-        """
-
-        if len(key_bytes) == 32:
-            try:
-                ed_pub = ed25519.Ed25519PublicKey.from_public_bytes(key_bytes)
-                return cls(ed_pub)
-            except Exception:
-                raise ValueError("Invalid 32-byte public key (not Ed25519).")
-
-        if len(key_bytes) in (33, 65):
-            try:
-                ec_pub = ec.EllipticCurvePublicKey.from_encoded_point(ec.SECP256K1(), key_bytes)
-                return cls(ec_pub)
-            except Exception:
-                raise ValueError("Failed to parse ECDSA public key from raw bytes.")
-
-        try:
-            maybe_pub = serialization.load_der_public_key(key_bytes, backend=default_backend())
-            if isinstance(maybe_pub, ed25519.Ed25519PublicKey):
-                return cls(maybe_pub)
-            if isinstance(maybe_pub, ec.EllipticCurvePublicKey):
-                curve = maybe_pub.curve
-                if not isinstance(curve, ec.SECP256K1):
-                    raise ValueError("Only secp256k1 ECDSA is supported.")
-                return cls(maybe_pub)
-            raise ValueError("Unsupported public key type (not Ed25519 or ECDSA).")
-        except Exception as e:
-            raise ValueError(f"Failed to load public key (DER): {e}")
+    #
+    # ---------------------------------
+    # Type-specific (Ed25519, ECDSA secp256k1, DER) from bytes loaders.
+    # Designed to help the user correctly manage key types.
+    # These are functionaly identical to the catch-all from_bytes method below.
+    # ---------------------------------
+    # 
 
     @classmethod
-    def from_string(cls, key_str):
+    def from_bytes(cls, pub: bytes) -> "PublicKey":
         """
-        Load a public key from a hex-encoded string.
-        For Ed25519, expects 32 bytes. Raw bytes string for ECDSA is not supported for now.
-        If the key is DER-encoded, tries to parse and detect Ed25519 vs ECDSA.
-        Args:
-            key_str (str): The hex-encoded public key string.
-        Returns:
-            PublicKey: A new instance of PublicKey.
-        Raises:
-            ValueError: If the key is invalid or unsupported.
+        Catch-all method to load public keys from bytes (Ed25519, ECDSA, or DER).
         """
+        _warn_ed25519_ambiguity("PublicKey.from_bytes")
+
+        # 1) 32-byte raw ⇒ Ed25519
+        if len(pub) == 32:
+            return cls.from_bytes_ed25519(pub)
+
+        # 2) 33/65 bytes ⇒ ECDSA (secp256k1)
+        if len(pub) in (33, 65):
+            return cls.from_bytes_ecdsa(pub)
+
+        # 3) Otherwise ⇒ DER, but wrap any failure
         try:
-            key_bytes = bytes.fromhex(key_str.removeprefix("0x"))
+            return cls.from_der(pub)
         except ValueError:
-            raise ValueError("Invalid hex-encoded public key string.")
+            raise ValueError("Failed to load public key")
 
-        return cls.from_bytes(key_bytes)
+    @classmethod
+    def from_bytes_ed25519(cls, pub: bytes) -> "PublicKey":
+        """
+        Load an Ed25519 public key from public raw bytes.
+
+        Args:
+            pub (bytes): 32-byte raw Ed25519 public key point.
+
+        Returns:
+            PublicKey: A new instance wrapping the validated public key.
+
+        Raises:
+            ValueError: If `pub` is not exactly 32 bytes or fails point validation.
+        """
+        _warn_ed25519_ambiguity("PublicKey.from_bytes_ed25519")
+
+        # 1) Enforce exact length for raw Ed25519 keys which are 32 bytes.
+        if len(pub) != 32:
+            raise ValueError(f"Ed25519 public key must be 32 bytes, got {len(pub)}.")
+
+        # 2) Delegate to ed25519 cryptography library for curve-point validation
+        try:
+            ed_pub = ed25519.Ed25519PublicKey.from_public_bytes(pub)
+        except Exception as e:
+            # Error raised if bytes do not form a valid Ed25519 public point
+            raise ValueError(f"Invalid Ed25519 public key bytes: {e}")
+        # 3) Return the validated public key
+        return cls(ed_pub)
+
+
+    @classmethod
+    def from_bytes_ecdsa(cls, pub: bytes) -> "PublicKey":
+        """
+        Load a secp256k1 ECDSA public key from raw bytes.
+
+        This method accepts only properly encoded public-key points:
+          - Compressed: 33 bytes, prefix 0x02 or 0x03.
+          - Uncompressed: 65 bytes, prefix 0x04.
+
+        Note:
+          - ECDSA private keys are 32-byte scalars and will be rejected.
+
+        Args:
+            pub (bytes): Raw public-key point in compressed or uncompressed form.
+
+        Returns:
+            PublicKey: Wrapped ECDSA (secp256k1) public key.
+
+        Raises:
+            ValueError: If length is not 33 or 65 bytes, or if point validation fails.
+        """
+        # 1) Enforce valid public bytes point lengths (does not allow private-key scalars which are 32 bytes)
+        if len(pub) not in (33, 65):
+            raise ValueError(f"ECDSA (secp256k1) public key must be 33 or 65 bytes, got {len(pub)}.")
+
+        # 2) Delegate to cryptography ec library for point decoding and validation
+        try:
+            ec_pub = ec.EllipticCurvePublicKey.from_encoded_point(ec.SECP256K1(), pub)
+        except Exception as e:
+            # Raised if bytes do not correspond to a valid curve point
+            raise ValueError(f"Invalid ECDSA public key bytes: {e}")
+
+        # 3) Wrap and return
+        return cls(ec_pub)
+
+    @classmethod
+    def from_der(cls, der_bytes: bytes) -> "PublicKey":
+        """
+        Load a public key from DER-encoded SubjectPublicKeyInfo.
+
+        This method automatically detects Ed25519 vs. secp256k1 ECDSA 
+        based on the OID found in the DER bytes. It strictly expects 
+        a DER-encoded **public** key (SubjectPublicKeyInfo).
+        
+        The `cryptography` library's `load_der_public_key` function 
+        rejects DER-encoded private keys, as their structure differs.
+
+        *Warning* a ed25519 private key incorrectly passed as a public key
+        and became DER-encoded will still be processed as a public key.  
+
+        Args:
+            der_bytes (bytes): DER-encoded SubjectPublicKeyInfo.
+
+        Returns:
+            PublicKey: A wrapped key of the detected algorithm 
+            (Ed25519 or secp256k1 ECDSA).
+
+        Raises:
+            ValueError: If the DER bytes cannot be parsed as a public 
+            key, or if the curve/algorithm is unsupported. This 
+            includes cases where a private key is passed instead of a 
+            public key.
+        """
+        try:
+            maybe_pub = serialization.load_der_public_key(der_bytes)
+        except Exception as e:
+            raise ValueError(f"Could not parse DER public key: {e}")
+
+        # If its Ed25519, delegate to cryptography Ed25519 library for point decoding and validation
+        # *Watch out!* Incorrectly passed private Ed25519 keys into DER will be treated as public.
+        if isinstance(maybe_pub, ed25519.Ed25519PublicKey):
+            return cls(maybe_pub)
+        # If its ECDSA, delegate to cryptography ec library for point decoding and validation
+        if isinstance(maybe_pub, ec.EllipticCurvePublicKey):
+            if not isinstance(maybe_pub.curve, ec.SECP256K1):
+                raise ValueError("Unsupported ECDSA curve (only secp256k1 allowed)")
+            return cls(maybe_pub)
+
+        raise ValueError("Unsupported public key type in DER (not Ed25519 or secp256k1 ECDSA)")
+
+    #
+    # -----------------------------------
+    # Type-specific (Ed25519, ECDSA secp256k1, DER) hex loaders. 
+    # The benefit is greater user clarity to enable correct key handling.
+    # -----------------------------------
+    #
+
+    @classmethod
+    def from_string_ed25519(cls, hex_str: str) -> "PublicKey":
+        """
+        Interpret the given string as a hex-encoded 32-byte Ed25519 public key.
+        """
+        _warn_ed25519_ambiguity("PublicKey.from_string_ed25519")
+
+        # Sanitizing. The "0x" prefix is used to denote that a string represents a hexadecimal number. The "0x" itself isn't part of the binary or numerical value represented by the hexadecimal string
+        hex_str = hex_str.removeprefix("0x")
+        # Python's .fromhex will throw if the hex string is malformed
+        try:
+            pub = bytes.fromhex(hex_str)
+        except ValueError:
+            raise ValueError(f"Invalid hex string for Ed25519 public key: {hex_str!r}")
+        # 3) Delegate to the byte-level loader
+        return cls.from_bytes_ed25519(pub)
+
+    @classmethod
+    def from_string_ecdsa(cls, hex_str: str) -> "PublicKey":
+        """
+        Interpret the given string as a hex-encoded compressed/uncompressed ECDSA pubkey (33/65 bytes).
+        """
+        # Sanitizing. The "0x" prefix is used to denote that a string represents a hexadecimal number. The "0x" itself isn't part of the binary or numerical value represented by the hexadecimal string
+        hex_str = hex_str.removeprefix("0x")
+        try:
+            # Python's .fromhex will throw if the hex string is malformed
+            pub = bytes.fromhex(hex_str)
+        except ValueError:
+            raise ValueError(f"Invalid hex string for ECDSA public key: {hex_str}")
+        return cls.from_bytes_ecdsa(pub)
+
+    @classmethod
+    def from_string_der(cls, hex_str: str) -> "PublicKey":
+        """
+        Interpret the given string as hex-encoded DER bytes containing a public key.
+        """
+        # Sanitizing. The "0x" prefix is used to denote that a string represents a hexadecimal number. The "0x" itself isn't part of the binary or numerical value represented by the hexadecimal string
+        hex_str = hex_str.removeprefix("0x")
+        try:
+            # Python's .fromhex will throw if the hex string is malformed
+            der_bytes = bytes.fromhex(hex_str)
+        except ValueError:
+            raise ValueError(f"Invalid hex string for DER public key: {hex_str}")
+        return cls.from_der(der_bytes)
+
+    #
+    # -----------------------------------
+    # Catch-all (Ed25519, ECDSA secp256k1, DER) hex loaders. 
+    # Used for convenience assuming correct key handling.
+    # -----------------------------------
+    #
+
+    @classmethod
+    def from_string(cls, hex_str: str) -> "PublicKey":
+        """
+        Load a *public* key from a hex-encoded string. Catch-all method supporting:
+        
+          - Ed25519 raw (32 bytes → 64 hex chars)
+          - secp256k1 ECDSA compressed (33 bytes → 66 hex chars)
+          - secp256k1 ECDSA uncompressed (65 bytes → 130 hex chars)
+          - DER-encoded SPKI (variable length)
+        
+        *Warning*: Raw Ed25519 private seeds are also 32 bytes and will be
+        treated as valid public keys here.
+        """
+        _warn_ed25519_ambiguity("PublicKey.from_string")
+
+        # 1) Remove the unecessary prefix and decode the hex
+        hex_str = hex_str.removeprefix("0x")
+        try:
+            data = bytes.fromhex(hex_str)
+        except ValueError:
+            raise ValueError(f"Invalid hex-encoded public key string: {hex_str!r}")
+
+        # 2) dispatch as ed25519 or ecdsa based on length
+        n = len(data)
+        if n == 32:
+            # raw Ed25519
+            # Warning! Incorrectly passed private ed25519 keys will be passed as public
+            return cls.from_bytes_ed25519(data)
+        if n in (33, 65):
+            # raw secp256k1
+            return cls.from_bytes_ecdsa(data)
+
+        # 3) fallback: DER-encoded
+        try:
+            return cls.from_der(data)
+        except ValueError as e:
+            raise ValueError(f"Couldn’t parse DER public key: {e}")
+
+    #
+    # ---------------------------------
+    # To proto
+    # ---------------------------------
+    #
+
+    def to_proto(self) -> Key:
+        """
+        Returns the protobuf representation of the public key (key type is known).
+        For Ed25519, uses the 'ed25519' field.
+        For ECDSA, uses 'ECDSASecp256k1'.
+        For DER, decode type first using from_der or from_bytes.
+
+        Returns:
+            Key: The protobuf Key message.
+        """
+        from hiero_sdk_python.hapi.services import basic_types_pb2
+
+        # get the raw public-key bytes (32/33/65 bytes depending on type)
+        pub_bytes = self.to_bytes_raw()
+
+        if self.is_ed25519():
+            return basic_types_pb2.Key(ed25519=pub_bytes)
+        else:
+            return basic_types_pb2.Key(ECDSA_secp256k1=pub_bytes)
+
+    #
+    # ---------------------------------
+    # Utilities
+    # ---------------------------------
+    #
+
+    def is_ed25519(self) -> bool:
+        """
+        Checks if this key (private or public) is Ed25519.
+        """
+        return isinstance(self._public_key, ed25519.Ed25519PublicKey)
+
+    def is_ecdsa(self) -> bool:
+        """
+        Checks if this public key is ECDSA (secp256k1).
+        """
+        return isinstance(self._public_key, ec.EllipticCurvePublicKey)
+    
+    #
+    # ---------------------------------
+    # Type-specific (Ed25519, ECDSA secp256k1) to raw bytes or DER.
+    # ---------------------------------
+    #
+
+    def to_bytes_raw(self) -> bytes:
+        """
+        Catch-all for convenience. 
+        Serialize this PublicKey into its raw, algorithm-specific byte form.
+
+        Ed25519 keys
+        --------------
+        - Always returns **32 bytes**.
+        - These 32 bytes are the raw public-key point with no prefix or metadata.
+
+        ECDSA (secp256k1) keys
+        ------------------------
+        - Returns the **compressed SEC1** form (33 bytes):
+            1. A 1-byte prefix (0x02 or 0x03) indicating the parity of the Y coordinate  
+            2. A 32-byte big-endian X coordinate  
+
+        Returns:
+            bytes:  
+            - If `is_ed25519() == True`, a 32-byte Ed25519 point.  
+            - Otherwise, a 33-byte compressed secp256k1 point.
+        """
+        if self.is_ed25519():
+            return self.to_bytes_ed25519()
+        else:
+        # ECDSA    
+            return self.to_bytes_ecdsa()
+
+    def to_bytes_ed25519(self) -> bytes:
+        """
+        Specific name for clarity.
+        Returns the Ed25519 public key in 32-bytes raw form.
+        """
+        return self._public_key.public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw
+        )
+        
+    def to_bytes_ecdsa(self, compressed: bool = True) -> bytes:
+        format_ = (serialization.PublicFormat.CompressedPoint 
+                if compressed 
+                else serialization.PublicFormat.UncompressedPoint)
+        return self._public_key.public_bytes(
+            encoding=serialization.Encoding.X962,
+            format=format_
+        )
+
+    def to_bytes_der(self) -> bytes:
+        """
+        Returns the DER-encoded public key.
+        """
+        return self._public_key.public_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo
+        )
+        
+    #
+    # ---------------------------------
+    # Type-specific (Ed25519, ECDSA secp256k1) to hex string.
+    # ---------------------------------
+    #
+
+    def to_string_ed25519(self) -> str:
+        """
+        Specific naming for clarity.
+        Returns the Ed25519 public key as raw hex-encoded public key
+        """
+        return self.to_bytes_ed25519().hex()
+        
+    def to_string_ecdsa(self) -> str:
+        """
+        Specific naming for clarity.
+        Returns the ECDSA public key as raw hex-encoded public key
+        """
+        return self.to_bytes_ecdsa().hex()
+    
+    def to_string_der(self) -> str:
+        """
+        Specific naming for clarity.
+        Hex-encoded DER form of the public key.
+        """
+        return self.to_bytes_der().hex()
+        
+    def to_string_raw(self) -> str:
+        """
+        Catch all ed25519 or ecdsa for convenience.
+        Returns the raw public key as a hex-encoded string.
+
+        Example:
+        >>> hex_str = pk.to_string_raw()
+        >>> len(hex_str)
+        64   # for Ed25519
+        """
+        return self.to_bytes_raw().hex()
+           
+    def to_string(self) -> str:
+        """
+        Returns the public key as a hex string (raw).
+        Matches old usage that calls to_string().
+        """
+        return self.to_string_raw()
+
+    #
+    # ----------------------------
+    # Signatures
+    # ----------------------------
+    #
 
     def verify(self, signature: bytes, data: bytes) -> None:
         """
@@ -91,72 +431,33 @@ class PublicKey:
         Raises:
             cryptography.exceptions.InvalidSignature: If the signature is invalid.
         """
+        if self.is_ed25519():
+            return self.verify_ed25519(signature, data)
+        else:
+            return self.verify_ecdsa(signature, data)
+        
+    def verify_ed25519(self, signature: bytes, data: bytes) -> None:
+        """
+        Verify an Ed25519 signature for clarity purposes. Raises InvalidSignature on failure.
+        """
+        # Ed25519 has no external hash; the library does it internally.
         self._public_key.verify(signature, data)
 
-    def to_bytes_raw(self) -> bytes:
+    def verify_ecdsa(self, signature: bytes, data: bytes) -> None:
         """
-        Returns the public key in raw form:
-         - For Ed25519, it's 32 bytes.
-         - For ECDSA (secp256k1), typically 33 bytes (compressed),
-           depending on how cryptography outputs raw.
+        Verify an ECDSA (secp256k1) signature using SHA-256.
 
-        Returns:
-            bytes: The raw public key bytes.
-        """
-        if self.is_ed25519():
-            return self._public_key.public_bytes(
-                encoding=serialization.Encoding.Raw,
-                format=serialization.PublicFormat.Raw
-            )
-        else:
-            return self._public_key.public_bytes(
-                encoding=serialization.Encoding.X962,
-                format=serialization.PublicFormat.CompressedPoint
-            )
+        Args:
+            signature: The DER-encoded signature bytes.
+            data:      The original message bytes.
 
-    def to_string(self) -> str:
+        Raises:
+            InvalidSignature: If the signature does not match.
         """
-        Returns the private key as a hex string (raw).
-        Matches old usage that calls to_string().
-        """
-        return self.to_string_raw()
-
-    def to_string_raw(self) -> str:
-        """
-        Returns the raw public key as a hex-encoded string.
-        """
-        return self.to_bytes_raw().hex()
-
-    def to_proto(self):
-        """
-        Returns the protobuf representation of the public key.
-        For Ed25519, uses the 'ed25519' field.
-        For ECDSA, uses 'ECDSASecp256k1'.
-
-        Returns:
-            Key: The protobuf Key message.
-        """
-        from hiero_sdk_python.hapi.services import basic_types_pb2
-
-        pub_bytes = self.to_bytes_raw()
-        if self.is_ed25519():
-            return basic_types_pb2.Key(ed25519=pub_bytes)
-        else:
-            return basic_types_pb2.Key(ECDSA_secp256k1=pub_bytes)
-
-    def is_ed25519(self) -> bool:
-        """
-        Checks if this public key is Ed25519.
-        """
-        return isinstance(self._public_key, ed25519.Ed25519PublicKey)
-
-    def is_ecdsa(self) -> bool:
-        """
-        Checks if this public key is ECDSA (secp256k1).
-        """
-        return isinstance(self._public_key, ec.EllipticCurvePublicKey)
+        self._public_key.verify(signature, data, ec.ECDSA(hashes.SHA256()))
 
     def __repr__(self):
         if self.is_ed25519():
             return f"<PublicKey (Ed25519) hex={self.to_string_raw()}>"
         return f"<PublicKey (ECDSA) hex={self.to_string_raw()}>"
+    

--- a/test.py
+++ b/test.py
@@ -74,7 +74,7 @@ def load_operator_credentials():
     """Load operator credentials from environment variables."""
     try:
         operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-        operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+        operator_key = PrivateKey.from_string_der(os.getenv('OPERATOR_KEY'))
     except Exception as e:
         print(f"Error parsing operator credentials: {e}")
         print(traceback.format_exc())
@@ -83,7 +83,8 @@ def load_operator_credentials():
 
 def create_new_account(client, initial_balance=100000000):
     """Tests account creation"""
-    new_account_private_key = PrivateKey.generate()
+    new_account_private_key = PrivateKey.generate("ed25519")
+
     new_account_public_key = new_account_private_key.public_key()
 
     transaction = AccountCreateTransaction(

--- a/tests/test_keys_private.py
+++ b/tests/test_keys_private.py
@@ -1,0 +1,460 @@
+import pytest
+import warnings
+import re
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric import ec, ed25519, rsa
+from cryptography.hazmat.primitives import serialization
+from hiero_sdk_python.crypto.public_key import PublicKey
+from hiero_sdk_python.crypto.private_key import PrivateKey
+
+
+def test_generate_ed25519():
+    """
+    Test generating an Ed25519 key, then:
+      1) Confirm it's detected as Ed25519 (not ECDSA).
+      2) Sign/verify some sample data.
+      3) Check raw/hex/DER serialization.
+      4) Confirm the __repr__ includes "Ed25519".
+    """
+    priv = PrivateKey.generate("ed25519")
+    assert priv.is_ed25519()
+    assert not priv.is_ecdsa()
+
+    data = b"hello ed25519"
+    sig = priv.sign(data)
+
+    # Verify the signature with the derived public key
+    pub = priv.public_key()
+    pub.verify(sig, data)  # should succeed if signature is valid
+
+    # Check round-trip raw bytes
+    raw_bytes = priv.to_bytes_ed25519_raw()
+    assert len(raw_bytes) == 32
+
+    # Check hex string conversion
+    raw_hex = priv.to_string_ed25519_raw()
+    assert len(raw_hex) == 64
+    assert raw_hex == raw_bytes.hex()
+
+    # Check DER
+    der_bytes = priv.to_bytes_der()
+    assert len(der_bytes) > 0
+    der_hex = priv.to_string_der()
+    assert der_hex == der_bytes.hex()
+
+    # Check __repr__ includes Ed25519
+    rep = repr(priv)
+    assert "Ed25519" in rep
+
+
+def test_generate_ecdsa():
+    """
+    Test generating an ECDSA (secp256k1) key, then:
+      1) Confirm it's detected as ECDSA (not Ed25519).
+      2) Sign/verify sample data.
+      3) Check raw/hex/DER serialization.
+      4) Confirm the __repr__ includes "ECDSA".
+    """
+    priv = PrivateKey.generate("ecdsa")
+    assert priv.is_ecdsa()
+    assert not priv.is_ed25519()
+
+    data = b"hello ecdsa"
+    sig = priv.sign(data)
+
+    # Verify the signature with the derived public key
+    pub = priv.public_key()
+    pub.verify(sig, data)  # should succeed
+
+    # Check raw bytes
+    raw_bytes = priv.to_bytes_ecdsa_raw()
+    assert len(raw_bytes) == 32
+
+    # Check hex string
+    raw_hex = priv.to_string_ecdsa_raw()
+    assert len(raw_hex) == 64
+    assert raw_hex == raw_bytes.hex()
+
+    # Check DER
+    der_bytes = priv.to_bytes_der()
+    assert len(der_bytes) > 0
+
+    # Check __repr__ includes ECDSA
+    rep = repr(priv)
+    assert "ECDSA" in rep
+
+
+def test_from_string_ed25519():
+    """
+    Test from_string_ed25519 by providing a valid 32-byte seed (in hex),
+    ensuring it loads as an Ed25519 key and can sign/verify data.
+    """
+    seed_hex = "01" * 32
+    priv = PrivateKey.from_string_ed25519(seed_hex)
+    assert priv.is_ed25519()
+
+    # Verify sign/verify flow
+    sig = priv.sign(b"data")
+    priv.public_key().verify(sig, b"data")
+
+
+def test_from_string_ed25519_invalid_length():
+    """
+    Test from_string_ed25519 with an invalid hex length (< 32 bytes),
+    expecting a ValueError due to insufficient seed length.
+    """
+    short_hex = "12" * 16  # Only 16 bytes
+    with pytest.raises(ValueError, match="Ed25519 private key seed must be 32 bytes"):
+        PrivateKey.from_string_ed25519(short_hex)
+
+
+def test_from_string_ecdsa():
+    """
+    Test from_string_ecdsa with a valid 32-byte scalar in hex.
+    Then sign/verify data to ensure it's functional.
+    """
+    scalar_hex = "abcdef0000000000000000000000000000000000000000000000000000000001"
+    priv = PrivateKey.from_string_ecdsa(scalar_hex)
+    assert priv.is_ecdsa()
+
+    sig = priv.sign(b"test-ecdsa")
+    priv.public_key().verify(sig, b"test-ecdsa")
+
+
+def test_from_string_ecdsa_zero_scalar():
+    """
+    Ensure that ECDSA scalar = 0 raises ValueError.
+    """
+    zero_scalar_hex = "00" * 32
+    with pytest.raises(ValueError, match="ECDSA private key scalar cannot be zero"):
+        PrivateKey.from_string_ecdsa(zero_scalar_hex)
+
+
+def test_from_string_der_ed25519():
+    """
+    Test from_string_der with a known valid DER encoding for Ed25519.
+    Then confirm sign/verify works.
+    
+    This example DER was built using a known Ed25519 seed (all '01').
+    """
+    der_hex = (
+        "302e020100300506032b657004220420"
+        "0101010101010101010101010101010101010101010101010101010101010101"
+    )
+    priv = PrivateKey.from_string_der(der_hex)
+    assert priv.is_ed25519()
+
+    sig = priv.sign(b"der-ed25519")
+    priv.public_key().verify(sig, b"der-ed25519")
+
+
+def test_from_string_der_ecdsa_round_trip():
+    """
+    Generate a secp256k1 private key with scalar = 1, serialize to DER hex,
+    then load it back via from_string_der() and confirm it's ECDSA.
+    """
+    # 1) Construct a PrivateKey from the scalar = 1
+    scalar_one = (1).to_bytes(32, "big")
+    original = PrivateKey.from_bytes_ecdsa(scalar_one)
+
+    # 2) Serialize to DER hex
+    der_hex = original.to_string_der()
+    assert len(der_hex) % 2 == 0  # must be even
+
+    # 3) Load it back
+    loaded = PrivateKey.from_string_der(der_hex)
+    assert loaded.is_ecdsa()
+
+    # 4) Confirm the raw scalar round-trips perfectly
+    assert loaded.to_bytes_ecdsa_raw() == scalar_one
+
+
+def test_from_string_der_invalid_hex():
+    """
+    Attempt to load DER from a string that is not valid hex,
+    expecting a ValueError from the hex parsing step.
+    """
+    with pytest.raises(ValueError, match="Invalid hex string for DER private key"):
+        PrivateKey.from_string_der("not-hex-data-zzzz")
+
+
+def test_from_string_der_parse_failure():
+    """
+    Provide valid hex but not valid DER-encoded data,
+    expecting a parse failure ValueError.
+    """
+    # Just random small hex that won't parse as DER
+    random_hex = "112233445566"
+    with pytest.raises(ValueError, match="Could not parse DER private key"):
+        PrivateKey.from_string_der(random_hex)
+
+
+def test_from_string_invalid_hex():
+    """
+    Provide a string that is not valid hex to from_string (the catch-all),
+    expecting a ValueError in hex decode.
+    """
+    with pytest.raises(ValueError, match="Invalid hex string for private key"):
+        PrivateKey.from_string("not-a-hex-string")
+
+
+def test_from_string_unrecognized():
+    """
+    Provide a valid hex string but only 8 bytes => fails both 32-byte raw
+    and DER parse => expect ValueError from from_bytes.
+    """
+    short_hex = "11" * 8
+    with pytest.raises(ValueError, match="Failed to load private key from bytes"):
+        PrivateKey.from_string(short_hex)
+
+
+def test_from_bytes_ed25519():
+    """
+    Test from_bytes_ed25519 with direct 32-byte seed => should load as Ed25519.
+    """
+    seed = bytes.fromhex("02" * 32)
+    priv = PrivateKey.from_bytes_ed25519(seed)
+    assert priv.is_ed25519()
+
+
+def test_from_bytes_ecdsa():
+    """
+    Test from_bytes_ecdsa with direct 32-byte scalar => should load as ECDSA.
+    """
+    # Example random scalar
+    scalar = bytes.fromhex("abcdef" + "00" * 29 + "01")[:32]
+    priv = PrivateKey.from_bytes_ecdsa(scalar)
+    assert priv.is_ecdsa()
+
+
+def test_from_bytes():
+    """
+    Test the catch-all from_bytes(32 bytes):
+      - If Ed25519 load succeeds, we get Ed25519.
+      - If Ed25519 fails, tries ECDSA.
+      - If both fail, tries DER.
+    Check the warning is triggered for 32-byte data.
+    """
+    # 32 bytes that definitely pass as Ed25519.
+    seed = bytes.fromhex("11" * 32)
+    with warnings.catch_warnings(record=True) as w:
+        priv = PrivateKey.from_bytes(seed)
+        assert len(w) == 1  # confirm we got the "ambiguity" warning
+    assert priv.is_ed25519()
+
+
+def test_from_bytes_not_32_der():
+    """
+    Provide something that's not 32 bytes => it tries DER => expect failure
+    if it's not valid DER.
+    """
+    random_33 = b"\x01" * 33
+    with pytest.raises(ValueError, match="Failed to load private key from bytes"):
+        PrivateKey.from_bytes(random_33)
+
+
+def test_sign_verify_ed25519():
+    """
+    Generate Ed25519 => sign => verify => then tamper with the signature
+    to confirm we get an InvalidSignature exception.
+    """
+    priv = PrivateKey.generate("ed25519")
+    data = b"test sign"
+    sig = priv.sign(data)
+    pub = priv.public_key()
+
+    # Valid signature
+    pub.verify(sig, data)
+
+    # Tamper with the signature (flip last byte)
+    tampered_sig = bytearray(sig)
+    tampered_sig[-1] ^= 0xFF
+    with pytest.raises(InvalidSignature):
+        pub.verify(tampered_sig, data)
+
+
+def test_sign_verify_ecdsa():
+    """
+    Generate ECDSA => sign => verify => then tamper with the signature
+    to confirm we get an InvalidSignature exception.
+    """
+    priv = PrivateKey.generate("ecdsa")
+    data = b"test ecdsa"
+    sig = priv.sign(data)
+    pub = priv.public_key()
+
+    # Valid signature
+    pub.verify(sig, data)
+
+    # Tamper with the signature (flip some byte in the middle)
+    tampered_sig = bytearray(sig)
+    tampered_sig[5] ^= 0xFF
+    with pytest.raises(InvalidSignature):
+        pub.verify(tampered_sig, data)
+
+
+def test_from_string_strips_0x_prefix():
+    """Make sure from_string()/from_string_ed25519()/from_string_ecdsa() drop a leading 0x."""
+    hex_seed = "0x" + "ab" * 32
+    # Should load as Ed25519
+    priv = PrivateKey.from_string_ed25519(hex_seed)
+    assert priv.is_ed25519()
+
+    # Similarly for the general catch-all
+    priv2 = PrivateKey.from_string(hex_seed)
+    # Depending on the bytes, it might parse as Ed25519 or ECDSA
+    # If 0xab… is valid as an Ed25519 seed, it’ll be Ed25519:
+    assert priv2.is_ed25519()
+
+
+def test_from_bytes_ambiguity_prefers_ecdsa_when_ed25519_fails(monkeypatch):
+    """
+    Ensure from_bytes tries Ed25519 first, then ECDSA.
+    We monkey-patch Ed25519 to always fail, then give it a scalar of 1
+    (which ECDSA will accept), and confirm the result is ECDSA.
+    """
+    # 1) Prepare a 32-byte big-endian scalar = 1
+    ecdsa_scalar_one = (1).to_bytes(32, "big")
+
+    # 2) Force the Ed25519 loader to always return None
+    monkeypatch.setattr(
+        PrivateKey,
+        "_try_load_ed25519",
+        staticmethod(lambda b: None)
+    )
+
+    # 3) Now from_bytes should skip Ed25519 and succeed with ECDSA
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        priv = PrivateKey.from_bytes(ecdsa_scalar_one)
+        # We should still get the ambiguity warning
+        assert any("try Ed25519" in str(wi.message) for wi in w)
+
+    assert priv.is_ecdsa(), "from_bytes should have returned an ECDSA key"
+    # And round-trip raw scalar
+    assert priv.to_bytes_ecdsa_raw() == ecdsa_scalar_one
+
+
+def test_type_checks_are_mutually_exclusive():
+    ed = PrivateKey.generate("ed25519")
+    ec_key = PrivateKey.generate("ecdsa")
+    assert ed.is_ed25519() and not ed.is_ecdsa()
+    assert ec_key.is_ecdsa() and not ec_key.is_ed25519()
+
+
+@pytest.mark.parametrize("length", [0, 1, 31, 33])
+def test_from_bytes_invalid_lengths(length):
+    bad = b"\x00" * length
+    with pytest.raises(ValueError, match="Failed to load private key from bytes"):
+        PrivateKey.from_bytes(bad)
+
+
+def test_from_bytes_warning_message():
+    seed = b"\x11" * 32
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        _ = PrivateKey.from_bytes(seed)
+        assert any("try Ed25519" in str(wi.message) for wi in w)
+
+
+@pytest.mark.parametrize("key_type", ["ed25519", "ecdsa"])
+def test_raw_roundtrip_idempotent(key_type):
+    priv1 = PrivateKey.generate(key_type)
+    raw = priv1.to_bytes_raw()
+    if key_type == "ed25519":
+        priv2 = PrivateKey.from_bytes_ed25519(raw)
+    else:
+        priv2 = PrivateKey.from_bytes_ecdsa(raw)
+    assert priv2.to_bytes_raw() == raw
+
+
+def test_generate_invalid_key_type():
+    with pytest.raises(ValueError, match="Invalid key_type"):
+        PrivateKey.generate("rsa")
+
+
+@pytest.mark.parametrize("key_type", ["ed25519", "ecdsa"])
+def test_to_string_alias(key_type):
+    priv = PrivateKey.generate(key_type)
+    assert priv.to_string() == priv.to_string_raw()
+
+
+def test_from_string_ecdsa_strips_0x():
+    hex_scalar = "0x" + "ab" * 32
+    priv = PrivateKey.from_string_ecdsa(hex_scalar)
+    assert priv.is_ecdsa()
+
+
+@pytest.mark.parametrize("fn, length", [
+    (PrivateKey.from_bytes_ed25519, 31),
+    (PrivateKey.from_bytes_ed25519, 33),
+    (PrivateKey.from_bytes_ecdsa, 31),
+    (PrivateKey.from_bytes_ecdsa, 33),
+])
+def test_from_bytes_wrong_length(fn, length):
+    bad = b"\x00" * length
+    with pytest.raises(ValueError):
+        fn(bad)
+
+
+def test_public_key_roundtrip_der_and_raw():
+    """
+    Test that private -> public -> raw DER -> PublicKey.from_der works
+    for an ECDSA key (though it also works for Ed25519).
+    """
+    priv = PrivateKey.generate("ecdsa")
+    pub = priv.public_key()
+    der = pub.to_string_der()
+    pub2 = PublicKey.from_string_der(der)
+    assert pub2.to_string_ecdsa() == pub.to_string_ecdsa()
+
+
+@pytest.mark.parametrize("key_type", ["ed25519", "ecdsa"])
+def test_repr_contains_full_hex(key_type):
+    """
+    Test that repr includes the full 64-character hex seed for both key types.
+    """
+    priv = PrivateKey.generate(key_type)
+    rep = repr(priv)
+
+    # Must contain 'hex='
+    assert "hex=" in rep
+
+    # Extract the hex part after 'hex=' up to the closing '>'
+    hex_part = rep.split("hex=")[1].rstrip(">")
+    # Should be exactly 64 hex characters
+    assert len(hex_part) == 64
+    # All characters should be valid lowercase hex digits
+    assert re.fullmatch(r"[0-9a-f]{64}", hex_part)
+
+
+@pytest.mark.parametrize("key_type", ["ed25519", "ecdsa"])
+def test_der_roundtrip(key_type):
+    """
+    Make sure that if we serialize a key to DER and then load it back,
+    we get the same raw seed/scalar. 
+    """
+    priv1 = PrivateKey.generate(key_type)
+    der_hex = priv1.to_string_der()
+    priv2 = PrivateKey.from_string_der(der_hex)
+    assert priv2.to_bytes_raw() == priv1.to_bytes_raw()
+    assert priv2.is_ed25519() == (key_type == "ed25519")
+
+
+@pytest.fixture(params=["ed25519", "ecdsa"])
+def raw_seed(request):
+    """
+    A fixture that yields the raw seed/scalar for each key type.
+    """
+    return PrivateKey.generate(request.param).to_bytes_raw()
+
+
+def test_from_bytes_fixture(raw_seed):
+    """
+    Demonstrate using the raw_seed fixture. from_bytes picks Ed25519 or ECDSA
+    based on the content. If it’s a valid Ed25519 seed, it becomes Ed25519;
+    otherwise if that fails, it tries ECDSA next.
+    """
+    priv = PrivateKey.from_bytes(raw_seed)
+    assert priv.to_bytes_raw() == raw_seed

--- a/tests/test_keys_public.py
+++ b/tests/test_keys_public.py
@@ -1,0 +1,543 @@
+import pytest
+import warnings
+from cryptography.hazmat.primitives.asymmetric import ec, ed25519
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.exceptions import InvalidSignature
+from hiero_sdk_python.hapi.services.basic_types_pb2 import Key
+from hiero_sdk_python.crypto.public_key import PublicKey
+
+@pytest.fixture
+def ed25519_keypair():
+    """Returns (private_key, public_key) for Ed25519."""
+    private = ed25519.Ed25519PrivateKey.generate()
+    public = private.public_key()
+    return private, public
+
+@pytest.fixture
+def ecdsa_keypair():
+    """Returns (private_key, public_key) for ECDSA with secp256k1."""
+    private = ec.generate_private_key(ec.SECP256K1())
+    public = private.public_key()
+    return private, public
+
+
+# ------------------------------------------------------------------------------
+# Test: from_bytes_ed25519
+# ------------------------------------------------------------------------------
+def test_from_bytes_ed25519_valid(ed25519_keypair):
+    # ed25519_keypair fixture returns (private_key, public_key) but only use public
+    _, public = ed25519_keypair
+
+    # Serialize the public key into its “raw” 32-byte form
+    raw_bytes = public.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    # Ed25519 public keys are always exactly 32 bytes
+    assert len(raw_bytes) == 32
+
+    # The loader emits a warning because a 32-byte blob could also be
+    # an Ed25519 *private* seed
+    with pytest.warns(
+        UserWarning,
+        match="cannot distinguish Ed25519 private seeds"
+    ):
+        # Attempt to construct a PublicKey wrapper from the raw bytes
+        pubk = PublicKey.from_bytes_ed25519(raw_bytes)
+
+    # Confirm that the wrapper recognized it as an Ed25519 key
+    assert pubk.is_ed25519()
+
+    # Confirm that converting it back to raw bytes also yields 32 bytes
+    assert len(pubk.to_bytes_ed25519()) == 32
+
+
+def test_from_bytes_ed25519_wrong_length():
+    # 31 bytes is incorrect
+    data = b"\x01" * 31
+    with pytest.raises(ValueError, match="must be 32 bytes"):
+        PublicKey.from_bytes_ed25519(data)
+
+def test_from_bytes_ed25519_private_seed(ed25519_keypair):
+    """
+    Demonstrate that from_bytes_ed25519 cannot tell a private seed apart
+    from a public key: it will emit the same warning and return a PublicKey
+    whose raw bytes round-trip to exactly the seed.
+    """
+    priv, _ = ed25519_keypair
+
+    seed = priv.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    assert len(seed) == 32
+
+    with pytest.warns(UserWarning, match="cannot distinguish Ed25519 private seeds"):
+        pk = PublicKey.from_bytes_ed25519(seed)
+
+    # …and still treat it as “Ed25519 public” under the hood
+    assert pk.is_ed25519()
+
+    # Round-tripping back to raw bytes returns the same 32 bytes (the seed)
+    assert pk.to_bytes_ed25519() == seed
+
+# ------------------------------------------------------------------------------
+# Test: from_bytes_ecdsa
+# ------------------------------------------------------------------------------
+def test_from_bytes_ecdsa_compressed_valid(ecdsa_keypair):
+    _, pub = ecdsa_keypair
+
+    # Serialize the public key into its SEC1 compressed form (33 bytes):
+    compressed = pub.public_bytes(
+        encoding=serialization.Encoding.X962,
+        format=serialization.PublicFormat.CompressedPoint, #Compressed
+    )
+    assert len(compressed) == 33
+
+    # Load the wrapper from the raw compressed point
+    pubk = PublicKey.from_bytes_ecdsa(compressed)
+
+    # It should detect and wrap an ECDSA (secp256k1) key
+    assert pubk.is_ecdsa()
+
+    # Round-trip: exporting back to compressed bytes should exactly match input
+    assert pubk.to_bytes_ecdsa() == compressed
+
+
+def test_from_bytes_ecdsa_uncompressed_valid(ecdsa_keypair):
+    _, pub = ecdsa_keypair
+
+    # Serialize the public key into its SEC1 uncompressed form (65 bytes):
+    uncompressed = pub.public_bytes(
+        encoding=serialization.Encoding.X962,
+        format=serialization.PublicFormat.UncompressedPoint, #Uncompressed
+    )
+    assert len(uncompressed) == 65
+
+    pubk = PublicKey.from_bytes_ecdsa(uncompressed)
+
+    # It should detect and wrap an ECDSA (secp256k1) key
+    assert pubk.is_ecdsa()
+
+    # When exporting, PublicKey always emits the compressed form:
+    compressed = pubk.to_bytes_ecdsa()
+
+    # The first byte should be 0x02 or 0x03, indicating the parity of Y
+    assert compressed[0] in (2, 3)
+
+    # And the total length of the compressed point must be 33 bytes
+    assert len(compressed) == 33
+
+def test_from_bytes_ecdsa_wrong_length():
+    # 32 bytes is not a valid ECDSA public point
+    data = b"\x02" + b"\x00" * 31
+    with pytest.raises(ValueError, match="must be 33 or 65 bytes"):
+        PublicKey.from_bytes_ecdsa(data)
+
+def test_from_bytes_ecdsa_invalid():
+    # 33 bytes but invalid prefix or data
+    # 0x05 is not a valid secp256k1 prefix (should be 0x02 or 0x03 if compressed)
+    data = b"\x05" + b"\x00" * 32
+    with pytest.raises(ValueError, match="Invalid ECDSA public key bytes"):
+        PublicKey.from_bytes_ecdsa(data)
+
+# ------------------------------------------------------------------------------
+# Test: from_der
+# ------------------------------------------------------------------------------
+def test_from_der_ed25519(ed25519_keypair):
+    """
+    Generate an Ed25519 public key in DER‐encoded SPKI form and load it
+    via the wrapper, then verify round-trip DER output.
+    """
+    _, pub = ed25519_keypair
+
+    # Serialize to DER-encoded SubjectPublicKeyInfo
+    der = pub.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    pubk = PublicKey.from_der(der)
+
+    # It should detect it is Ed25519
+    assert pubk.is_ed25519()
+
+    # Converting back to DER should match the original bytes exactly
+    assert pubk.to_bytes_der() == der
+
+
+def test_from_der_ecdsa(ecdsa_keypair):
+    """
+    Generate an ECDSA (secp256k1) public key in DER-encoded SPKI form and load it,
+    then verify round-trip DER output.
+    """
+    _, pub = ecdsa_keypair
+
+    der = pub.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    pk = PublicKey.from_der(der)
+
+    # It should detect it is ECDSA on curve secp256k1
+    assert pk.is_ecdsa()
+
+    # Converting back to DER should match the original exactly
+    assert pk.to_bytes_der() == der
+
+def test_from_der_unsupported_curve():
+    """
+    Ensure that DER-encoded keys on curves other than secp256k1
+    (e.g. secp384r1) are rejected with an appropriate error.
+    """
+    # Generate a keypair on an unsupported curve (secp384r1)
+    private_key = ec.generate_private_key(ec.SECP384R1())
+    public_key = private_key.public_key()
+
+    # Serialize to DER SPKI
+    der = public_key.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    # from_der should raise ValueError about unsupported curve
+    with pytest.raises(ValueError, match="Unsupported ECDSA curve"):
+        PublicKey.from_der(der)
+
+
+def test_from_der_invalid():
+    """
+    Passing corrupted or non-DER bytes should trigger a parse error
+    in from_der().
+    """
+    # Create a bogus DER-like blob
+    der = b"\x30\x82" + b"\xFF" * 50
+
+    # Expect a ValueError indicating failure to parse DER public key
+    with pytest.raises(ValueError, match="Could not parse DER public key"):
+        PublicKey.from_der(der)
+
+
+# ------------------------------------------------------------------------------
+# Test: from_bytes (the catch-all)
+# ------------------------------------------------------------------------------
+def test_from_bytes_ed25519_catch_all(ed25519_keypair):
+    """
+    Ensure that the catch-all loader treats 32 raw bytes as Ed25519.
+    """
+    _, pub = ed25519_keypair
+
+    # Serialize the public key into its “raw” 32-byte form
+    raw = pub.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+
+    # from_bytes() always warns about ambiguous 32-byte inputs
+    with pytest.warns(UserWarning, match="cannot distinguish Ed25519 private seeds"):
+        pubk = PublicKey.from_bytes(raw)
+
+    # Confirm it recognized Ed25519
+    assert pubk.is_ed25519()
+
+
+def test_from_bytes_ecdsa_catch_all_compressed(ecdsa_keypair):
+    """
+    Ensure that the catch-all loader treats 33 compressed bytes as secp256k1 ECDSA.
+    """
+    _, pub = ecdsa_keypair
+
+    # Serialize the public key into SEC1 compressed form (33 bytes)
+    compressed = pub.public_bytes(
+        encoding=serialization.Encoding.X962,
+        format=serialization.PublicFormat.CompressedPoint,
+    )
+
+    # from_bytes() still issues the Ed25519-seed ambiguity warning
+    with pytest.warns(UserWarning, match="cannot distinguish Ed25519 private seeds"):
+        pubk = PublicKey.from_bytes(compressed)
+
+    # Confirm it recognized ECDSA
+    assert pubk.is_ecdsa()
+
+
+def test_from_bytes_der_catch_all_ed25519(ed25519_keypair):
+    """
+    Ensure that the catch-all loader falls back to DER decoding.
+    """
+    _, pub = ed25519_keypair
+
+    der = pub.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    with pytest.warns(UserWarning, match="cannot distinguish Ed25519 private seeds"):
+        pubk = PublicKey.from_bytes(der)
+
+    # Confirm it recognized Ed25519
+    assert pubk.is_ed25519()
+
+
+def test_from_bytes_der_catch_all_ecdsa(ecdsa_keypair):
+    """
+    Ensure that the catch-all loader falls back to DER decoding for ECDSA DER SPKI.
+    """
+    _, pub = ecdsa_keypair
+
+    der = pub.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    with pytest.warns(UserWarning, match="cannot distinguish Ed25519 private seeds"):
+        pubk = PublicKey.from_bytes(der)
+
+    # Confirm it recognized ECDSA
+    assert pubk.is_ecdsa()
+
+
+def test_from_bytes_invalid():
+    """
+    Passing a blob that matches none of the 32/33/65 length cases
+    should fall through to DER, then raise ValueError.
+    """
+    # 1 byte of data: too small for Ed25519 (32), ECDSA (33/65), not valid DER
+    data = b"\x00"
+
+    # Always warns about Ed25519 ambiguity, then fails in DER loader
+    with pytest.warns(UserWarning):
+        with pytest.raises(ValueError, match="Failed to load public key"):
+            PublicKey.from_bytes(data)
+
+# ------------------------------------------------------------------------------
+# Test: from_string_xxx
+# ------------------------------------------------------------------------------
+def test_from_string_ed25519(ed25519_keypair):
+    """
+    Test loading an Ed25519 public key from a valid hex string.
+    Ensures the warning about seed vs. public key ambiguity is emitted
+    and that round-trip hex output matches the input.
+    """
+    _, pub = ed25519_keypair
+    raw = pub.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw
+    )
+    hex_str = raw.hex()
+
+    with pytest.warns(UserWarning, match="cannot distinguish Ed25519 private seeds from public keys"):
+        pubk = PublicKey.from_string_ed25519(hex_str)
+    assert pubk.is_ed25519()
+    assert pubk.to_string_ed25519() == hex_str
+
+
+def test_from_string_ed25519_invalid_hex():
+    """
+    Test that passing a malformed hex string to from_string_ed25519
+    raises a ValueError.
+    """
+    with pytest.raises(ValueError, match="Invalid hex string for Ed25519 public key"):
+        PublicKey.from_string_ed25519("zzzzzz")
+
+
+def test_from_string_ecdsa_compressed(ecdsa_keypair):
+    """
+    Test loading a compressed ECDSA secp256k1 public key from a valid hex string.
+    Ensures correct detection and round-trip hex output.
+    """
+    _, pub = ecdsa_keypair
+    compressed = pub.public_bytes(
+        encoding=serialization.Encoding.X962,
+        format=serialization.PublicFormat.CompressedPoint,
+    )
+    hex_str = compressed.hex()
+    pubk = PublicKey.from_string_ecdsa(hex_str)
+    assert pubk.is_ecdsa()
+    assert pubk.to_string_ecdsa() == hex_str
+
+
+def test_from_string_ecdsa_uncompressed(ecdsa_keypair):
+    """
+    Test loading an uncompressed ECDSA secp256k1 public key from hex.
+    Verifies detection and compression on output.
+    """
+    _, pub = ecdsa_keypair
+    uncompressed = pub.public_bytes(
+        encoding=serialization.Encoding.X962,
+        format=serialization.PublicFormat.UncompressedPoint,
+    )
+    hex_str = uncompressed.hex()
+    pubk = PublicKey.from_string_ecdsa(hex_str)
+    assert pubk.is_ecdsa()
+    # Round trip to compressed form
+    assert len(pubk.to_bytes_ecdsa()) == 33
+
+
+def test_from_string_ecdsa_invalid_hex():
+    """
+    Test that passing a malformed hex string to from_string_ecdsa
+    raises a ValueError.
+    """
+    with pytest.raises(ValueError, match="Invalid hex string for ECDSA public key"):
+        PublicKey.from_string_ecdsa("not-a-hex")
+
+def test_from_string_catch_all_ecdsa(ecdsa_keypair):
+    _, pub = ecdsa_keypair
+    compressed = pub.public_bytes(
+        encoding=serialization.Encoding.X962,
+        format=serialization.PublicFormat.CompressedPoint,
+    ).hex()
+
+    # Should still warn about the 32-byte ambiguity, then detect ECDSA
+    with pytest.warns(UserWarning, match="cannot distinguish"):
+        pubk = PublicKey.from_string(compressed)
+    assert pubk.is_ecdsa()
+    assert pubk.to_string_ecdsa() == compressed
+
+
+def test_from_string_der(ecdsa_keypair):
+    """
+    Test loading an ECDSA secp256k1 public key from a DER hex string.
+    Ensures correct detection and round-trip DER output.
+    """
+    _, pub = ecdsa_keypair
+    der = pub.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    hex_str = der.hex()
+    pubk = PublicKey.from_string_der(hex_str)
+    assert pubk.is_ecdsa()
+    assert pubk.to_string_der() == hex_str
+
+
+def test_from_string_der_invalid():
+    """
+    Test that passing a non-hex string to from_string_der raises a ValueError.
+    """
+    with pytest.raises(ValueError, match="Invalid hex string for DER public key"):
+        PublicKey.from_string_der("gghh")
+
+
+def test_from_string_catch_all_ed25519(ed25519_keypair):
+    """
+    Test the catch-all from_string method with an Ed25519 public key hex.
+    Ensures warning and correct detection.
+    """
+    _, pub = ed25519_keypair
+    raw = pub.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw
+    )
+    hex_str = raw.hex()
+
+    with pytest.warns(UserWarning, match="from_string.*cannot distinguish"):
+        pubk = PublicKey.from_string(hex_str)
+    assert pubk.is_ed25519()
+
+# ------------------------------------------------------------------------------
+# Test: to_proto
+# ------------------------------------------------------------------------------
+def test_to_proto_ed25519(ed25519_keypair):
+    _, pub = ed25519_keypair    
+    pubk = PublicKey(pub)
+    
+    # Convert to the protobuf Key message
+    proto = pubk.to_proto()
+    # Ensure the oneof field named “key” is set to the ed25519 variant
+    assert proto.WhichOneof("key") == "ed25519"
+    # The bytes in the proto should exactly match the raw Ed25519 bytes
+    assert proto.ed25519 == pubk.to_bytes_ed25519()
+
+
+def test_to_proto_ecdsa(ecdsa_keypair):
+    _, pub = ecdsa_keypair    
+    pubk = PublicKey(pub)
+    
+    # Convert to the protobuf Key message
+    proto = pubk.to_proto()
+    # Ensure the oneof field named “key” is set to the ECDSA_secp256k1 variant
+    assert proto.WhichOneof("key") == "ECDSA_secp256k1"
+    # The bytes in the proto should exactly match the compressed secp256k1 bytes
+    assert proto.ECDSA_secp256k1 == pubk.to_bytes_ecdsa()
+
+# ------------------------------------------------------------------------------
+# Test: verify signatures
+# ------------------------------------------------------------------------------
+def test_verify_ed25519_success(ed25519_keypair):
+    """
+    Verify that an Ed25519 signature created by the private key can be
+    successfully validated by the PublicKey wrapper’s verify() method.
+    """
+    priv, pub = ed25519_keypair
+    pubk = PublicKey(pub)
+
+    # The message to be signed
+    msg = b"hello world"
+
+    # Use the Ed25519 private key to sign the message.
+    sig = priv.sign(msg)
+
+    # Verify the signature against the original message.
+    # If the signature is correct, verify() returns None and raises no error.
+    pubk.verify(sig, msg)
+
+
+def test_verify_ed25519_fail(ed25519_keypair):
+    priv, pub = ed25519_keypair
+    pubk = PublicKey(pub)
+
+    msg = b"hello world"
+    sig = priv.sign(msg)
+    wrong_msg = b"hello worlds"
+
+    # If the signature is incorrect, it would raise cryptography.exceptions.InvalidSignature.
+    with pytest.raises(InvalidSignature):
+        pubk.verify(sig, wrong_msg)
+
+
+def test_verify_ecdsa_success(ecdsa_keypair):
+    priv, pub = ecdsa_keypair
+    pk = PublicKey(pub)
+
+    msg = b"some message"
+    signature = priv.sign(msg, ec.ECDSA(hashes.SHA256()))
+    # If the signature is correct, verify() returns None and raises no error.
+    pk.verify(signature, msg)
+
+def test_verify_ecdsa_fail(ecdsa_keypair):
+    priv, pub = ecdsa_keypair
+    pk = PublicKey(pub)
+
+    msg = b"some message"
+    signature = priv.sign(msg, ec.ECDSA(hashes.SHA256()))
+    wrong_msg = b"some message but slightly changed"
+
+    # If the signature is incorrect, it would raise cryptography.exceptions.InvalidSignature.
+    with pytest.raises(InvalidSignature):
+        pk.verify(signature, wrong_msg)
+
+
+# ------------------------------------------------------------------------------
+# Test: representation (__repr__)
+# ------------------------------------------------------------------------------
+def test_repr_ed25519(ed25519_keypair):
+    _, pub = ed25519_keypair
+    pubk = PublicKey(pub)
+
+    # Call repr(), which should include algorithm name and raw-hex
+    r = repr(pubk)
+    assert "Ed25519" in r
+    # It must include the raw public-key hex string
+    assert pubk.to_string_raw() in r
+
+def test_repr_ecdsa(ecdsa_keypair):
+    _, pub = ecdsa_keypair
+    pubk = PublicKey(pub)
+    r = repr(pubk)
+
+    assert "ECDSA" in r
+    # It must include the raw public-key hex string
+    assert pubk.to_string_raw() in r
+


### PR DESCRIPTION
**Description**:
Proposal / opening areas for further discussion to as a fix to "Ed25519 Public Key parsed as Ed25519 Private Key #67
"
https://github.com/hiero-ledger/hiero-sdk-python/issues/67

We discussed that the private and public keys cannot be distinguished.
We discussed pushing the task to the user through methods such as _ed25519 and _edcsa.

I propose retaining some of the original methods, and adding these additional methods. This is because the code is functionally often identical, sometimes for convenience with trained users a catch all can be beneficial. It should 'fix' the issue in the sense that the user has a low probability of putting in a private key as a public key.

I propose not adding _specific methods to all cases, but quite a lot of them. This should create a very clear experience overall for the users, yet hopefully isn't too much extra faff. 

Additional changes:
* Some explicit warnings
* Some local tests
* Some key-type specific examples
* Improved docstrings and documentation for the next user

Additional notes:
* Further additions to documentation, examples and tests could be desirable.

Note:
* Would invite expert opinions, progress made through research
* Unsure of requirements for PKCS8 vs Traditional Open SSL

**Checklist**

- [ Yes] Documented (Code comments, README, etc.)
- [ Yes] Tested (unit, integration, etc.)
