### PR TITLE
fix: INVALID_NODE_ACCOUNT during node switching

### DIFF
--- a/src/hiero_sdk_python/query/query.py
+++ b/src/hiero_sdk_python/query/query.py
@@ -145,7 +145,7 @@ class Query(_Executable):
         tx.transaction_id = TransactionId.generate(payer_account_id)
 
         body_bytes = tx.build_transaction_body().SerializeToString()
-        tx.transaction_body_bytes.setdefault(node_account_id, body_bytes)
+        tx._transaction_body_bytes.setdefault(node_account_id, body_bytes)
         tx.sign(payer_private_key)
 
         return tx.to_proto()

--- a/src/hiero_sdk_python/query/query.py
+++ b/src/hiero_sdk_python/query/query.py
@@ -145,7 +145,7 @@ class Query(_Executable):
         tx.transaction_id = TransactionId.generate(payer_account_id)
 
         body_bytes = tx.build_transaction_body().SerializeToString()
-        tx.transaction_body_bytes = body_bytes
+        tx.transaction_body_bytes.setdefault(node_account_id, body_bytes)
         tx.sign(payer_private_key)
 
         return tx.to_proto()

--- a/src/hiero_sdk_python/transaction/query_payment.py
+++ b/src/hiero_sdk_python/transaction/query_payment.py
@@ -26,7 +26,7 @@ def build_query_payment_transaction(
     tx.transaction_id = TransactionId.generate(payer_account_id)
 
     body_bytes = tx.build_transaction_body().SerializeToString()
-    tx.transaction_body_bytes = body_bytes
+    tx._transaction_body_bytes.setdefault(node_account_id, body_bytes)
 
     tx.sign(payer_private_key)
     return tx.to_proto()

--- a/src/hiero_sdk_python/transaction/transaction.py
+++ b/src/hiero_sdk_python/transaction/transaction.py
@@ -345,7 +345,7 @@ class Transaction(_Executable):
         Raises:
             Exception: If the transaction has not been frozen yet.
         """
-        if self.transaction_body_bytes is None:
+        if not self.transaction_body_bytes:
             raise Exception("Transaction is not frozen")
 
     def set_transaction_memo(self, memo):

--- a/tests/unit/test_account_create_transaction.py
+++ b/tests/unit/test_account_create_transaction.py
@@ -76,18 +76,18 @@ def test_account_create_transaction_sign(mock_account_ids, mock_client):
 
     # Add first signiture
     account_tx.sign(mock_client.operator_private_key)
-    body_bytes = account_tx.transaction_body_bytes[node_account_id]
+    body_bytes = account_tx._transaction_body_bytes[node_account_id]
     
-    assert body_bytes in account_tx.signature_map, "Body bytes should be a key in the signature map dictionary"
-    assert len(account_tx.signature_map[body_bytes].sigPair) == 1, \
+    assert body_bytes in account_tx._signature_map, "Body bytes should be a key in the signature map dictionary"
+    assert len(account_tx._signature_map[body_bytes].sigPair) == 1, \
         "Transaction should have exactly one signature"
     
     # Add second signiture
     account_tx.sign(operator_private_key)
-    body_bytes = account_tx.transaction_body_bytes[node_account_id]
+    body_bytes = account_tx._transaction_body_bytes[node_account_id]
     
-    assert body_bytes in account_tx.signature_map, "Body bytes should be a key in the signature map dictionary"
-    assert len(account_tx.signature_map[body_bytes].sigPair) == 2, \
+    assert body_bytes in account_tx._signature_map, "Body bytes should be a key in the signature map dictionary"
+    assert len(account_tx._signature_map[body_bytes].sigPair) == 2, \
         "Transaction should have exactly two signatures"
 
 def test_account_create_transaction():

--- a/tests/unit/test_account_create_transaction.py
+++ b/tests/unit/test_account_create_transaction.py
@@ -55,8 +55,8 @@ def test_account_create_transaction_build(mock_account_ids):
     assert transaction_body.cryptoCreateAccount.initialBalance == 100000000
     assert transaction_body.cryptoCreateAccount.memo == "Test account"
 
-# This test uses fixture mock_account_ids as parameter
-def test_account_create_transaction_sign(mock_account_ids):
+# This test uses fixture (mock_account_ids, mock_client) as parameter
+def test_account_create_transaction_sign(mock_account_ids, mock_client):
     """Test signing the account create transaction."""
     operator_id, node_account_id = mock_account_ids
 
@@ -72,12 +72,23 @@ def test_account_create_transaction_sign(mock_account_ids):
     )
     account_tx.transaction_id = generate_transaction_id(operator_id)
     account_tx.node_account_id = node_account_id
-    account_tx.freeze_with(None)  
-    account_tx.sign(operator_private_key)
+    account_tx.freeze_with(mock_client)
 
-    # Verify signature was added
-    assert len(account_tx.signature_map.sigPair) == 1, \
+    # Add first signiture
+    account_tx.sign(mock_client.operator_private_key)
+    body_bytes = account_tx.transaction_body_bytes[node_account_id]
+    
+    assert body_bytes in account_tx.signature_map, "Body bytes should be a key in the signature map dictionary"
+    assert len(account_tx.signature_map[body_bytes].sigPair) == 1, \
         "Transaction should have exactly one signature"
+    
+    # Add second signiture
+    account_tx.sign(operator_private_key)
+    body_bytes = account_tx.transaction_body_bytes[node_account_id]
+    
+    assert body_bytes in account_tx.signature_map, "Body bytes should be a key in the signature map dictionary"
+    assert len(account_tx.signature_map[body_bytes].sigPair) == 2, \
+        "Transaction should have exactly two signatures"
 
 def test_account_create_transaction():
     """Integration test for AccountCreateTransaction with retry and response handling."""

--- a/tests/unit/test_executable.py
+++ b/tests/unit/test_executable.py
@@ -424,8 +424,8 @@ def test_transaction_node_switching_body_bytes():
         )
         
         for node in client.network.nodes:
-            assert transaction.transaction_body_bytes.get(node._account_id) is not None, "Transaction body bytes should be set for all nodes"
-            sig_map = transaction.signature_map.get(transaction.transaction_body_bytes[node._account_id])
+            assert transaction._transaction_body_bytes.get(node._account_id) is not None, "Transaction body bytes should be set for all nodes"
+            sig_map = transaction._signature_map.get(transaction._transaction_body_bytes[node._account_id])
             assert sig_map is not None, "Signature map should be set for all nodes"
             assert len(sig_map.sigPair) == 1, "Signature map should have one signature"
             assert sig_map.sigPair[0].pubKeyPrefix == client.operator_private_key.public_key().to_bytes_raw(), "Signature should be for the operator"

--- a/tests/unit/test_executable.py
+++ b/tests/unit/test_executable.py
@@ -111,10 +111,6 @@ def test_node_switching_after_single_grpc_error():
     ]
 
     with mock_hedera_servers(response_sequences) as client, patch('time.sleep'):
-        # We set the current node to the first one - that will give an error
-        client.network._node_index = 0
-        client.network.current_node = client.network.nodes[0]
-        
         transaction = (
             AccountCreateTransaction()
             .set_key(PrivateKey.generate().public_key())
@@ -152,10 +148,6 @@ def test_node_switching_after_multiple_grpc_errors():
     ]
     
     with mock_hedera_servers(response_sequences) as client, patch('time.sleep'):
-        # We set the current node to the first one, the next will be the second and the thrid will be success
-        client.network._node_index = 0
-        client.network.current_node = client.network.nodes[0]
-        
         transaction = (
             AccountCreateTransaction()
             .set_key(PrivateKey.generate().public_key())

--- a/tests/unit/test_executable.py
+++ b/tests/unit/test_executable.py
@@ -111,6 +111,10 @@ def test_node_switching_after_single_grpc_error():
     ]
 
     with mock_hedera_servers(response_sequences) as client, patch('time.sleep'):
+        # We set the current node to the first one - that will give an error
+        client.network._node_index = 0
+        client.network.current_node = client.network.nodes[0]
+        
         transaction = (
             AccountCreateTransaction()
             .set_key(PrivateKey.generate().public_key())
@@ -148,6 +152,10 @@ def test_node_switching_after_multiple_grpc_errors():
     ]
     
     with mock_hedera_servers(response_sequences) as client, patch('time.sleep'):
+        # We set the current node to the first one, the next will be the second and the thrid will be success
+        client.network._node_index = 0
+        client.network.current_node = client.network.nodes[0]
+        
         transaction = (
             AccountCreateTransaction()
             .set_key(PrivateKey.generate().public_key())
@@ -380,3 +388,51 @@ def test_topic_create_transaction_fails_on_nonretriable_error():
         
         # Verify the error contains the expected status
         assert str(ResponseCode.INVALID_TRANSACTION_BODY) in str(exc_info.value)
+        
+def test_transaction_node_switching_body_bytes():
+    """Test that execution switches nodes after receiving a non-retriable error."""
+    ok_response = TransactionResponseProto(nodeTransactionPrecheckCode=ResponseCode.OK)
+    error = RealRpcError(grpc.StatusCode.UNAVAILABLE, "Test error")
+    
+    receipt_response = response_pb2.Response(
+        transactionGetReceipt=transaction_get_receipt_pb2.TransactionGetReceiptResponse(
+            header=response_header_pb2.ResponseHeader(
+                nodeTransactionPrecheckCode=ResponseCode.OK
+            ),
+            receipt=transaction_receipt_pb2.TransactionReceipt(
+                status=ResponseCode.SUCCESS
+            )
+        )
+    )
+    # First node gives error, second node gives OK, third node gives error
+    response_sequences = [
+        [error],
+        [ok_response, receipt_response],
+    ]
+    
+    with mock_hedera_servers(response_sequences) as client, patch('time.sleep'):
+        # We set the current node to 0
+        client.network._node_index = 0
+        client.network.current_node = client.network.nodes[0]
+        
+        transaction = (
+            AccountCreateTransaction()
+            .set_key(PrivateKey.generate().public_key())
+            .set_initial_balance(100_000_000)
+            .freeze_with(client)
+            .sign(client.operator_private_key)
+        )
+        
+        for node in client.network.nodes:
+            assert transaction.transaction_body_bytes.get(node._account_id) is not None, "Transaction body bytes should be set for all nodes"
+            sig_map = transaction.signature_map.get(transaction.transaction_body_bytes[node._account_id])
+            assert sig_map is not None, "Signature map should be set for all nodes"
+            assert len(sig_map.sigPair) == 1, "Signature map should have one signature"
+            assert sig_map.sigPair[0].pubKeyPrefix == client.operator_private_key.public_key().to_bytes_raw(), "Signature should be for the operator"
+
+        try:
+            transaction.execute(client)
+        except (Exception, grpc.RpcError) as e:
+            pytest.fail(f"Transaction execution should not raise an exception, but raised: {e}")
+        # Verify we're now on the second node
+        assert client.network.current_node._account_id == AccountId(0, 0, 4), "Client should have switched to the second node"

--- a/tests/unit/test_token_associate_transaction.py
+++ b/tests/unit/test_token_associate_transaction.py
@@ -71,11 +71,11 @@ def test_sign_transaction(mock_account_ids, mock_client):
     associate_tx.sign(private_key)
     
     node_id = mock_client.network.current_node._account_id
-    body_bytes = associate_tx.transaction_body_bytes[node_id]
+    body_bytes = associate_tx._transaction_body_bytes[node_id]
 
-    assert body_bytes in associate_tx.signature_map, "Body bytes should be a key in the signature map dictionary"
-    assert len(associate_tx.signature_map[body_bytes].sigPair) == 1
-    sig_pair = associate_tx.signature_map[body_bytes].sigPair[0]
+    assert body_bytes in associate_tx._signature_map, "Body bytes should be a key in the signature map dictionary"
+    assert len(associate_tx._signature_map[body_bytes].sigPair) == 1
+    sig_pair = associate_tx._signature_map[body_bytes].sigPair[0]
 
     assert sig_pair.pubKeyPrefix == b'public_key'  
     assert sig_pair.ed25519 == b'signature'

--- a/tests/unit/test_token_associate_transaction.py
+++ b/tests/unit/test_token_associate_transaction.py
@@ -69,9 +69,13 @@ def test_sign_transaction(mock_account_ids, mock_client):
     
     # Sign the transaction
     associate_tx.sign(private_key)
+    
+    node_id = mock_client.network.current_node._account_id
+    body_bytes = associate_tx.transaction_body_bytes[node_id]
 
-    assert len(associate_tx.signature_map.sigPair) == 1
-    sig_pair = associate_tx.signature_map.sigPair[0]
+    assert body_bytes in associate_tx.signature_map, "Body bytes should be a key in the signature map dictionary"
+    assert len(associate_tx.signature_map[body_bytes].sigPair) == 1
+    sig_pair = associate_tx.signature_map[body_bytes].sigPair[0]
 
     assert sig_pair.pubKeyPrefix == b'public_key'  
     assert sig_pair.ed25519 == b'signature'

--- a/tests/unit/test_token_create_transaction.py
+++ b/tests/unit/test_token_create_transaction.py
@@ -278,21 +278,21 @@ def test_sign_transaction(mock_account_ids, mock_client):
     token_tx.sign(private_key_admin) # Since admin key exists
     
     node_id = mock_client.network.current_node._account_id
-    body_bytes = token_tx.transaction_body_bytes[node_id]
+    body_bytes = token_tx._transaction_body_bytes[node_id]
 
     # Expect 2 sigPairs
-    assert len(token_tx.signature_map[body_bytes].sigPair) == 2
+    assert len(token_tx._signature_map[body_bytes].sigPair) == 2
 
-    sig_pair = token_tx.signature_map[body_bytes].sigPair[0]
+    sig_pair = token_tx._signature_map[body_bytes].sigPair[0]
     assert sig_pair.pubKeyPrefix == b"public_key"
     assert sig_pair.ed25519 == b"signature"
 
-    sig_pair_admin = token_tx.signature_map[body_bytes].sigPair[1]
+    sig_pair_admin = token_tx._signature_map[body_bytes].sigPair[1]
     assert sig_pair_admin.pubKeyPrefix == b"admin_public_key"
     assert sig_pair_admin.ed25519 == b"admin_signature"
 
     # Confirm that neither sigPair belongs to supply_key or freeze_key:
-    for sig_pair in token_tx.signature_map[body_bytes].sigPair:
+    for sig_pair in token_tx._signature_map[body_bytes].sigPair:
         assert sig_pair.pubKeyPrefix not in (b"supply_public_key", b"freeze_public_key")
 
 # This test uses fixture (mock_account_ids, mock_client) as parameter
@@ -448,7 +448,7 @@ def test_transaction_execution_failure(mock_account_ids):
     token_tx.transaction_id = generate_transaction_id(treasury_account)
     
     # Set the transaction body bytes to avoid calling build_transaction_body
-    token_tx.transaction_body_bytes = b"mock_body_bytes"
+    token_tx._transaction_body_bytes = b"mock_body_bytes"
     
     # Mock the client and its operator_private_key
     token_tx.client = MagicMock()

--- a/tests/unit/test_token_create_transaction.py
+++ b/tests/unit/test_token_create_transaction.py
@@ -276,20 +276,23 @@ def test_sign_transaction(mock_account_ids, mock_client):
     # Sign with both sign keys
     token_tx.sign(private_key) # Necessary
     token_tx.sign(private_key_admin) # Since admin key exists
+    
+    node_id = mock_client.network.current_node._account_id
+    body_bytes = token_tx.transaction_body_bytes[node_id]
 
     # Expect 2 sigPairs
-    assert len(token_tx.signature_map.sigPair) == 2
+    assert len(token_tx.signature_map[body_bytes].sigPair) == 2
 
-    sig_pair = token_tx.signature_map.sigPair[0]
+    sig_pair = token_tx.signature_map[body_bytes].sigPair[0]
     assert sig_pair.pubKeyPrefix == b"public_key"
     assert sig_pair.ed25519 == b"signature"
 
-    sig_pair_admin = token_tx.signature_map.sigPair[1]
+    sig_pair_admin = token_tx.signature_map[body_bytes].sigPair[1]
     assert sig_pair_admin.pubKeyPrefix == b"admin_public_key"
     assert sig_pair_admin.ed25519 == b"admin_signature"
 
     # Confirm that neither sigPair belongs to supply_key or freeze_key:
-    for sig_pair in token_tx.signature_map.sigPair:
+    for sig_pair in token_tx.signature_map[body_bytes].sigPair:
         assert sig_pair.pubKeyPrefix not in (b"supply_public_key", b"freeze_public_key")
 
 # This test uses fixture (mock_account_ids, mock_client) as parameter
@@ -543,8 +546,8 @@ def test_overwrite_defaults(mock_account_ids, mock_client):
     # Confirm no adminKey was set
     assert not tx_body.tokenCreation.HasField("adminKey")
 
-# This test uses fixture mock_account_ids as parameter
-def test_transaction_freeze_prevents_modification(mock_account_ids):
+# This test uses fixture (mock_account_ids, mock_client) as parameter
+def test_transaction_freeze_prevents_modification(mock_account_ids, mock_client):
     """
     Test that after freeze() is called, attempts to modify TokenCreateTransaction
     parameters raise an exception indicating immutability.
@@ -562,10 +565,9 @@ def test_transaction_freeze_prevents_modification(mock_account_ids):
 
     transaction.node_account_id = node_account_id
     transaction.transaction_id = generate_transaction_id(treasury_account)
-    transaction.client = MagicMock()
     
     # Freeze the transaction
-    transaction.freeze_with(transaction.client)
+    transaction.freeze_with(mock_client)
 
     # Attempt to overwrite after freeze - expect exceptions
     with pytest.raises(Exception, match="Transaction is immutable; it has been frozen."):

--- a/tests/unit/test_token_delete_transaction.py
+++ b/tests/unit/test_token_delete_transaction.py
@@ -61,10 +61,10 @@ def test_sign_transaction(mock_account_ids, mock_client):
     delete_tx.sign(private_key)
 
     node_id = mock_client.network.current_node._account_id
-    body_bytes = delete_tx.transaction_body_bytes[node_id]
+    body_bytes = delete_tx._transaction_body_bytes[node_id]
 
-    assert len(delete_tx.signature_map[body_bytes].sigPair) == 1
-    sig_pair = delete_tx.signature_map[body_bytes].sigPair[0]
+    assert len(delete_tx._signature_map[body_bytes].sigPair) == 1
+    sig_pair = delete_tx._signature_map[body_bytes].sigPair[0]
     assert sig_pair.pubKeyPrefix == b'public_key'
     assert sig_pair.ed25519 == b'signature'
 

--- a/tests/unit/test_token_delete_transaction.py
+++ b/tests/unit/test_token_delete_transaction.py
@@ -60,8 +60,11 @@ def test_sign_transaction(mock_account_ids, mock_client):
 
     delete_tx.sign(private_key)
 
-    assert len(delete_tx.signature_map.sigPair) == 1
-    sig_pair = delete_tx.signature_map.sigPair[0]
+    node_id = mock_client.network.current_node._account_id
+    body_bytes = delete_tx.transaction_body_bytes[node_id]
+
+    assert len(delete_tx.signature_map[body_bytes].sigPair) == 1
+    sig_pair = delete_tx.signature_map[body_bytes].sigPair[0]
     assert sig_pair.pubKeyPrefix == b'public_key'
     assert sig_pair.ed25519 == b'signature'
 

--- a/tests/unit/test_token_dissociate_transaction.py
+++ b/tests/unit/test_token_dissociate_transaction.py
@@ -89,8 +89,11 @@ def test_sign_transaction(mock_account_ids, mock_client):
 
     dissociate_tx.sign(private_key)
 
-    assert len(dissociate_tx.signature_map.sigPair) == 1
-    sig_pair = dissociate_tx.signature_map.sigPair[0]
+    node_id = mock_client.network.current_node._account_id
+    body_bytes = dissociate_tx.transaction_body_bytes[node_id]
+
+    assert len(dissociate_tx.signature_map[body_bytes].sigPair) == 1
+    sig_pair = dissociate_tx.signature_map[body_bytes].sigPair[0]
 
     assert sig_pair.pubKeyPrefix == b'public_key'  
     assert sig_pair.ed25519 == b'signature'

--- a/tests/unit/test_token_dissociate_transaction.py
+++ b/tests/unit/test_token_dissociate_transaction.py
@@ -90,10 +90,10 @@ def test_sign_transaction(mock_account_ids, mock_client):
     dissociate_tx.sign(private_key)
 
     node_id = mock_client.network.current_node._account_id
-    body_bytes = dissociate_tx.transaction_body_bytes[node_id]
+    body_bytes = dissociate_tx._transaction_body_bytes[node_id]
 
-    assert len(dissociate_tx.signature_map[body_bytes].sigPair) == 1
-    sig_pair = dissociate_tx.signature_map[body_bytes].sigPair[0]
+    assert len(dissociate_tx._signature_map[body_bytes].sigPair) == 1
+    sig_pair = dissociate_tx._signature_map[body_bytes].sigPair[0]
 
     assert sig_pair.pubKeyPrefix == b'public_key'  
     assert sig_pair.ed25519 == b'signature'

--- a/tests/unit/test_token_freeze_transaction.py
+++ b/tests/unit/test_token_freeze_transaction.py
@@ -80,10 +80,10 @@ def test_sign_transaction(mock_account_ids, mock_client):
     freeze_tx.sign(freeze_key)
 
     node_id = mock_client.network.current_node._account_id
-    body_bytes = freeze_tx.transaction_body_bytes[node_id]
+    body_bytes = freeze_tx._transaction_body_bytes[node_id]
 
-    assert len(freeze_tx.signature_map[body_bytes].sigPair) == 1
-    sig_pair = freeze_tx.signature_map[body_bytes].sigPair[0]
+    assert len(freeze_tx._signature_map[body_bytes].sigPair) == 1
+    sig_pair = freeze_tx._signature_map[body_bytes].sigPair[0]
     assert sig_pair.pubKeyPrefix == b'public_key'
     assert sig_pair.ed25519 == b'signature'
 

--- a/tests/unit/test_token_freeze_transaction.py
+++ b/tests/unit/test_token_freeze_transaction.py
@@ -79,8 +79,11 @@ def test_sign_transaction(mock_account_ids, mock_client):
 
     freeze_tx.sign(freeze_key)
 
-    assert len(freeze_tx.signature_map.sigPair) == 1
-    sig_pair = freeze_tx.signature_map.sigPair[0]
+    node_id = mock_client.network.current_node._account_id
+    body_bytes = freeze_tx.transaction_body_bytes[node_id]
+
+    assert len(freeze_tx.signature_map[body_bytes].sigPair) == 1
+    sig_pair = freeze_tx.signature_map[body_bytes].sigPair[0]
     assert sig_pair.pubKeyPrefix == b'public_key'
     assert sig_pair.ed25519 == b'signature'
 

--- a/tests/unit/test_token_mint_transaction.py
+++ b/tests/unit/test_token_mint_transaction.py
@@ -166,8 +166,11 @@ def test_sign_transaction_fungible(mock_account_ids, amount, mock_client):
 
     mint_tx.sign(supply_key)
 
-    assert len(mint_tx.signature_map.sigPair) == 1
-    sig_pair = mint_tx.signature_map.sigPair[0]
+    node_id = mock_client.network.current_node._account_id
+    body_bytes = mint_tx.transaction_body_bytes[node_id]
+
+    assert len(mint_tx.signature_map[body_bytes].sigPair) == 1
+    sig_pair = mint_tx.signature_map[body_bytes].sigPair[0]
     assert sig_pair.pubKeyPrefix == b'public_key'
     assert sig_pair.ed25519 == b'signature'
 
@@ -189,8 +192,11 @@ def test_sign_transaction_nft(mock_account_ids, metadata, mock_client):
     supply_key.public_key().to_bytes_raw.return_value = b'public_key'
     mint_tx.sign(supply_key)
 
-    assert len(mint_tx.signature_map.sigPair) == 1
-    sig_pair = mint_tx.signature_map.sigPair[0]
+    node_id = mock_client.network.current_node._account_id
+    body_bytes = mint_tx.transaction_body_bytes[node_id]
+
+    assert len(mint_tx.signature_map[body_bytes].sigPair) == 1
+    sig_pair = mint_tx.signature_map[body_bytes].sigPair[0]
     assert sig_pair.pubKeyPrefix == b'public_key'
     assert sig_pair.ed25519 == b'signature'
 

--- a/tests/unit/test_token_mint_transaction.py
+++ b/tests/unit/test_token_mint_transaction.py
@@ -167,10 +167,10 @@ def test_sign_transaction_fungible(mock_account_ids, amount, mock_client):
     mint_tx.sign(supply_key)
 
     node_id = mock_client.network.current_node._account_id
-    body_bytes = mint_tx.transaction_body_bytes[node_id]
+    body_bytes = mint_tx._transaction_body_bytes[node_id]
 
-    assert len(mint_tx.signature_map[body_bytes].sigPair) == 1
-    sig_pair = mint_tx.signature_map[body_bytes].sigPair[0]
+    assert len(mint_tx._signature_map[body_bytes].sigPair) == 1
+    sig_pair = mint_tx._signature_map[body_bytes].sigPair[0]
     assert sig_pair.pubKeyPrefix == b'public_key'
     assert sig_pair.ed25519 == b'signature'
 
@@ -193,10 +193,10 @@ def test_sign_transaction_nft(mock_account_ids, metadata, mock_client):
     mint_tx.sign(supply_key)
 
     node_id = mock_client.network.current_node._account_id
-    body_bytes = mint_tx.transaction_body_bytes[node_id]
+    body_bytes = mint_tx._transaction_body_bytes[node_id]
 
-    assert len(mint_tx.signature_map[body_bytes].sigPair) == 1
-    sig_pair = mint_tx.signature_map[body_bytes].sigPair[0]
+    assert len(mint_tx._signature_map[body_bytes].sigPair) == 1
+    sig_pair = mint_tx._signature_map[body_bytes].sigPair[0]
     assert sig_pair.pubKeyPrefix == b'public_key'
     assert sig_pair.ed25519 == b'signature'
 

--- a/tests/unit/test_token_unfreeze_transaction.py
+++ b/tests/unit/test_token_unfreeze_transaction.py
@@ -79,8 +79,11 @@ def test_sign_transaction(mock_account_ids, mock_client):
 
     unfreeze_tx.sign(freeze_key)
 
-    assert len(unfreeze_tx.signature_map.sigPair) == 1
-    sig_pair = unfreeze_tx.signature_map.sigPair[0]
+    node_id = mock_client.network.current_node._account_id
+    body_bytes = unfreeze_tx.transaction_body_bytes[node_id]
+
+    assert len(unfreeze_tx.signature_map[body_bytes].sigPair) == 1
+    sig_pair = unfreeze_tx.signature_map[body_bytes].sigPair[0]
 
     assert sig_pair.pubKeyPrefix == b'public_key'
     assert sig_pair.ed25519 == b'signature'

--- a/tests/unit/test_token_unfreeze_transaction.py
+++ b/tests/unit/test_token_unfreeze_transaction.py
@@ -80,10 +80,10 @@ def test_sign_transaction(mock_account_ids, mock_client):
     unfreeze_tx.sign(freeze_key)
 
     node_id = mock_client.network.current_node._account_id
-    body_bytes = unfreeze_tx.transaction_body_bytes[node_id]
+    body_bytes = unfreeze_tx._transaction_body_bytes[node_id]
 
-    assert len(unfreeze_tx.signature_map[body_bytes].sigPair) == 1
-    sig_pair = unfreeze_tx.signature_map[body_bytes].sigPair[0]
+    assert len(unfreeze_tx._signature_map[body_bytes].sigPair) == 1
+    sig_pair = unfreeze_tx._signature_map[body_bytes].sigPair[0]
 
     assert sig_pair.pubKeyPrefix == b'public_key'
     assert sig_pair.ed25519 == b'signature'

--- a/tests/unit/test_topic_create_transaction.py
+++ b/tests/unit/test_topic_create_transaction.py
@@ -71,10 +71,10 @@ def test_sign_topic_create_transaction(mock_account_ids, private_key):
     tx.node_account_id = node_account_id
 
     body_bytes = tx.build_transaction_body().SerializeToString()
-    tx.transaction_body_bytes.setdefault(node_account_id, body_bytes)
+    tx._transaction_body_bytes.setdefault(node_account_id, body_bytes)
 
     tx.sign(private_key)
-    assert len(tx.signature_map[body_bytes].sigPair) == 1
+    assert len(tx._signature_map[body_bytes].sigPair) == 1
 
 def test_execute_topic_create_transaction():
     """Test executing the TopicCreateTransaction successfully with mock server."""

--- a/tests/unit/test_topic_create_transaction.py
+++ b/tests/unit/test_topic_create_transaction.py
@@ -71,10 +71,10 @@ def test_sign_topic_create_transaction(mock_account_ids, private_key):
     tx.node_account_id = node_account_id
 
     body_bytes = tx.build_transaction_body().SerializeToString()
-    tx.transaction_body_bytes = body_bytes
+    tx.transaction_body_bytes.setdefault(node_account_id, body_bytes)
 
     tx.sign(private_key)
-    assert len(tx.signature_map.sigPair) == 1
+    assert len(tx.signature_map[body_bytes].sigPair) == 1
 
 def test_execute_topic_create_transaction():
     """Test executing the TopicCreateTransaction successfully with mock server."""

--- a/tests/unit/test_topic_delete_transaction.py
+++ b/tests/unit/test_topic_delete_transaction.py
@@ -49,10 +49,10 @@ def test_sign_topic_delete_transaction(mock_account_ids, topic_id, private_key):
     tx.node_account_id = node_account_id
 
     body_bytes = tx.build_transaction_body().SerializeToString()
-    tx.transaction_body_bytes.setdefault(node_account_id, body_bytes)
+    tx._transaction_body_bytes.setdefault(node_account_id, body_bytes)
 
     tx.sign(private_key)
-    assert len(tx.signature_map[body_bytes].sigPair) == 1
+    assert len(tx._signature_map[body_bytes].sigPair) == 1
 
 # This test uses fixture topic_id as parameter
 def test_execute_topic_delete_transaction(topic_id):

--- a/tests/unit/test_topic_delete_transaction.py
+++ b/tests/unit/test_topic_delete_transaction.py
@@ -49,10 +49,10 @@ def test_sign_topic_delete_transaction(mock_account_ids, topic_id, private_key):
     tx.node_account_id = node_account_id
 
     body_bytes = tx.build_transaction_body().SerializeToString()
-    tx.transaction_body_bytes = body_bytes
+    tx.transaction_body_bytes.setdefault(node_account_id, body_bytes)
 
     tx.sign(private_key)
-    assert len(tx.signature_map.sigPair) == 1
+    assert len(tx.signature_map[body_bytes].sigPair) == 1
 
 # This test uses fixture topic_id as parameter
 def test_execute_topic_delete_transaction(topic_id):

--- a/tests/unit/test_topic_update_transaction.py
+++ b/tests/unit/test_topic_update_transaction.py
@@ -55,10 +55,10 @@ def test_sign_topic_update_transaction(mock_account_ids, topic_id, private_key):
     tx.node_account_id = node_account_id
 
     body_bytes = tx.build_transaction_body().SerializeToString()
-    tx.transaction_body_bytes.setdefault(node_account_id, body_bytes)
+    tx._transaction_body_bytes.setdefault(node_account_id, body_bytes)
 
     tx.sign(private_key)
-    assert len(tx.signature_map[body_bytes].sigPair) == 1
+    assert len(tx._signature_map[body_bytes].sigPair) == 1
 
 
 # This test uses fixture topic_id as parameter

--- a/tests/unit/test_topic_update_transaction.py
+++ b/tests/unit/test_topic_update_transaction.py
@@ -55,10 +55,10 @@ def test_sign_topic_update_transaction(mock_account_ids, topic_id, private_key):
     tx.node_account_id = node_account_id
 
     body_bytes = tx.build_transaction_body().SerializeToString()
-    tx.transaction_body_bytes = body_bytes
+    tx.transaction_body_bytes.setdefault(node_account_id, body_bytes)
 
     tx.sign(private_key)
-    assert len(tx.signature_map.sigPair) == 1
+    assert len(tx.signature_map[body_bytes].sigPair) == 1
 
 
 # This test uses fixture topic_id as parameter


### PR DESCRIPTION
**Description**:
Improve `Transaction` to build transaction body bytes for all nodes to prevent invalid node account errors during node switching

* Change `transaction_body_bytes` from `bytes` to `dict[AccountId, bytes]` to store `bytes` for each node
* Change `signature_map` from `SignatureMap` to `dict[bytes, SignatureMap]` to store signatures for each transaction body
* Update `freeze_with` to build transaction body bytes for all nodes in the network
* Update `sign` function to sign all transaction body bytes and store signatures in the map

**Related issue(s)**:

Fixes #94

**Notes for reviewer**:
- Previously, transactions were built only for the current node, which could cause "Invalid Node Account" errors when the transaction was sent to a different node
- Now, transactions are built for all nodes in the network, ensuring the transaction body bytes are available for any node that might process the transaction
- Transaction body bytes are stored in a dictionary mapping AccountId to bytes for each node
- Signature maps are now stored in a dictionary mapping transaction body bytes to their corresponding signatures

**Checklist**
- [X] Documented (Code comments)
- [X] Tested (unit, integration)
