### PR TITLE
feat: add _require_frozen()

### DIFF
--- a/src/hiero_sdk_python/transaction/transaction.py
+++ b/src/hiero_sdk_python/transaction/transaction.py
@@ -320,6 +320,19 @@ class Transaction(_Executable):
         if self.transaction_body_bytes is not None:
             raise Exception("Transaction is immutable; it has been frozen.")
 
+    def _require_frozen(self):
+        """
+        Ensures the transaction is frozen before allowing operations that require a frozen transaction.
+
+        This method checks if the transaction has been frozen by verifying that transaction_body_bytes
+        has been set.
+
+        Raises:
+            Exception: If the transaction has not been frozen yet.
+        """
+        if self.transaction_body_bytes is None:
+            raise Exception("Transaction is not frozen")
+
     def set_transaction_memo(self, memo):
         """
         Sets the memo field for the transaction.

--- a/src/hiero_sdk_python/transaction/transaction.py
+++ b/src/hiero_sdk_python/transaction/transaction.py
@@ -146,8 +146,8 @@ class Transaction(_Executable):
         Raises:
             Exception: If the transaction body has not been built.
         """
-        if self.transaction_body_bytes is None:
-            self.transaction_body_bytes = self.build_transaction_body().SerializeToString()
+        # We require the transaction to be frozen before signing
+        self._require_frozen()
 
         signature = private_key.sign(self.transaction_body_bytes)
 
@@ -172,8 +172,8 @@ class Transaction(_Executable):
         Raises:
             Exception: If the transaction body has not been built.
         """
-        if self.transaction_body_bytes is None:
-            raise Exception("Transaction must be signed before calling to_proto()")
+        # We require the transaction to be frozen before converting to protobuf
+        self._require_frozen()
 
         signed_transaction = transaction_contents_pb2.SignedTransaction(
             bodyBytes=self.transaction_body_bytes,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,5 +1,9 @@
 import pytest
 from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.client.network import Network
+from hiero_sdk_python.client.client import Client
+from hiero_sdk_python.logger.log_level import LogLevel
+from hiero_sdk_python.node import _Node
 from hiero_sdk_python.consensus.topic_id import TopicId
 from hiero_sdk_python.crypto.private_key import PrivateKey
 from hiero_sdk_python.tokens.token_id import TokenId
@@ -39,3 +43,17 @@ def private_key():
 def topic_id():
     """Fixture to create a topic ID for testing."""
     return TopicId(0, 0, 1234)
+
+@pytest.fixture
+def mock_client():
+    """Fixture to provide a mock client with hardcoded nodes for testing purposes."""
+    nodes = [_Node(AccountId(0, 0, 3), "node1.example.com:50211", None)]
+    network = Network(nodes=nodes)
+    client = Client(network)
+    client.logger.set_level(LogLevel.DISABLED)
+
+    operator_key = PrivateKey.generate()
+    operator_id = AccountId(0, 0, 1984)
+    client.set_operator(operator_id, operator_key)
+
+    return client

--- a/tests/unit/test_account_create_transaction.py
+++ b/tests/unit/test_account_create_transaction.py
@@ -131,6 +131,25 @@ def test_account_create_transaction():
         assert receipt.status == ResponseCode.SUCCESS, "Transaction should have succeeded"
         assert receipt.accountId.num == 1234, "Should have created account with ID 1234"
 
+def test_sign_account_create_without_freezing_raises_error(mock_account_ids):
+    """Test that signing a transaction without freezing it first raises an error."""
+    operator_id, node_account_id = mock_account_ids
+    
+    new_private_key = PrivateKey.generate()
+    new_public_key = new_private_key.public_key()
+    
+    account_tx = (
+        AccountCreateTransaction()
+        .set_key(new_public_key)
+        .set_initial_balance(100000000)
+        .set_account_memo("Test account")
+    )
+    account_tx.transaction_id = generate_transaction_id(operator_id)
+    account_tx.node_account_id = node_account_id
+
+    with pytest.raises(Exception, match="Transaction is not frozen"):
+        account_tx.sign(new_private_key)
+
 @pytest.fixture
 def mock_account_ids():
     """Fixture to provide mock account IDs for testing."""

--- a/tests/unit/test_token_delete_transaction.py
+++ b/tests/unit/test_token_delete_transaction.py
@@ -43,18 +43,20 @@ def test_missing_token_id():
     with pytest.raises(ValueError, match="Missing required TokenID."):
         delete_tx.build_transaction_body()
 
-# This test uses fixture mock_account_ids as parameter
-def test_sign_transaction(mock_account_ids):
+# This test uses fixtures (mock_account_ids, mock_client) as parameters
+def test_sign_transaction(mock_account_ids, mock_client):
     """Test signing the token delete transaction with a private key."""
-    operator_id, _, node_account_id, token_id, _= mock_account_ids
+    operator_id, _, _, token_id, _= mock_account_ids
+    
     delete_tx = TokenDeleteTransaction()
     delete_tx.set_token_id(token_id)
     delete_tx.transaction_id = generate_transaction_id(operator_id)
-    delete_tx.node_account_id = node_account_id
 
     private_key = MagicMock()
     private_key.sign.return_value = b'signature'
     private_key.public_key().to_bytes_raw.return_value = b'public_key'
+    
+    delete_tx.freeze_with(mock_client)
 
     delete_tx.sign(private_key)
 
@@ -63,18 +65,20 @@ def test_sign_transaction(mock_account_ids):
     assert sig_pair.pubKeyPrefix == b'public_key'
     assert sig_pair.ed25519 == b'signature'
 
-# This test uses fixture mock_account_ids as parameter
-def test_to_proto(mock_account_ids):
+# This test uses fixtures (mock_account_ids, mock_client) as parameters
+def test_to_proto(mock_account_ids, mock_client):
     """Test converting the token delete transaction to protobuf format after signing."""
-    operator_id, _, node_account_id, token_id, _= mock_account_ids
+    operator_id, _, _, token_id, _= mock_account_ids
+    
     delete_tx = TokenDeleteTransaction()
     delete_tx.set_token_id(token_id)
     delete_tx.transaction_id = generate_transaction_id(operator_id)
-    delete_tx.node_account_id = node_account_id
 
     private_key = MagicMock()
     private_key.sign.return_value = b'signature'
     private_key.public_key().to_bytes_raw.return_value = b'public_key'
+    
+    delete_tx.freeze_with(mock_client)
 
     delete_tx.sign(private_key)
     proto = delete_tx.to_proto()

--- a/tests/unit/test_token_dissociate_transaction.py
+++ b/tests/unit/test_token_dissociate_transaction.py
@@ -72,18 +72,20 @@ def test_missing_fields():
     with pytest.raises(ValueError, match="Account ID and token IDs must be set."):
         dissociate_tx.build_transaction_body()
 
-def test_sign_transaction(mock_account_ids):
+def test_sign_transaction(mock_account_ids, mock_client):
     """Test signing the token dissociate transaction with a private key."""
-    account_id, _, node_account_id, token_id_1, _ = mock_account_ids
+    account_id, _, _, token_id_1, _ = mock_account_ids
+    
     dissociate_tx = TokenDissociateTransaction()
     dissociate_tx.set_account_id(account_id)
     dissociate_tx.add_token_id(token_id_1)
     dissociate_tx.transaction_id = generate_transaction_id(account_id)
-    dissociate_tx.node_account_id = node_account_id
 
     private_key = MagicMock()
     private_key.sign.return_value = b'signature'
     private_key.public_key().to_bytes_raw.return_value = b'public_key'
+    
+    dissociate_tx.freeze_with(mock_client)
 
     dissociate_tx.sign(private_key)
 
@@ -93,18 +95,20 @@ def test_sign_transaction(mock_account_ids):
     assert sig_pair.pubKeyPrefix == b'public_key'  
     assert sig_pair.ed25519 == b'signature'
 
-def test_to_proto(mock_account_ids):
+def test_to_proto(mock_account_ids, mock_client):
     """Test converting the token dissociate transaction to protobuf format after signing."""
-    account_id, _, node_account_id, token_id_1, _ = mock_account_ids
+    account_id, _, _, token_id_1, _ = mock_account_ids
+    
     dissociate_tx = TokenDissociateTransaction()
     dissociate_tx.set_account_id(account_id)
     dissociate_tx.add_token_id(token_id_1)
-    dissociate_tx.transaction_id = generate_transaction_id(account_id)
-    dissociate_tx.node_account_id = node_account_id
-
+    dissociate_tx.transaction_id = generate_transaction_id(account_id)  
+    
     private_key = MagicMock()
     private_key.sign.return_value = b'signature'
     private_key.public_key().to_bytes_raw.return_value = b'public_key'
+    
+    dissociate_tx.freeze_with(mock_client)
 
     dissociate_tx.sign(private_key)
     proto = dissociate_tx.to_proto()

--- a/tests/unit/test_token_freeze_transaction.py
+++ b/tests/unit/test_token_freeze_transaction.py
@@ -61,19 +61,21 @@ def test_missing_account_id(mock_account_ids):
     with pytest.raises(ValueError, match="Missing required AccountID."):
         freeze_tx.build_transaction_body()
 
-# This test uses fixtures (mock_account_ids) as parameters
-def test_sign_transaction(mock_account_ids):
+# This test uses fixtures (mock_account_id, mock_client) as parameters
+def test_sign_transaction(mock_account_ids, mock_client):
     """Test signing the token freeze transaction with a freeze key."""
-    account_id, freeze_id, node_account_id, token_id, _= mock_account_ids
+    account_id, freeze_id, _, token_id, _= mock_account_ids
+    
     freeze_tx = TokenFreezeTransaction()
     freeze_tx.set_token_id(token_id)
     freeze_tx.set_account_id(freeze_id)
     freeze_tx.transaction_id = generate_transaction_id(account_id)
-    freeze_tx.node_account_id = node_account_id
 
     freeze_key = MagicMock()
     freeze_key.sign.return_value = b'signature'
     freeze_key.public_key().to_bytes_raw.return_value = b'public_key'
+    
+    freeze_tx.freeze_with(mock_client)
 
     freeze_tx.sign(freeze_key)
 
@@ -83,18 +85,20 @@ def test_sign_transaction(mock_account_ids):
     assert sig_pair.ed25519 == b'signature'
 
 # This test uses fixtures (mock_account_ids) as parameters
-def test_to_proto(mock_account_ids):
+def test_to_proto(mock_account_ids, mock_client):
     """Test converting the token freeze transaction to protobuf format after signing."""
-    account_id, freeze_id, node_account_id, token_id, _= mock_account_ids
+    account_id, freeze_id, _, token_id, _= mock_account_ids
+
     freeze_tx = TokenFreezeTransaction()
     freeze_tx.set_token_id(token_id)
     freeze_tx.set_account_id(freeze_id)
     freeze_tx.transaction_id = generate_transaction_id(account_id)
-    freeze_tx.node_account_id = node_account_id
 
     freeze_key = MagicMock()
     freeze_key.sign.return_value = b'signature'
     freeze_key.public_key().to_bytes_raw.return_value = b'public_key'
+    
+    freeze_tx.freeze_with(mock_client)
 
     freeze_tx.sign(freeze_key)
     proto = freeze_tx.to_proto()

--- a/tests/unit/test_token_mint_transaction.py
+++ b/tests/unit/test_token_mint_transaction.py
@@ -147,21 +147,22 @@ def test_build_transaction_body_both_amount_and_metadata(mock_account_ids, amoun
     with pytest.raises(ValueError, match="Specify either amount for fungible tokens or metadata for NFTs, not both."):
         mint_tx.build_transaction_body()
 
-# This test uses fixtures (mock_account_ids, amount) as parameters
-def test_sign_transaction_fungible(mock_account_ids, amount):
+# This test uses fixtures (mock_account_ids, amount, mock_client) as parameters
+def test_sign_transaction_fungible(mock_account_ids, amount, mock_client):
     """Test signing the fungible token mint transaction with a supply key."""
-    operator_id, _, node_account_id, token_id, _= mock_account_ids
+    operator_id, _, _, token_id, _= mock_account_ids
     
     mint_tx = TokenMintTransaction()
     mint_tx.set_token_id(token_id)
     mint_tx.set_amount(amount)        
     mint_tx.transaction_id = generate_transaction_id(operator_id)
-    mint_tx.node_account_id = node_account_id
 
     #Mock a supply key
     supply_key = MagicMock()
     supply_key.sign.return_value = b'signature'
     supply_key.public_key().to_bytes_raw.return_value = b'public_key'
+    
+    mint_tx.freeze_with(mock_client)
 
     mint_tx.sign(supply_key)
 
@@ -170,19 +171,18 @@ def test_sign_transaction_fungible(mock_account_ids, amount):
     assert sig_pair.pubKeyPrefix == b'public_key'
     assert sig_pair.ed25519 == b'signature'
 
-# This test uses fixtures (mock_account_ids, metadata) as parameters
-def test_sign_transaction_nft(mock_account_ids, metadata):
+# This test uses fixtures (mock_account_ids, metadata, mock_client) as parameters
+def test_sign_transaction_nft(mock_account_ids, metadata, mock_client):
     """Test signing the NFT mint transaction with a supply key."""
-    operator_id, _, node_account_id, token_id, _ = mock_account_ids
+    operator_id, _, _, token_id, _ = mock_account_ids
 
     mint_tx = TokenMintTransaction()
     mint_tx.set_token_id(token_id)
     mint_tx.set_metadata(metadata)
 
     mint_tx.transaction_id = generate_transaction_id(operator_id)
-    mint_tx.node_account_id = node_account_id
 
-    mint_tx.build_transaction_body()
+    mint_tx.freeze_with(mock_client)
 
     supply_key = MagicMock()
     supply_key.sign.return_value = b'signature'
@@ -194,20 +194,21 @@ def test_sign_transaction_nft(mock_account_ids, metadata):
     assert sig_pair.pubKeyPrefix == b'public_key'
     assert sig_pair.ed25519 == b'signature'
 
-# This test uses fixtures (mock_account_ids, amount) as parameters
-def test_to_proto_fungible(mock_account_ids, amount):
+# This test uses fixtures (mock_account_ids, amount, mock_client) as parameters
+def test_to_proto_fungible(mock_account_ids, amount, mock_client):
     """Test converting the fungible token mint transaction to protobuf format after signing."""
-    operator_id, _, node_account_id, token_id, _= mock_account_ids
+    operator_id, _, _, token_id, _= mock_account_ids
 
     mint_tx = TokenMintTransaction()
     mint_tx.set_token_id(token_id)
     mint_tx.set_amount(amount)        
     mint_tx.transaction_id = generate_transaction_id(operator_id)
-    mint_tx.node_account_id = node_account_id
 
     supply_key = MagicMock()
     supply_key.sign.return_value = b'signature'
     supply_key.public_key().to_bytes_raw.return_value = b'public_key'
+    
+    mint_tx.freeze_with(mock_client)
 
     mint_tx.sign(supply_key)
     proto = mint_tx.to_proto()
@@ -215,18 +216,17 @@ def test_to_proto_fungible(mock_account_ids, amount):
     assert proto.signedTransactionBytes
     assert len(proto.signedTransactionBytes) > 0
 
-# This test uses fixtures (mock_account_ids, metadata) as parameters
-def test_to_proto_nft(mock_account_ids, metadata):
+# This test uses fixtures (mock_account_ids, metadata, mock_client) as parameters
+def test_to_proto_nft(mock_account_ids, metadata, mock_client):
     """Test converting the nft token mint transaction to protobuf format after signing."""
-    operator_id, _, node_account_id, token_id, _= mock_account_ids
+    operator_id, _, _, token_id, _= mock_account_ids
 
     mint_tx = TokenMintTransaction()
     mint_tx.set_token_id(token_id)
     mint_tx.set_metadata(metadata)
     mint_tx.transaction_id = generate_transaction_id(operator_id)
-    mint_tx.node_account_id = node_account_id
-
-    mint_tx.build_transaction_body()
+    
+    mint_tx.freeze_with(mock_client)
 
     supply_key = MagicMock()
     supply_key.sign.return_value = b'signature'

--- a/tests/unit/test_token_unfreeze_transaction.py
+++ b/tests/unit/test_token_unfreeze_transaction.py
@@ -62,20 +62,20 @@ def test_missing_account_id(mock_account_ids):
     with pytest.raises(ValueError, match="Missing required AccountID."):
         unfreeze_tx.build_transaction_body()
 
-def test_sign_transaction(mock_account_ids):
+def test_sign_transaction(mock_account_ids, mock_client):
     """Test signing the token unfreeze transaction with a freeze key."""
-
-    account_id, freeze_id, node_account_id, token_id, _= mock_account_ids
+    account_id, freeze_id, _, token_id, _= mock_account_ids
 
     unfreeze_tx = TokenUnfreezeTransaction()
     unfreeze_tx.set_token_id(token_id)
     unfreeze_tx.set_account_id(freeze_id)
     unfreeze_tx.transaction_id = generate_transaction_id(account_id)
-    unfreeze_tx.node_account_id = node_account_id
 
     freeze_key = MagicMock()
     freeze_key.sign.return_value = b'signature'
     freeze_key.public_key().to_bytes_raw.return_value = b'public_key'
+    
+    unfreeze_tx.freeze_with(mock_client)
 
     unfreeze_tx.sign(freeze_key)
 
@@ -85,20 +85,20 @@ def test_sign_transaction(mock_account_ids):
     assert sig_pair.pubKeyPrefix == b'public_key'
     assert sig_pair.ed25519 == b'signature'
 
-def test_to_proto(mock_account_ids):
+def test_to_proto(mock_account_ids, mock_client):
     """Test converting the token unfreeze transaction to protobuf format after signing."""
-
-    account_id, freeze_id, node_account_id, token_id, _= mock_account_ids
+    account_id, freeze_id, _, token_id, _= mock_account_ids
 
     unfreeze_tx = TokenUnfreezeTransaction()
     unfreeze_tx.set_token_id(token_id)
     unfreeze_tx.set_account_id(freeze_id)
     unfreeze_tx.transaction_id = generate_transaction_id(account_id)
-    unfreeze_tx.node_account_id = node_account_id
 
     freeze_key = MagicMock()
     freeze_key.sign.return_value = b'signature'
     freeze_key.public_key().to_bytes_raw.return_value = b'mock_pubkey'
+    
+    unfreeze_tx.freeze_with(mock_client)
 
     unfreeze_tx.sign(freeze_key)
     proto = unfreeze_tx.to_proto()

--- a/tests/unit/test_token_wipe_transaction.py
+++ b/tests/unit/test_token_wipe_transaction.py
@@ -83,10 +83,11 @@ def test_build_transaction_body_with_serial_numbers(mock_account_ids):
 
     assert transaction_body.tokenWipe.serialNumbers == serial_numbers
 
-# This test uses fixture mock_account_ids as parameter
-def test_to_proto(mock_account_ids):
+# This test uses fixture (mock_account_ids, mock_client) as parameter
+def test_to_proto(mock_account_ids, mock_client):
     """Test converting the token wipe transaction to protobuf format after signing."""
-    account_id, wipe_account_id, node_account_id, token_id, _ = mock_account_ids
+    account_id, wipe_account_id, _, token_id, _ = mock_account_ids
+    
     amount = 1000
 
     wipe_tx = (
@@ -97,11 +98,12 @@ def test_to_proto(mock_account_ids):
     )
     
     wipe_tx.transaction_id = generate_transaction_id(account_id)
-    wipe_tx.node_account_id = node_account_id
 
     wipe_key = MagicMock()
     wipe_key.sign.return_value = b'signature'
     wipe_key.public_key().to_bytes_raw.return_value = b'public_key'
+    
+    wipe_tx.freeze_with(mock_client)
 
     wipe_tx.sign(wipe_key)
     proto = wipe_tx.to_proto()


### PR DESCRIPTION
**Description**:
Add transaction freezing requirement and reorganize test utilities

* Add `_require_frozen()` check in `Transaction` class
* Updated `sign()` and `to_proto()` to use `_require_frozen()`
* Move `utils_for_test.py` from `tests/integration` to `tests/` for better code organization
* Update unit tests to properly freeze transactions before execution
* Add `create_mock_client()` utility for testing transaction-related functionality

**Related issue(s)**:

Fixes #95

**Notes for reviewer**:
- We need this changes so we can later fix `INVALID_NODE_ACCOUNT` during node switching. Currently, we can sign a transaction without freezing it first, but this is a problem because we need to build the transaction body bytes for each node in the network. By requiring freezing before signing, we ensure that the transaction body bytes map (dict[AccountId, bytes]) is properly populated for all nodes, which is needed for proper node switching. Without freezing, we can't properly build and sign the transaction for all nodes, leading to potential `INVALID_NODE_ACCOUNT` errors when the transaction is sent to a different node.
- This change aligns our Python SDK with other Hedera SDKs by requiring transaction freezing.

**Checklist**

- [X] Documented (Code comments)
- [X] Tested (unit, integration)
