### PR TITLE
feat: add `TokenRejectTransaction`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -25,6 +25,8 @@ You can choose either syntax or even mix both styles in your projects.
   - [Deleting a Token](#deleting-a-token)
   - [Freezing a Token](#freezing-a-token)
   - [Unfreezing a Token](#unfreezing-a-token)
+  - [Rejecting a Token](#rejecting-a-token)
+  - [Rejecting a Non-Fungible Token](#rejecting-a-non-fungible-token)
   - [Querying NFT Info](#querying-nft-info)
 - [HBAR Transactions](#hbar-transactions)
   - [Transferring HBAR](#transferring-hbar)
@@ -391,6 +393,58 @@ transaction = (
         .freeze_with(client)
     )
     transaction.sign(freeze_key)
+    transaction.execute(client)
+```
+
+### Rejecting a Token
+
+#### Pythonic Syntax:
+```
+transaction = TokenRejectTransaction(
+    owner_id=owner_id,
+    token_ids=[token_id]
+).freeze_with(client)
+
+transaction.sign(owner_key)
+transaction.execute(client)
+
+```
+#### Method Chaining:
+```
+    transaction = (
+        TokenRejectTransaction()
+        .set_owner_id(owner_id)
+        .set_token_ids([token_id])
+        .freeze_with(client)
+        .sign(owner_key)
+    )
+
+    transaction.execute(client)
+```
+
+### Rejecting a Non-Fungible Token
+
+#### Pythonic Syntax:
+```
+transaction = TokenRejectTransaction(
+    owner_id=owner_id,
+    nft_ids=[nft_id1]
+).freeze_with(client)
+
+transaction.sign(owner_key)
+transaction.execute(client)
+
+```
+#### Method Chaining:
+```
+    transaction = (
+        TokenRejectTransaction()
+        .set_owner_id(owner_id)
+        .set_nft_ids([nft_id1])
+        .freeze_with(client)
+        .sign(owner_key)
+    )
+
     transaction.execute(client)
 ```
 

--- a/examples/token_reject.py
+++ b/examples/token_reject.py
@@ -1,0 +1,268 @@
+import os
+import sys
+from dotenv import load_dotenv
+
+from hiero_sdk_python import (
+    Client,
+    AccountId,
+    PrivateKey,
+    Network,
+    TransferTransaction,
+)
+from hiero_sdk_python.account.account_balance import AccountBalance
+from hiero_sdk_python.account.account_create_transaction import AccountCreateTransaction
+from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenType
+from hiero_sdk_python.hbar import Hbar
+from hiero_sdk_python.query.account_balance_query import CryptoGetAccountBalanceQuery
+from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.tokens.nft_id import NftId
+from hiero_sdk_python.tokens.supply_type import SupplyType
+from hiero_sdk_python.tokens.token_associate_transaction import TokenAssociateTransaction
+from hiero_sdk_python.tokens.token_create_transaction import TokenCreateTransaction
+from hiero_sdk_python.tokens.token_mint_transaction import TokenMintTransaction
+from hiero_sdk_python.tokens.token_reject_transaction import TokenRejectTransaction
+
+load_dotenv()
+
+def setup_client():
+    """Initialize and set up the client with operator account"""
+    # Initialize network and client
+    network = Network(network='testnet')
+    client = Client(network)
+
+    # Set up operator account
+    operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
+    operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+    client.set_operator(operator_id, operator_key)
+    
+    return client
+
+def create_test_account(client):
+    """Create a new account for testing"""
+    # Generate private key for new account
+    new_account_private_key = PrivateKey.generate_ed25519()
+    new_account_public_key = new_account_private_key.public_key()
+    
+    # Create new account with initial balance of 1 HBAR
+    receipt = (
+        AccountCreateTransaction()
+        .set_key(new_account_public_key)
+        .set_initial_balance(Hbar(2))
+        .execute(client)
+    )
+    
+    # Check if account creation was successful
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}")
+        sys.exit(1)
+    
+    # Get account ID from receipt
+    account_id = receipt.accountId
+    print(f"New account created with ID: {account_id}")
+    
+    return account_id, new_account_private_key
+
+def create_nft(client, account_id, new_account_private_key):
+    """Create a non-fungible token"""
+    receipt = (
+        TokenCreateTransaction()
+        .set_token_name("MyExampleNFT")
+        .set_token_symbol("EXNFT")
+        .set_decimals(0)
+        .set_initial_supply(0)
+        .set_treasury_account_id(account_id)
+        .set_token_type(TokenType.NON_FUNGIBLE_UNIQUE)
+        .set_supply_type(SupplyType.FINITE)
+        .set_max_supply(100)
+        .set_admin_key(client.operator_private_key)
+        .set_supply_key(client.operator_private_key)
+        .set_freeze_key(client.operator_private_key)
+        .freeze_with(client)
+        .sign(new_account_private_key)
+        .execute(client)
+    )
+    
+    # Check if nft creation was successful
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"NFT creation failed with status: {ResponseCode.get_name(receipt.status)}")
+        sys.exit(1)
+    
+    # Get token ID from receipt
+    nft_token_id = receipt.tokenId
+    print(f"NFT created with ID: {nft_token_id}")
+    
+    return nft_token_id
+
+def mint_nfts(client, nft_token_id, metadata_list):
+    """Mint a non-fungible token"""
+    receipt = (
+        TokenMintTransaction()
+        .set_token_id(nft_token_id)
+        .set_metadata(metadata_list)
+        .execute(client)
+    )
+    
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"NFT minting failed with status: {ResponseCode.get_name(receipt.status)}")
+        sys.exit(1)
+    
+    print(f"NFT minted with serial numbers: {receipt.serial_numbers}")
+    
+    return [NftId(nft_token_id, serial_number) for serial_number in receipt.serial_numbers]
+
+def associate_tokens(client, account_id, nft_token_id, token_id, account_private_key):
+    """Associate tokens with an account"""
+    # Associate the token_ids with the new account
+    receipt = (
+        TokenAssociateTransaction()
+        .set_account_id(account_id)
+        .add_token_id(nft_token_id)
+        .add_token_id(token_id)
+        .freeze_with(client)
+        .sign(account_private_key) # Has to be signed by new account's key
+        .execute(client)
+    )
+    
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Token association failed with status: {ResponseCode.get_name(receipt.status)}")
+        sys.exit(1)
+    
+    print(f"Tokens successfully associated with account: {account_id}")
+
+def create_fungible_token(client, account_id, new_account_private_key):
+    """Create a fungible token"""
+    receipt = (
+        TokenCreateTransaction()
+        .set_token_name("MyExampleFT")
+        .set_token_symbol("EXFT")
+        .set_decimals(2)
+        .set_initial_supply(100)
+        .set_treasury_account_id(account_id)
+        .set_token_type(TokenType.FUNGIBLE_COMMON)
+        .set_supply_type(SupplyType.FINITE)
+        .set_max_supply(1000)
+        .set_admin_key(client.operator_private_key)
+        .set_supply_key(client.operator_private_key)
+        .freeze_with(client)
+        .sign(new_account_private_key)
+        .execute(client)
+    )
+    
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Fungible token creation failed with status: {ResponseCode.get_name(receipt.status)}")
+        sys.exit(1)
+    
+    token_id = receipt.tokenId
+    print(f"Fungible token created with ID: {token_id}")
+    
+    return token_id
+
+def transfer_tokens(client, account_id, new_account_private_key, receiver_id, token_id, nft_ids):
+    """Transfer tokens to the new account"""
+    # Transfer tokens to the new account
+    receipt = (
+        TransferTransaction()
+        .add_nft_transfer(nft_ids[0], account_id, receiver_id)
+        .add_nft_transfer(nft_ids[1], account_id, receiver_id)
+        .add_token_transfer(token_id, account_id, -10)
+        .add_token_transfer(token_id, receiver_id, 10)
+        .freeze_with(client)
+        .sign(new_account_private_key)
+        .execute(client)
+    )
+    
+    # Check if transfer was successful
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Transfer failed with status: {ResponseCode.get_name(receipt.status)}")
+        sys.exit(1)
+    
+    print(f"Successfully transferred tokens to account {account_id}")
+    
+def get_token_balances(client, account_id, receiver_id, token_id, nft_token_id):
+    """Get token balances for both accounts"""
+    token_balance = (
+        CryptoGetAccountBalanceQuery()
+        .set_account_id(account_id)
+        .execute(client)
+    )
+    print(f"Token balance of account {account_id}: {token_balance.token_balances[token_id]}")
+    print(f"NFT balance of account {account_id}: {token_balance.token_balances[nft_token_id]}")
+    
+    receiver_token_balance = (
+        CryptoGetAccountBalanceQuery()
+        .set_account_id(receiver_id)
+        .execute(client)
+    )
+    print(f"Token balance of receiver {receiver_id}: {receiver_token_balance.token_balances[token_id]}")
+    print(f"NFT balance of receiver {receiver_id}: {receiver_token_balance.token_balances[nft_token_id]}")
+
+def token_reject():
+    """
+    Demonstrates the token reject functionality by:
+    1. Creating a new account
+    2. Creating a non-fungible token
+    3. Minting two NFTs
+    4. Creating a fungible token
+    5. Associating the NFTs and fungible token with the new account
+    6. Transferring the tokens to the new account
+    7. Rejecting the fungible token
+    8. Rejecting the NFTs
+    """
+    client = setup_client()
+    # Create test accounts
+    account_id, new_account_private_key = create_test_account(client)
+    receiver_id, receiver_private_key = create_test_account(client)
+    
+    # Create NFTs
+    nft_token_id = create_nft(client, account_id, new_account_private_key)
+    nft_ids = mint_nfts(client, nft_token_id, [b"ExampleMetadata 1", b"ExampleMetadata 2"])
+    
+    # Create fungible token
+    token_id = create_fungible_token(client, account_id, new_account_private_key)
+    
+    # Associate tokens with the receiver account
+    associate_tokens(client, receiver_id, nft_token_id, token_id, receiver_private_key)
+    
+    # Transfer tokens to the receiver account
+    transfer_tokens(client, account_id, new_account_private_key, receiver_id, token_id, nft_ids)
+
+    # Get token balances
+    get_token_balances(client, account_id, receiver_id, token_id, nft_token_id)
+    
+    # Reject the fungible tokens
+    receipt = (
+        TokenRejectTransaction()
+        .set_owner_id(receiver_id)
+        .set_token_ids([token_id])
+        .freeze_with(client)
+        .sign(receiver_private_key)
+        .execute(client)
+    )
+    
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Token rejection failed with status: {ResponseCode.get_name(receipt.status)}")
+        sys.exit(1)
+        
+    print(f"Successfully rejected token {token_id} from account {receiver_id}")
+    
+    # Reject the NFTs
+    receipt = (
+        TokenRejectTransaction()
+        .set_owner_id(receiver_id)
+        .set_nft_ids([nft_ids[0], nft_ids[1]])
+        .freeze_with(client)
+        .sign(receiver_private_key)
+        .execute(client)
+    )
+    
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"NFT rejection failed with status: {ResponseCode.get_name(receipt.status)}")
+        sys.exit(1)
+    
+    print(f"Successfully rejected NFTs {nft_ids[0]} and {nft_ids[1]} from account {receiver_id}")
+    
+    # Get token balances
+    get_token_balances(client, account_id, receiver_id, token_id, nft_token_id)
+    
+if __name__ == "__main__":
+    token_reject()

--- a/examples/token_reject_fungible_token.py
+++ b/examples/token_reject_fungible_token.py
@@ -1,0 +1,192 @@
+import os
+import sys
+from dotenv import load_dotenv
+
+from hiero_sdk_python import (
+    Client,
+    AccountId,
+    PrivateKey,
+    Network,
+    TransferTransaction,
+)
+from hiero_sdk_python.account.account_create_transaction import AccountCreateTransaction
+from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenType
+from hiero_sdk_python.hbar import Hbar
+from hiero_sdk_python.query.account_balance_query import CryptoGetAccountBalanceQuery
+from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.tokens.supply_type import SupplyType
+from hiero_sdk_python.tokens.token_associate_transaction import TokenAssociateTransaction
+from hiero_sdk_python.tokens.token_create_transaction import TokenCreateTransaction
+from hiero_sdk_python.tokens.token_reject_transaction import TokenRejectTransaction
+
+load_dotenv()
+
+def setup_client():
+    """Initialize and set up the client with operator account"""
+    network = Network(network='testnet')
+    client = Client(network)
+
+    operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
+    operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+    client.set_operator(operator_id, operator_key)
+    
+    return client
+
+def create_test_account(client):
+    """Create a new account for testing"""
+    # Generate private key for new account
+    new_account_private_key = PrivateKey.generate_ed25519()
+    new_account_public_key = new_account_private_key.public_key()
+    
+    # Create new account with initial balance of 1 HBAR
+    receipt = (
+        AccountCreateTransaction()
+        .set_key(new_account_public_key)
+        .set_initial_balance(Hbar(1))
+        .execute(client)
+    )
+    
+    # Check if account creation was successful
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}")
+        sys.exit(1)
+    
+    # Get account ID from receipt
+    account_id = receipt.accountId
+    print(f"New account created with ID: {account_id}")
+    
+    return account_id, new_account_private_key
+
+def create_fungible_token(client: 'Client', treasury_id, treasury_private_key):
+    """Create a fungible token"""
+    receipt = (
+        TokenCreateTransaction()
+        .set_token_name("MyExampleFT")
+        .set_token_symbol("EXFT")
+        .set_decimals(2)
+        .set_initial_supply(100)
+        .set_treasury_account_id(treasury_id)
+        .set_token_type(TokenType.FUNGIBLE_COMMON)
+        .set_supply_type(SupplyType.FINITE)
+        .set_max_supply(1000)
+        .set_admin_key(treasury_private_key)
+        .set_supply_key(treasury_private_key)
+        .set_freeze_key(treasury_private_key)
+        .freeze_with(client)
+        .sign(treasury_private_key) # Has to be signed by treasury account's key as we set the treasury_account_id to be the treasury_id
+        .execute(client)
+    )
+    
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Fungible token creation failed with status: {ResponseCode.get_name(receipt.status)}")
+        sys.exit(1)
+    
+    token_id = receipt.tokenId
+    print(f"Fungible token created with ID: {token_id}")
+    
+    return token_id
+
+def associate_token(client, receiver_id, token_id, receiver_private_key):
+    """Associate token with an account"""
+    # Associate the token_id with the new account
+    receipt = (
+        TokenAssociateTransaction()
+        .set_account_id(receiver_id)
+        .add_token_id(token_id)
+        .freeze_with(client)
+        .sign(receiver_private_key) # Has to be signed here by receiver's key
+        .execute(client)
+    )
+    
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Token association failed with status: {ResponseCode.get_name(receipt.status)}")
+        sys.exit(1)
+    
+    print(f"Token successfully associated with account: {receiver_id}")
+
+def transfer_tokens(client, treasury_id, treasury_private_key, receiver_id, token_id, amount=10):
+    """Transfer tokens to the receiver account so we can later reject them"""
+    # Transfer tokens to the receiver account
+    receipt = (
+        TransferTransaction()
+        .add_token_transfer(token_id, treasury_id, -amount)
+        .add_token_transfer(token_id, receiver_id, amount)
+        .freeze_with(client)
+        .sign(treasury_private_key)
+        .execute(client)
+    )
+    
+    # Check if transfer was successful
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Transfer failed with status: {ResponseCode.get_name(receipt.status)}")
+        sys.exit(1)
+    
+    print(f"Successfully transferred {amount} tokens to receiver account {receiver_id}")
+    
+def get_token_balances(client, treasury_id, receiver_id, token_id):
+    """Get token balances for both accounts"""
+    token_balance = (
+        CryptoGetAccountBalanceQuery()
+        .set_account_id(treasury_id)
+        .execute(client)
+    )
+    print(f"Token balance of treasury {treasury_id}: {token_balance.token_balances[token_id]}")
+    
+    receiver_token_balance = (
+        CryptoGetAccountBalanceQuery()
+        .set_account_id(receiver_id)
+        .execute(client)
+    )
+    print(f"Token balance of receiver {receiver_id}: {receiver_token_balance.token_balances[token_id]}")
+
+def token_reject_fungible():
+    """
+    Demonstrates the fungible token reject functionality by:
+    1. Creating a new treasury account
+    2. Creating a new receiver account
+    3. Creating a fungible token with the treasury account as owner
+    4. Associating the token with the receiver account
+    5. Transferring tokens to the receiver account
+    6. Rejecting the tokens from the receiver account
+    """
+    client = setup_client()
+    # Create treasury/sender account that will create and send tokens
+    treasury_id, treasury_private_key = create_test_account(client)
+    # Create receiver account that will receive and later reject tokens
+    receiver_id, receiver_private_key = create_test_account(client)
+    
+    # Create a fungible token with the treasury account as owner and signer
+    token_id = create_fungible_token(client, treasury_id, treasury_private_key)
+    
+    # Associate token with the receiver account so they can receive the tokens from the treasury
+    associate_token(client, receiver_id, token_id, receiver_private_key)
+    
+    # Transfer tokens to the receiver account
+    transfer_tokens(client, treasury_id, treasury_private_key, receiver_id, token_id)
+
+    # Get and print token balances before rejection to show the initial state
+    print("\nToken balances before rejection:")
+    get_token_balances(client, treasury_id, receiver_id, token_id)
+    
+    # Receiver rejects the fungible tokens that were previously transferred to them
+    receipt = (
+        TokenRejectTransaction()
+        .set_owner_id(receiver_id)
+        .set_token_ids([token_id])
+        .freeze_with(client)
+        .sign(receiver_private_key)
+        .execute(client)
+    )
+    
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Token rejection failed with status: {ResponseCode.get_name(receipt.status)}")
+        sys.exit(1)
+        
+    print(f"Successfully rejected token {token_id} from account {receiver_id}")
+    
+    # Get and print token balances after rejection to show the final state
+    print("\nToken balances after rejection:")
+    get_token_balances(client, treasury_id, receiver_id, token_id)
+    
+if __name__ == "__main__":
+    token_reject_fungible()

--- a/src/hiero_sdk_python/__init__.py
+++ b/src/hiero_sdk_python/__init__.py
@@ -19,6 +19,7 @@ from .tokens.token_mint_transaction import TokenMintTransaction
 from .tokens.token_freeze_transaction import TokenFreezeTransaction
 from .tokens.token_unfreeze_transaction import TokenUnfreezeTransaction
 from .tokens.token_wipe_transaction import TokenWipeTransaction
+from .tokens.token_reject_transaction import TokenRejectTransaction
 from .tokens.token_id import TokenId
 from .tokens.nft_id import NftId
 from .tokens.token_nft_transfer import TokenNftTransfer
@@ -91,6 +92,7 @@ __all__ = [
     "NftId",
     "TokenNftTransfer",
     "TokenNftInfo",
+    "TokenRejectTransaction",
 
     # Transaction
     "TransferTransaction",

--- a/src/hiero_sdk_python/tokens/token_reject_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_reject_transaction.py
@@ -84,6 +84,11 @@ class TokenRejectTransaction(Transaction):
             TokenRejectTransaction: Returns self for method chaining.
         """
         self.owner_id = AccountId.from_proto(proto.owner)
-        self.token_ids = [TokenId.from_proto(token_id) for token_id in proto.tokenIds]
-        self.nft_ids = [NftId.from_proto(nft_id) for nft_id in proto.nftIds]
+        
+        # Extract fungible token IDs from rejections with fungible_token field set (using HasField to filter out default/empty values)
+        self.token_ids = [TokenId.from_proto(token_id.fungible_token) for token_id in proto.rejections if token_id.HasField('fungible_token')]
+        
+        # Extract NFT IDs from rejections with nft field set (using HasField to filter out default/empty values)
+        self.nft_ids = [NftId.from_proto(nft_id.nft) for nft_id in proto.rejections if nft_id.HasField('nft')]
+        
         return self

--- a/src/hiero_sdk_python/tokens/token_reject_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_reject_transaction.py
@@ -17,19 +17,19 @@ class TokenRejectTransaction(Transaction):
     Inherits from the base Transaction class and implements the required methods
     to build and execute a token reject transaction.
     """
-    def __init__(self, owner_id=None, token_ids=[], nft_ids=[]):
+    def __init__(self, owner_id=None, token_ids=None, nft_ids=None):
         """
         Initializes a new TokenRejectTransaction instance with optional owner_id, token_ids, and nft_ids.
 
         Args:
             owner_id (AccountId, optional): The ID of the account to reject the token transfer.
-            token_ids (list[TokenId], optional): The IDs of the tokens to reject.
-            nft_ids (list[int], optional): The serial numbers of NFTs to reject.
+            token_ids (list[TokenId], optional): The IDs of the fungible tokens to reject.
+            nft_ids (list[NftId], optional): The IDs of the non-fungible tokens (NFTs) to reject.
         """
         super().__init__()
         self.owner_id : AccountId = owner_id
-        self.token_ids : list[TokenId] = token_ids
-        self.nft_ids : list[NftId] = nft_ids
+        self.token_ids : list[TokenId] = token_ids if token_ids else []
+        self.nft_ids : list[NftId] = nft_ids if nft_ids else []
         
     def set_owner_id(self, owner_id):
         self._require_not_frozen()
@@ -68,6 +68,18 @@ class TokenRejectTransaction(Transaction):
         return transaction_body
     
     def _get_method(self, channel: _Channel) -> _Method:
+        """
+        Gets the method to execute the token reject transaction.
+
+        This internal method returns a _Method object containing the appropriate gRPC
+        function to call when executing this transaction on the Hedera network.
+
+        Args:
+            channel (_Channel): The channel containing service stubs
+        
+        Returns:
+            _Method: An object containing the transaction function to reject tokens.
+        """
         return _Method(
             transaction_func=channel.token.rejectToken,
             query_func=None

--- a/src/hiero_sdk_python/tokens/token_reject_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_reject_transaction.py
@@ -11,6 +11,8 @@ class TokenRejectTransaction(Transaction):
     Represents a token reject transaction on the Hedera network.
     
     This transaction rejects a token transfer.
+    Allows users to reject and return unwanted airdrops
+    to the treasury account without incurring custom fees.
     
     Inherits from the base Transaction class and implements the required methods
     to build and execute a token reject transaction.

--- a/src/hiero_sdk_python/tokens/token_reject_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_reject_transaction.py
@@ -1,0 +1,87 @@
+from hiero_sdk_python.hapi.services.token_reject_pb2 import TokenReference, TokenRejectTransactionBody
+from hiero_sdk_python.tokens.nft_id import NftId
+from hiero_sdk_python.tokens.token_id import TokenId
+from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.channels import _Channel
+from hiero_sdk_python.executable import _Method
+
+class TokenRejectTransaction(Transaction):
+    """
+    Represents a token reject transaction on the Hedera network.
+    
+    This transaction rejects a token transfer.
+    
+    Inherits from the base Transaction class and implements the required methods
+    to build and execute a token reject transaction.
+    """
+    def __init__(self, owner_id=None, token_ids=[], nft_ids=[]):
+        """
+        Initializes a new TokenRejectTransaction instance with optional owner_id, token_ids, and nft_ids.
+
+        Args:
+            owner_id (AccountId, optional): The ID of the account to reject the token transfer.
+            token_ids (list[TokenId], optional): The IDs of the tokens to reject.
+            nft_ids (list[int], optional): The serial numbers of NFTs to reject.
+        """
+        super().__init__()
+        self.owner_id : AccountId = owner_id
+        self.token_ids : list[TokenId] = token_ids
+        self.nft_ids : list[NftId] = nft_ids
+        
+    def set_owner_id(self, owner_id):
+        self._require_not_frozen()
+        self.owner_id = owner_id
+        return self
+
+    def set_token_ids(self, token_ids):
+        self._require_not_frozen()
+        self.token_ids = token_ids
+        return self
+    
+    def set_nft_ids(self, nft_ids):
+        self._require_not_frozen()
+        self.nft_ids = nft_ids
+        return self
+    
+    def build_transaction_body(self):
+        """
+        Builds and returns the protobuf transaction body for token reject.
+
+        Returns:
+            TransactionBody: The protobuf transaction body containing the token reject details.
+        """
+        token_references = []
+        for token_id in self.token_ids:
+            token_references.append(TokenReference(fungible_token=token_id.to_proto()))
+        for nft_id in self.nft_ids:
+            token_references.append(TokenReference(nft=nft_id.to_proto()))
+        
+        token_reject_body = TokenRejectTransactionBody(
+            owner=self.owner_id and self.owner_id.to_proto(),
+            rejections=token_references
+        )
+        transaction_body = self.build_base_transaction_body()
+        transaction_body.tokenReject.CopyFrom(token_reject_body)
+        return transaction_body
+    
+    def _get_method(self, channel: _Channel) -> _Method:
+        return _Method(
+            transaction_func=channel.token.rejectToken,
+            query_func=None
+        )
+    
+    def _from_proto(self, proto: TokenRejectTransactionBody):
+        """
+        Deserializes a TokenRejectTransactionBody from a protobuf object.
+
+        Args:
+            proto (TokenRejectTransactionBody): The protobuf object to deserialize.
+
+        Returns:
+            TokenRejectTransaction: Returns self for method chaining.
+        """
+        self.owner_id = AccountId.from_proto(proto.owner)
+        self.token_ids = [TokenId.from_proto(token_id) for token_id in proto.tokenIds]
+        self.nft_ids = [NftId.from_proto(nft_id) for nft_id in proto.nftIds]
+        return self

--- a/tests/integration/token_reject_transaction_e2e_test.py
+++ b/tests/integration/token_reject_transaction_e2e_test.py
@@ -940,7 +940,6 @@ def test_token_reject_transaction_receiver_sig_required_fungible():
     env = IntegrationTestEnv()
     
     try:
-        # Create treasury account with receiver signature required
         treasury_private_key = PrivateKey.generate()
         treasury_public_key = treasury_private_key.public_key()
         
@@ -991,11 +990,8 @@ def test_token_reject_transaction_receiver_sig_required_fungible():
         assert receipt.status == ResponseCode.SUCCESS, f"Token transfer failed with status: {ResponseCode.get_name(receipt.status)}"
         
         # Reject the token
-        ft_reject_transaction = TokenRejectTransaction(
-            owner_id=receiver_id,
-            token_ids=[fungible_token_id]
-        )
-        receipt = ft_reject_transaction.freeze_with(env.client).sign(receiver_private_key).execute(env.client)
+        receipt = (TokenRejectTransaction().set_owner_id(receiver_id).set_token_ids([fungible_token_id])
+            .freeze_with(env.client).sign(receiver_private_key).execute(env.client))
         assert receipt.status == ResponseCode.SUCCESS, f"Token rejection failed with status: {ResponseCode.get_name(receipt.status)}"
         
         # Verify the balance of the receiver is 0

--- a/tests/integration/token_reject_transaction_e2e_test.py
+++ b/tests/integration/token_reject_transaction_e2e_test.py
@@ -186,12 +186,11 @@ def test_integration_token_reject_transaction_can_execute_for_ft_and_nft_paralle
         receipt = (TransferTransaction()
             .add_token_transfer(token_id_1, account_id, 10).add_token_transfer(token_id_1, env.client.operator_account_id, -10)
             .add_token_transfer(token_id_2, account_id, 10).add_token_transfer(token_id_2, env.client.operator_account_id, -10)
+            .add_nft_transfer(NftId(nft_id_1, serials_1[0]), env.client.operator_account_id, account_id)
+            .add_nft_transfer(NftId(nft_id_1, serials_1[1]), env.client.operator_account_id, account_id)
+            .add_nft_transfer(NftId(nft_id_2, serials_2[0]), env.client.operator_account_id, account_id)
+            .add_nft_transfer(NftId(nft_id_2, serials_2[1]), env.client.operator_account_id, account_id)
             .execute(env.client))
-        assert receipt.status == ResponseCode.SUCCESS, f"Token transfer failed with status: {ResponseCode.get_name(receipt.status)}"
-        
-        receipt = (TransferTransaction().add_nft_transfer(NftId(nft_id_1, serials_1[0]), env.client.operator_account_id, account_id)
-            .add_nft_transfer(NftId(nft_id_1, serials_1[1]), env.client.operator_account_id, account_id).add_nft_transfer(NftId(nft_id_2, serials_2[0]), env.client.operator_account_id, account_id)
-            .add_nft_transfer(NftId(nft_id_2, serials_2[1]), env.client.operator_account_id, account_id).execute(env.client))
         assert receipt.status == ResponseCode.SUCCESS, f"Token transfer failed with status: {ResponseCode.get_name(receipt.status)}"
         
         reject_transaction = (TokenRejectTransaction().set_owner_id(account_id)

--- a/tests/integration/token_reject_transaction_e2e_test.py
+++ b/tests/integration/token_reject_transaction_e2e_test.py
@@ -1,0 +1,1081 @@
+import pytest
+
+from hiero_sdk_python.crypto.private_key import PrivateKey
+from hiero_sdk_python.exceptions import PrecheckError
+from hiero_sdk_python.hbar import Hbar
+from hiero_sdk_python.query.account_balance_query import CryptoGetAccountBalanceQuery
+from hiero_sdk_python.tokens.token_associate_transaction import TokenAssociateTransaction
+from hiero_sdk_python.account.account_create_transaction import AccountCreateTransaction
+from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.tokens.token_freeze_transaction import TokenFreezeTransaction
+from hiero_sdk_python.tokens.token_mint_transaction import TokenMintTransaction
+from hiero_sdk_python.tokens.token_reject_transaction import TokenRejectTransaction
+from hiero_sdk_python.transaction.transfer_transaction import TransferTransaction
+from tests.integration.utils_for_test import IntegrationTestEnv, create_fungible_token, create_nft_token
+from hiero_sdk_python.tokens.nft_id import NftId
+from hiero_sdk_python.query.token_nft_info_query import TokenNftInfoQuery
+
+
+@pytest.mark.integration
+def test_integration_token_reject_transaction_can_execute():
+    env = IntegrationTestEnv()
+    
+    try:
+        new_account_private_key = PrivateKey.generate()
+        new_account_public_key = new_account_private_key.public_key()
+        
+        # Create the new account
+        transaction = AccountCreateTransaction(
+            key=new_account_public_key,
+            initial_balance=Hbar(1),
+            memo="Recipient Account"
+        )
+        
+        transaction.freeze_with(env.client)
+        receipt = transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        account_id = receipt.accountId
+        
+        token1 = create_fungible_token(env)
+        token2 = create_fungible_token(env)
+        
+        # Associate the tokens to the new account
+        token_associate_transaction = TokenAssociateTransaction(
+            account_id=account_id,
+            token_ids=[token1, token2]
+        )
+        
+        token_associate_transaction.freeze_with(env.client)
+        token_associate_transaction.sign(new_account_private_key)
+        receipt = token_associate_transaction.execute(env.client)
+
+        assert receipt.status == ResponseCode.SUCCESS, f"Token association failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Transfer the tokens to the new account
+        token_transfer_transaction = TransferTransaction()
+        token_transfer_transaction.add_token_transfer(token1, account_id, 10)
+        token_transfer_transaction.add_token_transfer(token1, env.client.operator_account_id, -10)
+        token_transfer_transaction.add_token_transfer(token2, account_id, 10)
+        token_transfer_transaction.add_token_transfer(token2, env.client.operator_account_id, -10)
+        
+        receipt = token_transfer_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"Token transfer failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Reject the tokens
+        token_reject_transaction = TokenRejectTransaction(
+            owner_id=account_id,
+            token_ids=[token1, token2]
+        )
+        
+        token_reject_transaction.freeze_with(env.client)
+        token_reject_transaction.sign(new_account_private_key)
+        receipt = token_reject_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"Token rejection failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Verify the balance of the new account is 0
+        balance = CryptoGetAccountBalanceQuery(account_id).execute(env.client)
+        assert balance.token_balances is not None and balance.token_balances.get(token1) == 0 and balance.token_balances.get(token2) == 0
+        
+        # Verify the balance of the operator account is the same as the initial balance
+        balance = CryptoGetAccountBalanceQuery(env.client.operator_account_id).execute(env.client)
+        assert balance.token_balances is not None and balance.token_balances.get(token1) == 1000 and balance.token_balances.get(token2) == 1000
+    finally:
+        env.close()
+        
+
+@pytest.mark.integration
+def test_integration_token_reject_transaction_can_execute_for_nft():
+    env = IntegrationTestEnv()
+    
+    try:
+        # Create NFT collections with treasury
+        nft_id_1 = create_nft_token(env)
+        nft_id_2 = create_nft_token(env)
+        
+        # Mint NFTs for the first token
+        mint_transaction_1 = TokenMintTransaction(
+            token_id=nft_id_1,
+            metadata=[b"metadata1", b"metadata2"]
+        )
+        receipt = mint_transaction_1.execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"NFT minting failed with status: {ResponseCode.get_name(receipt.status)}"
+        serials_1 = receipt.serial_numbers
+        
+        # Mint NFTs for the second token
+        mint_transaction_2 = TokenMintTransaction(
+            token_id=nft_id_2,
+            metadata=[b"metadata1", b"metadata2"]
+        )
+        receipt = mint_transaction_2.execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"NFT minting failed with status: {ResponseCode.get_name(receipt.status)}"
+        serials_2 = receipt.serial_numbers
+
+        new_account_private_key = PrivateKey.generate()
+        new_account_public_key = new_account_private_key.public_key()
+        
+        account_transaction = AccountCreateTransaction(
+            key=new_account_public_key,
+            initial_balance=Hbar(1),
+            memo="Receiver Account"
+        )
+        receipt = account_transaction.execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        account_id = receipt.accountId
+        assert account_id is not None
+        
+        # Associate the tokens to the new account
+        token_associate_transaction = TokenAssociateTransaction(
+            account_id=account_id,
+            token_ids=[nft_id_1, nft_id_2]
+        )
+        receipt = token_associate_transaction.freeze_with(env.client).sign(new_account_private_key).execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"Token association failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        transfer_transaction = TransferTransaction()
+        transfer_transaction.add_nft_transfer(NftId(nft_id_1, serials_1[0]), env.client.operator_account_id, account_id)
+        transfer_transaction.add_nft_transfer(NftId(nft_id_1, serials_1[1]), env.client.operator_account_id, account_id)
+        transfer_transaction.add_nft_transfer(NftId(nft_id_2, serials_2[0]), env.client.operator_account_id, account_id)
+        transfer_transaction.add_nft_transfer(NftId(nft_id_2, serials_2[1]), env.client.operator_account_id, account_id)
+        
+        receipt = transfer_transaction.execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"NFT transfer failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Reject the tokens
+        token_reject_transaction = TokenRejectTransaction(
+            owner_id=account_id,
+            nft_ids=[NftId(nft_id_1, serials_1[1]), NftId(nft_id_2, serials_2[1])]
+        )
+        receipt = token_reject_transaction.freeze_with(env.client).sign(new_account_private_key).execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"Token rejection failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Verify the balance is decremented by 1 for each token
+        balance = CryptoGetAccountBalanceQuery(account_id).execute(env.client)
+        assert balance.token_balances is not None
+        assert balance.token_balances.get(nft_id_1) == 1, f"Expected 1 NFT for token {nft_id_1}, got {balance.token_balances.get(nft_id_1)}"
+        assert balance.token_balances.get(nft_id_2) == 1, f"Expected 1 NFT for token {nft_id_2}, got {balance.token_balances.get(nft_id_2)}"
+        
+        # Verify the NFTs are transferred back to the treasury
+        nft_info_1 = TokenNftInfoQuery(NftId(nft_id_1, serials_1[1])).execute(env.client)
+        assert nft_info_1.account_id == env.operator_id, f"Expected NFT owner to be {env.operator_id}, got {nft_info_1.account_id}"
+        
+        nft_info_2 = TokenNftInfoQuery(NftId(nft_id_2, serials_2[1])).execute(env.client)
+        assert nft_info_2.account_id == env.operator_id, f"Expected NFT owner to be {env.operator_id}, got {nft_info_2.account_id}"
+    finally:
+        env.close()
+        
+@pytest.mark.integration
+def test_integration_token_reject_transaction_can_execute_for_ft_and_nft_parallel():
+    env = IntegrationTestEnv()
+    
+    try:
+        nft_id_1 = create_nft_token(env)
+        nft_id_2 = create_nft_token(env)
+        
+        token_id_1 = create_fungible_token(env)
+        token_id_2 = create_fungible_token(env)
+        
+        mint = TokenMintTransaction(
+            token_id=nft_id_1,
+            metadata=[b"metadata1", b"metadata2"]
+        )
+        receipt = mint.execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"Token minting failed with status: {ResponseCode.get_name(receipt.status)}"
+        serials_1 = receipt.serial_numbers
+        
+        mint = TokenMintTransaction(
+            token_id=nft_id_2,
+            metadata=[b"metadata1", b"metadata2"]
+        )
+        receipt = mint.execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"Token minting failed with status: {ResponseCode.get_name(receipt.status)}"
+        serials_2 = receipt.serial_numbers
+        
+        new_account_private_key = PrivateKey.generate()
+        new_account_public_key = new_account_private_key.public_key()
+        
+        account_transaction = AccountCreateTransaction(
+            key=new_account_public_key,
+            initial_balance=Hbar(1),
+            memo="Receiver Account"
+        )
+        receipt = account_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        account_id = receipt.accountId
+        assert account_id is not None
+        
+        token_associate_transaction = TokenAssociateTransaction(
+            account_id=account_id,
+            token_ids=[token_id_1, token_id_2, nft_id_1, nft_id_2]
+        )
+        receipt = token_associate_transaction.freeze_with(env.client).sign(new_account_private_key).execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"Token association failed with status: {ResponseCode.get_name(receipt.status)}"
+
+        token_transfer_transaction = TransferTransaction()
+        token_transfer_transaction.add_token_transfer(token_id_1, account_id, 10)
+        token_transfer_transaction.add_token_transfer(token_id_1, env.client.operator_account_id, -10)
+        token_transfer_transaction.add_token_transfer(token_id_2, account_id, 10)
+        token_transfer_transaction.add_token_transfer(token_id_2, env.client.operator_account_id, -10)
+        
+        receipt = token_transfer_transaction.execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"Token transfer failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        token_transfer_transaction = TransferTransaction()
+        token_transfer_transaction.add_nft_transfer(NftId(nft_id_1, serials_1[0]), env.client.operator_account_id, account_id)
+        token_transfer_transaction.add_nft_transfer(NftId(nft_id_1, serials_1[1]), env.client.operator_account_id, account_id)
+        token_transfer_transaction.add_nft_transfer(NftId(nft_id_2, serials_2[0]), env.client.operator_account_id, account_id)
+        token_transfer_transaction.add_nft_transfer(NftId(nft_id_2, serials_2[1]), env.client.operator_account_id, account_id)
+        
+        receipt = token_transfer_transaction.execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"Token transfer failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        reject_transaction = TokenRejectTransaction(
+            owner_id=account_id,
+            token_ids=[token_id_1, token_id_2],
+            nft_ids=[NftId(nft_id_1, serials_1[1]), NftId(nft_id_2, serials_2[1])]
+        )
+        # Set transaction fee to be higher than 2 Hbars
+        reject_transaction.transaction_fee = Hbar(3).to_tinybars()
+        receipt = reject_transaction.freeze_with(env.client).sign(new_account_private_key).execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"Token rejection failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        balance = CryptoGetAccountBalanceQuery(account_id).execute(env.client)
+        assert balance.token_balances and balance.token_balances.get(token_id_1) == 0, f"Expected token balance to be 0 for token {token_id_1}, got {balance.token_balances.get(token_id_1)}"
+        assert balance.token_balances and balance.token_balances.get(token_id_2) == 0, f"Expected token balance to be 0 for token {token_id_2}, got {balance.token_balances.get(token_id_2)}"
+        
+        balance = CryptoGetAccountBalanceQuery(env.operator_id).execute(env.client)
+        assert balance.token_balances and balance.token_balances.get(token_id_1) == 1000, f"Expected token balance to be 1000 for token {token_id_1}, got {balance.token_balances.get(token_id_1)}"
+        assert balance.token_balances and balance.token_balances.get(token_id_2) == 1000, f"Expected token balance to be 1000 for token {token_id_2}, got {balance.token_balances.get(token_id_2)}"
+        
+        nft_info_1 = TokenNftInfoQuery(NftId(nft_id_1, serials_1[1])).execute(env.client)
+        assert nft_info_1.account_id == env.operator_id, f"Expected NFT owner to be {env.operator_id}, got {nft_info_1.account_id}"
+        
+        nft_info_2 = TokenNftInfoQuery(NftId(nft_id_2, serials_2[1])).execute(env.client)
+        assert nft_info_2.account_id == env.operator_id, f"Expected NFT owner to be {env.operator_id}, got {nft_info_2.account_id}"
+    finally:
+        env.close()
+
+@pytest.mark.integration
+def test_token_reject_transaction_fails_with_invalid_signature():
+    env = IntegrationTestEnv()
+    
+    try:
+        new_account_private_key = PrivateKey.generate()
+        new_account_public_key = new_account_private_key.public_key()
+        
+        # Create the new account
+        transaction = AccountCreateTransaction(
+            key=new_account_public_key,
+            initial_balance=Hbar(1),
+            memo="Recipient Account"
+        )
+        
+        receipt = transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        account_id = receipt.accountId
+        
+        token1 = create_fungible_token(env)
+        
+        # Associate the tokens to the new account
+        token_associate_transaction = TokenAssociateTransaction(
+            account_id=account_id,
+            token_ids=[token1]  
+        )
+        
+        token_associate_transaction.freeze_with(env.client)
+        token_associate_transaction.sign(new_account_private_key)
+        receipt = token_associate_transaction.execute(env.client)
+
+        assert receipt.status == ResponseCode.SUCCESS, f"Token association failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Transfer the tokens to the new account
+        token_transfer_transaction = TransferTransaction()
+        token_transfer_transaction.add_token_transfer(token1, account_id, 10)
+        token_transfer_transaction.add_token_transfer(token1, env.client.operator_account_id, -10)
+        
+        receipt = token_transfer_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"Token transfer failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        wrong_key = PrivateKey.generate()
+        
+        # Reject the tokens
+        token_reject_transaction = TokenRejectTransaction(
+            owner_id=account_id,
+            token_ids=[token1]
+        )
+        
+        token_reject_transaction.freeze_with(env.client)
+        # Sign with wrong key
+        token_reject_transaction.sign(wrong_key)
+        receipt = token_reject_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.INVALID_SIGNATURE, f"Token rejection should have failed with INVALID_SIGNATURE status but got: {ResponseCode.get_name(receipt.status)}"
+    finally:
+        env.close()
+
+@pytest.mark.integration
+def test_integration_token_reject_transaction_fails_with_reference_size_exceeded():
+    env = IntegrationTestEnv()
+    
+    try:
+        nft_id = create_nft_token(env)
+        
+        token_id = create_fungible_token(env)
+        
+        # Mint 10 NFTs
+        mint = TokenMintTransaction(
+            token_id=nft_id,
+            metadata=[b"1", b"2", b"3", b"4", b"5", b"6", b"7", b"8", b"9", b"10"]
+        )
+        receipt = mint.execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"NFT minting failed with status: {ResponseCode.get_name(receipt.status)}"
+        serials = receipt.serial_numbers
+        
+        new_account_private_key = PrivateKey.generate()
+        new_account_public_key = new_account_private_key.public_key()
+        
+        account_transaction = AccountCreateTransaction(
+            key=new_account_public_key,
+            initial_balance=Hbar(1),
+            memo="Receiver Account"
+        )
+        receipt = account_transaction.execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        account_id = receipt.accountId
+        assert account_id is not None
+        
+        # Associate the tokens to the new account
+        token_associate_transaction = TokenAssociateTransaction(
+            account_id=account_id,
+            token_ids=[nft_id, token_id]
+        )
+        receipt = token_associate_transaction.freeze_with(env.client).sign(new_account_private_key).execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"Token association failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Transfer the tokens to the new account
+        transfer_transaction = TransferTransaction()
+        transfer_transaction.add_token_transfer(token_id, env.client.operator_account_id, -10)
+        transfer_transaction.add_token_transfer(token_id, account_id, 10)
+        transfer_transaction.add_nft_transfer(NftId(nft_id, serials[0]), env.client.operator_account_id, account_id)
+        transfer_transaction.add_nft_transfer(NftId(nft_id, serials[1]), env.client.operator_account_id, account_id)
+        transfer_transaction.add_nft_transfer(NftId(nft_id, serials[2]), env.client.operator_account_id, account_id)
+        transfer_transaction.add_nft_transfer(NftId(nft_id, serials[3]), env.client.operator_account_id, account_id)
+        transfer_transaction.add_nft_transfer(NftId(nft_id, serials[4]), env.client.operator_account_id, account_id)
+        transfer_transaction.add_nft_transfer(NftId(nft_id, serials[5]), env.client.operator_account_id, account_id)
+        transfer_transaction.add_nft_transfer(NftId(nft_id, serials[6]), env.client.operator_account_id, account_id)
+        transfer_transaction.add_nft_transfer(NftId(nft_id, serials[7]), env.client.operator_account_id, account_id)
+        transfer_transaction.add_nft_transfer(NftId(nft_id, serials[8]), env.client.operator_account_id, account_id)
+        transfer_transaction.add_nft_transfer(NftId(nft_id, serials[9]), env.client.operator_account_id, account_id)
+        
+        receipt = transfer_transaction.execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"NFT transfer failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Reject the tokens with 11 token references - should fail with TOKEN_REFERENCE_LIST_SIZE_LIMIT_EXCEEDED
+        token_reject_transaction = TokenRejectTransaction(
+            owner_id=account_id,
+            token_ids=[token_id],
+            nft_ids=[NftId(nft_id, serials[0]), NftId(nft_id, serials[1]), NftId(nft_id, serials[2]), NftId(nft_id, serials[3]), NftId(nft_id, serials[4]), 
+                     NftId(nft_id, serials[5]), NftId(nft_id, serials[6]), NftId(nft_id, serials[7]), NftId(nft_id, serials[8]), NftId(nft_id, serials[9])]
+        )
+        # Set transaction fee to be higher than 2 Hbars
+        token_reject_transaction.transaction_fee = Hbar(3).to_tinybars()
+        receipt =token_reject_transaction.freeze_with(env.client).sign(new_account_private_key).execute(env.client)
+        assert receipt.status == ResponseCode.TOKEN_REFERENCE_LIST_SIZE_LIMIT_EXCEEDED, f"Token rejection should have failed with TOKEN_REFERENCE_LIST_SIZE_LIMIT_EXCEEDED status but got: {ResponseCode.get_name(receipt.status)}"
+    finally:
+        env.close()
+
+@pytest.mark.integration
+def test_integration_token_reject_transaction_fails_with_invalid_token_id():
+    env = IntegrationTestEnv()
+    
+    try:
+        # Leave the token_ids/nft_ids empty
+        token_reject_transaction = TokenRejectTransaction(
+            owner_id=env.operator_id,
+        )
+        
+        with pytest.raises(PrecheckError, match="failed precheck with status: EMPTY_TOKEN_REFERENCE_LIST"):
+            token_reject_transaction.execute(env.client)
+    finally:
+        env.close()
+        
+@pytest.mark.integration
+def test_integration_token_reject_transaction_fails_treasury_rejects():
+    env = IntegrationTestEnv()
+    
+    try:
+        # Create fungible token with treasury
+        token_id = create_fungible_token(env)
+        
+        # Skip the transfer 
+        
+        # Reject the token with the treasury
+        token_reject_transaction = TokenRejectTransaction(
+            owner_id=env.operator_id,
+            token_ids=[token_id]
+        )
+        
+        receipt = token_reject_transaction.execute(env.client)
+
+        assert receipt.status == ResponseCode.ACCOUNT_IS_TREASURY, f"Token rejection should have failed with ACCOUNT_IS_TREASURY status but got: {ResponseCode.get_name(receipt.status)}"
+        
+        # Create NFT with treasury
+        nft_token_id = create_nft_token(env)
+        
+        # Mint NFT
+        mint = TokenMintTransaction(
+            token_id=nft_token_id,
+            metadata=[b"test metadata"]
+        )
+        
+        receipt = mint.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"NFT minting failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Attempt to reject the NFT token with the treasury
+        token_reject_transaction = TokenRejectTransaction(
+            owner_id=env.operator_id,
+            token_ids=[nft_token_id]
+        )
+        
+        receipt = token_reject_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.ACCOUNT_IS_TREASURY, f"Token rejection should have failed with ACCOUNT_IS_TREASURY status but got: {ResponseCode.get_name(receipt.status)}"
+    finally:
+        env.close()
+
+@pytest.mark.integration
+def test_integration_token_reject_transaction_fails_when_fungible_token_owner_has_no_balance():
+    env = IntegrationTestEnv()
+    
+    try:
+        # Create fungible token with treasury
+        token_id = create_fungible_token(env)
+        
+        # Create receiver account
+        new_account_private_key = PrivateKey.generate()
+        new_account_public_key = new_account_private_key.public_key()
+        
+        account_transaction = AccountCreateTransaction(
+            key=new_account_public_key,
+            initial_balance=Hbar(1),
+            memo="Receiver Account"
+        )
+        
+        receipt = account_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        account_id = receipt.accountId
+        
+        # Associate the token to the receiver account
+        token_associate_transaction = TokenAssociateTransaction(
+            account_id=account_id,
+            token_ids=[token_id]
+        )
+        
+        token_associate_transaction.freeze_with(env.client)
+        token_associate_transaction.sign(new_account_private_key)
+        receipt = token_associate_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"Token association failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Skip the transfer
+        
+        # Reject the token - should fail with INSUFFICIENT_TOKEN_BALANCE
+        token_reject_transaction = TokenRejectTransaction(
+            owner_id=account_id,
+            token_ids=[token_id]
+        )
+        
+        token_reject_transaction.freeze_with(env.client)
+        token_reject_transaction.sign(new_account_private_key)
+        receipt = token_reject_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.INSUFFICIENT_TOKEN_BALANCE, f"Token rejection should have failed with INSUFFICIENT_TOKEN_BALANCE status but got: {ResponseCode.get_name(receipt.status)}"
+    finally:
+        env.close()
+
+@pytest.mark.integration
+def test_integration_token_reject_transaction_fails_when_nft_owner_has_no_balance():
+    env = IntegrationTestEnv()
+    
+    try:
+        # Create receiver account
+        new_account_private_key = PrivateKey.generate()
+        new_account_public_key = new_account_private_key.public_key()
+        
+        account_transaction = AccountCreateTransaction(
+            key=new_account_public_key,
+            initial_balance=Hbar(1),
+            memo="Receiver Account"
+        )
+        
+        receipt = account_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        account_id = receipt.accountId
+        
+        # Create NFT with treasury
+        nft_token_id = create_nft_token(env)
+        
+        # Mint NFTs
+        mint_transaction = TokenMintTransaction(
+            token_id=nft_token_id,
+            metadata=[b"test metadata"]
+        )
+        
+        receipt = mint_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"NFT minting failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        serials = receipt.serial_numbers
+        
+        # Associate the NFT to the receiver account
+        nft_associate_transaction = TokenAssociateTransaction(
+            account_id=account_id,
+            token_ids=[nft_token_id]
+        )
+        
+        nft_associate_transaction.freeze_with(env.client)
+        nft_associate_transaction.sign(new_account_private_key)
+        receipt = nft_associate_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"NFT association failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Skip the transfer
+        
+        # Reject the NFT - should fail with INVALID_OWNER_ID
+        nft_id = NftId(nft_token_id, serials[0])
+        nft_reject_transaction = TokenRejectTransaction(
+            owner_id=account_id,
+            nft_ids=[nft_id]
+        )
+        
+        nft_reject_transaction.freeze_with(env.client)
+        nft_reject_transaction.sign(new_account_private_key)
+        receipt = nft_reject_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.INVALID_OWNER_ID, f"Token rejection should have failed with INVALID_OWNER_ID status but got: {ResponseCode.get_name(receipt.status)}"
+    finally:
+        env.close()
+
+@pytest.mark.integration
+def test_token_reject_transaction_fails_with_token_reference_repeated_fungible():
+    env = IntegrationTestEnv()
+    
+    try:
+        # Create a new account with private key
+        new_account_private_key = PrivateKey.generate()
+        new_account_public_key = new_account_private_key.public_key()
+        
+        # Create the new account
+        transaction = AccountCreateTransaction(
+            key=new_account_public_key,
+            initial_balance=Hbar(1),
+            memo="Recipient Account"
+        )
+        
+        receipt = transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        account_id = receipt.accountId
+        
+        # Create fungible token with treasury
+        token_id = create_fungible_token(env)
+        
+        # Associate the token to the new account
+        token_associate_transaction = TokenAssociateTransaction(
+            account_id=account_id,
+            token_ids=[token_id]
+        )
+        
+        token_associate_transaction.freeze_with(env.client)
+        token_associate_transaction.sign(new_account_private_key)
+        receipt = token_associate_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"Token association failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Transfer tokens to the new account
+        token_transfer_transaction = TransferTransaction()
+        token_transfer_transaction.add_token_transfer(token_id, account_id, 10)
+        token_transfer_transaction.add_token_transfer(token_id, env.client.operator_account_id, -10)
+        
+        receipt = token_transfer_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"Token transfer failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Reject the token with duplicate token id - should fail with TOKEN_REFERENCE_REPEATED
+        token_reject_transaction = TokenRejectTransaction(
+            owner_id=account_id,
+            token_ids=[token_id, token_id]  # Duplicate token ID
+        )
+        
+        token_reject_transaction.freeze_with(env.client)
+        token_reject_transaction.sign(new_account_private_key)
+        
+        with pytest.raises(PrecheckError, match="failed precheck with status: TOKEN_REFERENCE_REPEATED"):
+            token_reject_transaction.execute(env.client)
+    finally:
+        env.close()
+
+@pytest.mark.integration
+def test_token_reject_transaction_fails_with_token_reference_repeated_nft():
+    env = IntegrationTestEnv()
+    
+    try:
+        # Create a new account with private key
+        new_account_private_key = PrivateKey.generate()
+        new_account_public_key = new_account_private_key.public_key()
+        
+        # Create the new account
+        transaction = AccountCreateTransaction(
+            key=new_account_public_key,
+            initial_balance=Hbar(1),
+            memo="Recipient Account"
+        )
+        
+        receipt = transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        account_id = receipt.accountId
+        
+        # Create NFT with treasury
+        nft_token_id = create_nft_token(env)
+        
+        # Mint NFTs
+        mint_transaction = TokenMintTransaction(
+            token_id=nft_token_id,
+            metadata=[b"test metadata"]
+        )
+        
+        receipt = mint_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"NFT minting failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        serials = receipt.serial_numbers
+        
+        # Associate the NFT to the receiver account
+        nft_associate_transaction = TokenAssociateTransaction(
+            account_id=account_id,
+            token_ids=[nft_token_id]
+        )
+        
+        nft_associate_transaction.freeze_with(env.client)
+        nft_associate_transaction.sign(new_account_private_key)
+        receipt = nft_associate_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"NFT association failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Transfer NFT to the receiver
+        nft_transfer_transaction = TransferTransaction()
+        nft_transfer_transaction.add_nft_transfer(
+            NftId(nft_token_id, serials[0]), 
+            env.client.operator_account_id, 
+            account_id
+        )
+        
+        receipt = nft_transfer_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"NFT transfer failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Reject the NFT with duplicate NFT id - should fail with TOKEN_REFERENCE_REPEATED
+        nft_id = NftId(nft_token_id, serials[0])
+        nft_reject_transaction = TokenRejectTransaction(
+            owner_id=account_id,
+            nft_ids=[nft_id, nft_id]  # Duplicate NFT ID
+        )
+        
+        nft_reject_transaction.freeze_with(env.client)
+        nft_reject_transaction.sign(new_account_private_key)
+        
+        with pytest.raises(PrecheckError, match="failed precheck with status: TOKEN_REFERENCE_REPEATED"):
+            nft_reject_transaction.execute(env.client)
+    finally:
+        env.close()
+
+@pytest.mark.integration
+def test_integration_token_reject_transaction_fails_when_rejecting_nft_with_token_id():
+    env = IntegrationTestEnv()
+    
+    try:
+        # Create NFT with treasury
+        nft_token_id = create_nft_token(env)
+        
+        # Mint NFTs
+        mint_transaction = TokenMintTransaction(
+            token_id=nft_token_id,
+            metadata=[b"metadata1", b"metadata2", b"metadata3"]
+        )
+        
+        receipt = mint_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"NFT minting failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        serials = receipt.serial_numbers
+        
+        # Create receiver account with auto associations
+        new_account_private_key = PrivateKey.generate()
+        new_account_public_key = new_account_private_key.public_key()
+        
+        account_transaction = AccountCreateTransaction(
+            key=new_account_public_key,
+            initial_balance=Hbar(1),
+            memo="Receiver Account"
+        )
+        
+        receipt = account_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        account_id = receipt.accountId
+        
+        # Associate the NFT to the receiver
+        nft_associate_transaction = TokenAssociateTransaction(
+            account_id=account_id,
+            token_ids=[nft_token_id]
+        )
+        
+        nft_associate_transaction.freeze_with(env.client)
+        nft_associate_transaction.sign(new_account_private_key)
+        receipt = nft_associate_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"NFT association failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Transfer NFTs to the receiver
+        nft_transfer_transaction = TransferTransaction()
+        nft_transfer_transaction.add_nft_transfer(NftId(nft_token_id, serials[0]), env.client.operator_account_id, account_id)
+        nft_transfer_transaction.add_nft_transfer(NftId(nft_token_id, serials[1]), env.client.operator_account_id, account_id)
+        nft_transfer_transaction.add_nft_transfer(NftId(nft_token_id, serials[2]), env.client.operator_account_id, account_id)
+        
+        receipt = nft_transfer_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"NFT transfer failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Reject the whole collection - should fail
+        token_reject_transaction = TokenRejectTransaction(
+            owner_id=account_id,
+            token_ids=[nft_token_id]
+        )
+        
+        token_reject_transaction.freeze_with(env.client)
+        token_reject_transaction.sign(new_account_private_key)
+        
+        receipt = token_reject_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.ACCOUNT_AMOUNT_TRANSFERS_ONLY_ALLOWED_FOR_FUNGIBLE_COMMON, f"Token rejection should have failed with ACCOUNT_AMOUNT_TRANSFERS_ONLY_ALLOWED_FOR_FUNGIBLE_COMMON status but got: {ResponseCode.get_name(receipt.status)}"
+    finally:
+        env.close()
+
+@pytest.mark.integration
+def test_token_reject_transaction_fails_with_nft_token_frozen():
+    env = IntegrationTestEnv()
+    try:
+        # Create NFT with treasury
+        nft_token_id = create_nft_token(env)
+        
+        # Mint NFTs
+        mint_transaction = TokenMintTransaction(
+            token_id=nft_token_id,
+            metadata=[b"test metadata", b"test metadata", b"test metadata"]
+        )
+        
+        receipt = mint_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"NFT minting failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        serials = receipt.serial_numbers
+        
+        # Create a new account with private key
+        new_account_private_key = PrivateKey.generate()
+        new_account_public_key = new_account_private_key.public_key()
+        
+        # Create the new account
+        transaction = AccountCreateTransaction(
+            key=new_account_public_key,
+            initial_balance=Hbar(1),
+            memo="Recipient Account"
+        )
+        
+        receipt = transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        account_id = receipt.accountId
+        
+        # Associate the NFT to the receiver
+        associate_transaction = TokenAssociateTransaction(
+            account_id=account_id,
+            token_ids=[nft_token_id]
+        )
+        
+        associate_transaction.freeze_with(env.client)
+        associate_transaction.sign(new_account_private_key)
+        receipt = associate_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"NFT association failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Transfer NFTs to the receiver
+        nft_transfer_transaction = TransferTransaction()
+        nft_transfer_transaction.add_nft_transfer(NftId(nft_token_id, serials[0]), env.client.operator_account_id, account_id)
+        nft_transfer_transaction.add_nft_transfer(NftId(nft_token_id, serials[1]), env.client.operator_account_id, account_id)
+        
+        receipt = nft_transfer_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"NFT transfer failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Freeze the token
+        token_freeze_transaction = TokenFreezeTransaction(
+            token_id=nft_token_id,
+            account_id=account_id
+        )
+        
+        receipt = token_freeze_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"Token freeze failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Reject the NFT - should fail with ACCOUNT_FROZEN_FOR_TOKEN
+        nft_reject_transaction = TokenRejectTransaction(
+            owner_id=account_id,
+            nft_ids=[NftId(nft_token_id, serials[1])]
+        )
+        
+        nft_reject_transaction.freeze_with(env.client)
+        nft_reject_transaction.sign(new_account_private_key)
+        receipt = nft_reject_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.ACCOUNT_FROZEN_FOR_TOKEN, f"Token rejection should have failed with ACCOUNT_FROZEN_FOR_TOKEN status but got: {ResponseCode.get_name(receipt.status)}"
+    finally:
+        env.close()
+
+@pytest.mark.integration
+def test_token_reject_transaction_fails_with_fungible_token_frozen():
+    env = IntegrationTestEnv()
+    
+    try:
+        # Create a new account with private key
+        new_account_private_key = PrivateKey.generate()
+        new_account_public_key = new_account_private_key.public_key()
+        
+        # Create the new account
+        transaction = AccountCreateTransaction(
+            key=new_account_public_key,
+            initial_balance=Hbar(1),
+            memo="Recipient Account"
+        )
+        
+        receipt = transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        account_id = receipt.accountId
+        
+        # Create fungible token with treasury
+        token_id = create_fungible_token(env)
+        
+        # Associate the token to the receiver
+        associate_transaction = TokenAssociateTransaction(
+            account_id=account_id,
+            token_ids=[token_id]
+        )
+        
+        associate_transaction.freeze_with(env.client)
+        associate_transaction.sign(new_account_private_key)
+        receipt = associate_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"Token association failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Transfer tokens to the receiver
+        token_transfer_transaction = TransferTransaction()
+        token_transfer_transaction.add_token_transfer(token_id, account_id, 10)
+        token_transfer_transaction.add_token_transfer(token_id, env.client.operator_account_id, -10)
+
+        receipt = token_transfer_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"Token transfer failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Freeze the token
+        token_freeze_transaction = TokenFreezeTransaction(
+            token_id=token_id,
+            account_id=account_id
+        )
+        
+        receipt = token_freeze_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"Token freeze failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Reject the token - should fail with ACCOUNT_FROZEN_FOR_TOKEN
+        token_reject_transaction = TokenRejectTransaction(
+            owner_id=account_id,
+            token_ids=[token_id]
+        )
+        
+        token_reject_transaction.freeze_with(env.client)
+        token_reject_transaction.sign(new_account_private_key)
+        receipt = token_reject_transaction.execute(env.client)
+        
+        assert receipt.status == ResponseCode.ACCOUNT_FROZEN_FOR_TOKEN, f"Token rejection should have failed with ACCOUNT_FROZEN_FOR_TOKEN status but got: {ResponseCode.get_name(receipt.status)}"
+    finally:
+        env.close()
+
+@pytest.mark.integration
+def test_token_reject_transaction_receiver_sig_required_nft():
+    env = IntegrationTestEnv()
+    
+    try:
+        treasury_private_key = PrivateKey.generate()
+        treasury_public_key = treasury_private_key.public_key()
+        
+        transaction = AccountCreateTransaction(
+            key=treasury_public_key,
+            initial_balance=Hbar(0),
+            receiver_signature_required=True,
+            memo="Treasury Account"
+        )
+        receipt = transaction.freeze_with(env.client).sign(treasury_private_key).execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"Treasury account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        treasury_id = receipt.accountId
+        
+        # Create a new NFT token with a custom treasury account that requires receiver signatures
+        # Pass lambda functions to create_nft_token to configure the treasury account and sign with its key
+        nft_token_id = create_nft_token(env, [
+            lambda tx: tx.set_treasury_account_id(treasury_id).freeze_with(env.client),
+            lambda tx: tx.sign(treasury_private_key)
+        ])
+        
+        transaction = TokenMintTransaction(
+            token_id=nft_token_id,
+            metadata=[b"test metadata 1", b"test metadata 2"]
+        )
+        receipt = transaction.execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"NFT minting failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        serials = receipt.serial_numbers
+        
+        receiver_private_key = PrivateKey.generate()
+        receiver_public_key = receiver_private_key.public_key()
+        
+        transaction = AccountCreateTransaction(
+            key=receiver_public_key,
+            initial_balance=Hbar(1),
+            memo="Receiver Account"
+        )
+        receipt = transaction.execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"Receiver account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        receiver_id = receipt.accountId
+        
+        associate_transaction = TokenAssociateTransaction(
+            account_id=receiver_id,
+            token_ids=[nft_token_id]
+        )
+        receipt = associate_transaction.freeze_with(env.client).sign(receiver_private_key).execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"NFT association failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        nft_transfer_transaction = TransferTransaction()
+        nft_transfer_transaction.add_nft_transfer(NftId(nft_token_id, serials[0]), treasury_id, receiver_id)
+        nft_transfer_transaction.add_nft_transfer(NftId(nft_token_id, serials[1]), treasury_id, receiver_id)
+        
+        receipt = nft_transfer_transaction.freeze_with(env.client).sign(treasury_private_key).execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"NFT transfer failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Reject one of the NFTs
+        nft_id = NftId(nft_token_id, serials[1])
+        nft_reject_transaction = TokenRejectTransaction(
+            owner_id=receiver_id,
+            nft_ids=[nft_id]
+        )
+        receipt = nft_reject_transaction.freeze_with(env.client).sign(receiver_private_key).execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"NFT rejection failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Verify the balance is decremented by 1
+        token_balance = CryptoGetAccountBalanceQuery(account_id=receiver_id).execute(env.client)
+        assert token_balance.token_balances.get(nft_token_id) == 1, f"Expected NFT balance to be 1, got {token_balance.token_balances.get(nft_token_id)}"
+        
+        # Verify the NFT is transferred back to the treasury
+        nft_info = TokenNftInfoQuery(nft_id=nft_id).execute(env.client)
+        assert nft_info.account_id == treasury_id, f"Expected NFT owner to be {treasury_id}, got {nft_info.account_id}"
+    finally:
+        env.close()
+
+@pytest.mark.integration
+def test_token_reject_transaction_receiver_sig_required_fungible():
+    env = IntegrationTestEnv()
+    
+    try:
+        # Create treasury account with receiver signature required
+        treasury_private_key = PrivateKey.generate()
+        treasury_public_key = treasury_private_key.public_key()
+        
+        transaction = AccountCreateTransaction(
+            key=treasury_public_key,
+            initial_balance=Hbar(0),
+            receiver_signature_required=True,
+            memo="Treasury Account"
+        )
+        receipt = transaction.freeze_with(env.client).sign(treasury_private_key).execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"Treasury account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        treasury_id = receipt.accountId
+        
+        # Create a fungible token with a custom treasury account that requires receiver signatures
+        # Pass lambda functions to create_fungible_token to configure the treasury account and sign with its key
+        fungible_token_id = create_fungible_token(env, [
+            lambda tx: tx.set_treasury_account_id(treasury_id).freeze_with(env.client),
+            lambda tx: tx.sign(treasury_private_key)
+        ])
+        
+        # Create receiver account
+        receiver_private_key = PrivateKey.generate()
+        receiver_public_key = receiver_private_key.public_key()
+        
+        receiver_transaction = AccountCreateTransaction(
+            key=receiver_public_key,
+            initial_balance=Hbar(1),
+            memo="Receiver Account"
+        )
+        receipt = receiver_transaction.execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"Receiver account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        receiver_id = receipt.accountId
+        
+        # Associate the token to the receiver
+        associate_transaction = TokenAssociateTransaction(
+            account_id=receiver_id,
+            token_ids=[fungible_token_id]
+        )
+        receipt = associate_transaction.freeze_with(env.client).sign(receiver_private_key).execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"Token association failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Transfer tokens to the receiver
+        ft_transfer_transaction = TransferTransaction()
+        ft_transfer_transaction.add_token_transfer(fungible_token_id, treasury_id, -10)
+        ft_transfer_transaction.add_token_transfer(fungible_token_id, receiver_id, 10)
+        
+        receipt = ft_transfer_transaction.freeze_with(env.client).sign(treasury_private_key).execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"Token transfer failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Reject the token
+        ft_reject_transaction = TokenRejectTransaction(
+            owner_id=receiver_id,
+            token_ids=[fungible_token_id]
+        )
+        receipt = ft_reject_transaction.freeze_with(env.client).sign(receiver_private_key).execute(env.client)
+        assert receipt.status == ResponseCode.SUCCESS, f"Token rejection failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Verify the balance of the receiver is 0
+        receiver_balance = CryptoGetAccountBalanceQuery(account_id=receiver_id).execute(env.client)
+        assert receiver_balance.token_balances.get(fungible_token_id) == 0, f"Expected token balance to be 0, got {receiver_balance.token_balances.get(fungible_token_id)}"
+        
+        # Verify the tokens are transferred back to the treasury
+        treasury_balance = CryptoGetAccountBalanceQuery(account_id=treasury_id).execute(env.client)
+        assert treasury_balance.token_balances.get(fungible_token_id) == 1000, f"Expected treasury token balance to be 1000, got {treasury_balance.token_balances.get(fungible_token_id)}"
+    finally:
+        env.close()

--- a/tests/integration/utils_for_test.py
+++ b/tests/integration/utils_for_test.py
@@ -30,7 +30,7 @@ class IntegrationTestEnv:
         self.client.close()
     
 
-def create_fungible_token(env):
+def create_fungible_token(env, opts=[]):
     token_params = TokenParams(
             token_name="PTokenTest34",
             token_symbol="PTT34",
@@ -50,14 +50,18 @@ def create_fungible_token(env):
         )
         
     token_transaction = TokenCreateTransaction(token_params, token_keys)
-    token_transaction.freeze_with(env.client)
+    
+    # Apply optional functions to the token creation transaction
+    for opt in opts:
+        opt(token_transaction)
+    
     token_receipt = token_transaction.execute(env.client)
     
     assert token_receipt.status == ResponseCode.SUCCESS, f"Token creation failed with status: {ResponseCode.get_name(token_receipt.status)}"
     
     return token_receipt.tokenId
 
-def create_nft_token(env):
+def create_nft_token(env, opts=[]):
     token_params = TokenParams(
         token_name="PythonNFTToken",
         token_symbol="PNFT",
@@ -76,7 +80,11 @@ def create_nft_token(env):
     )
 
     transaction = TokenCreateTransaction(token_params, token_keys)
-    transaction.freeze_with(env.client)
+
+    # Apply optional functions to the token creation transaction
+    for opt in opts:
+        opt(transaction)
+
     token_receipt = transaction.execute(env.client)
     
     assert token_receipt.status == ResponseCode.SUCCESS, f"Token creation failed with status: {ResponseCode.get_name(token_receipt.status)}"

--- a/tests/integration/utils_for_test.py
+++ b/tests/integration/utils_for_test.py
@@ -31,6 +31,15 @@ class IntegrationTestEnv:
     
 
 def create_fungible_token(env, opts=[]):
+    """
+    Create a fungible token with the given options.
+
+    Args:
+        env: The environment object containing the client and operator account.
+        opts: List of optional functions that can modify the token creation transaction before execution.
+             Example opt function:
+             lambda tx: tx.set_treasury_account_id(custom_treasury_id).freeze_with(client)
+    """
     token_params = TokenParams(
             token_name="PTokenTest34",
             token_symbol="PTT34",
@@ -62,6 +71,15 @@ def create_fungible_token(env, opts=[]):
     return token_receipt.tokenId
 
 def create_nft_token(env, opts=[]):
+    """
+    Create a non-fungible token (NFT) with the given options.
+
+    Args:
+        env: The environment object containing the client and operator account.
+        opts: List of optional functions that can modify the token creation transaction before execution.
+             Example opt function:
+             lambda tx: tx.set_treasury_account_id(custom_treasury_id).freeze_with(client)
+    """
     token_params = TokenParams(
         token_name="PythonNFTToken",
         token_symbol="PNFT",

--- a/tests/unit/test_token_reject_transaction.py
+++ b/tests/unit/test_token_reject_transaction.py
@@ -1,0 +1,183 @@
+import pytest
+
+from hiero_sdk_python.hapi.services.transaction_receipt_pb2 import TransactionReceipt as TransactionReceiptProto
+from hiero_sdk_python.hapi.services.transaction_response_pb2 import TransactionResponse as TransactionResponseProto
+from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.tokens.token_reject_transaction import TokenRejectTransaction
+from hiero_sdk_python.tokens.nft_id import NftId
+from hiero_sdk_python.hapi.services import response_header_pb2, response_pb2, timestamp_pb2, transaction_get_receipt_pb2
+from hiero_sdk_python.transaction.transaction_id import TransactionId
+
+from tests.unit.mock_server import mock_hedera_servers
+
+pytestmark = pytest.mark.unit
+
+def generate_transaction_id(account_id_proto):
+    """Generate a unique transaction ID based on the account ID and the current timestamp."""
+    import time
+    current_time = time.time()
+    timestamp_seconds = int(current_time)
+    timestamp_nanos = int((current_time - timestamp_seconds) * 1e9)
+
+    tx_timestamp = timestamp_pb2.Timestamp(seconds=timestamp_seconds, nanos=timestamp_nanos)
+
+    tx_id = TransactionId(
+        valid_start=tx_timestamp,
+        account_id=account_id_proto
+    )
+    return tx_id
+
+def test_build_transaction_body_with_token_ids(mock_account_ids):
+    """Test building a token reject transaction body with token IDs."""
+    account_id, owner_account_id, node_account_id, token_id, _ = mock_account_ids
+    token_ids = [token_id]
+
+    reject_tx = (
+        TokenRejectTransaction()
+        .set_owner_id(owner_account_id)
+        .set_token_ids(token_ids)
+    )
+    
+    reject_tx.transaction_id = generate_transaction_id(account_id)
+    reject_tx.node_account_id = node_account_id
+
+    transaction_body = reject_tx.build_transaction_body()
+
+    assert transaction_body.tokenReject.owner.shardNum == owner_account_id.shard
+    assert transaction_body.tokenReject.owner.realmNum == owner_account_id.realm
+    assert transaction_body.tokenReject.owner.accountNum == owner_account_id.num
+
+    assert len(transaction_body.tokenReject.rejections) == 1
+    assert transaction_body.tokenReject.rejections[0].fungible_token.shardNum == token_id.shard
+    assert transaction_body.tokenReject.rejections[0].fungible_token.realmNum == token_id.realm
+    assert transaction_body.tokenReject.rejections[0].fungible_token.tokenNum == token_id.num
+
+def test_build_transaction_body_with_nft_ids(mock_account_ids):
+    """Test building a token reject transaction body with NFT IDs."""
+    account_id, owner_account_id, node_account_id, token_id, _ = mock_account_ids
+    
+    # Create NftId instances
+    nft_ids = [NftId(tokenId=token_id, serialNumber=1), NftId(tokenId=token_id, serialNumber=2)]
+
+    reject_tx = ( 
+        TokenRejectTransaction()
+        .set_owner_id(owner_account_id)
+        .set_nft_ids(nft_ids)
+    )
+    
+    reject_tx.transaction_id = generate_transaction_id(account_id)
+    reject_tx.node_account_id = node_account_id
+
+    transaction_body = reject_tx.build_transaction_body()
+
+    assert transaction_body.tokenReject.owner.shardNum == owner_account_id.shard
+    assert transaction_body.tokenReject.owner.realmNum == owner_account_id.realm
+    assert transaction_body.tokenReject.owner.accountNum == owner_account_id.num
+
+    assert len(transaction_body.tokenReject.rejections) == 2
+
+    # Check first NFT
+    assert transaction_body.tokenReject.rejections[0].nft.token_ID.shardNum == token_id.shard
+    assert transaction_body.tokenReject.rejections[0].nft.token_ID.realmNum == token_id.realm
+    assert transaction_body.tokenReject.rejections[0].nft.token_ID.tokenNum == token_id.num
+    assert transaction_body.tokenReject.rejections[0].nft.serial_number == 1
+    
+    # Check second NFT
+    assert transaction_body.tokenReject.rejections[1].nft.token_ID.shardNum == token_id.shard
+    assert transaction_body.tokenReject.rejections[1].nft.token_ID.realmNum == token_id.realm
+    assert transaction_body.tokenReject.rejections[1].nft.token_ID.tokenNum == token_id.num
+    assert transaction_body.tokenReject.rejections[1].nft.serial_number == 2
+
+def test_constructor_with_parameters(mock_account_ids):
+    """Test creating a token reject transaction with constructor parameters."""
+    _, owner_account_id, _, token_id, _ = mock_account_ids
+    token_ids = [token_id]
+    nft_ids = [NftId(tokenId=token_id, serialNumber=1)]
+
+    reject_tx = TokenRejectTransaction(
+        owner_id=owner_account_id,
+        token_ids=token_ids,
+        nft_ids=nft_ids
+    )
+
+    assert reject_tx.owner_id == owner_account_id
+    assert reject_tx.token_ids == token_ids
+    assert reject_tx.nft_ids == nft_ids
+
+def test_set_methods(mock_account_ids):
+    """Test the set methods of TokenRejectTransaction."""
+    _, owner_account_id, _, token_id, _ = mock_account_ids
+    token_ids = [token_id]
+    nft_ids = [NftId(tokenId=token_id, serialNumber=1)]
+
+    reject_tx = TokenRejectTransaction()
+    
+    # Test method chaining
+    tx_after_set = reject_tx.set_owner_id(owner_account_id)
+    assert tx_after_set is reject_tx
+    assert reject_tx.owner_id == owner_account_id
+    
+    tx_after_set = reject_tx.set_token_ids(token_ids)
+    assert tx_after_set is reject_tx
+    assert reject_tx.token_ids == token_ids
+    
+    tx_after_set = reject_tx.set_nft_ids(nft_ids)
+    assert tx_after_set is reject_tx
+    assert reject_tx.nft_ids == nft_ids
+
+def test_set_methods_require_not_frozen(mock_account_ids, nft_id, mock_client):
+    """Test the set methods of TokenRejectTransaction."""
+    _, owner_account_id, _, token_id, _ = mock_account_ids
+    token_ids = [token_id]
+    nft_ids = [nft_id]
+
+    reject_tx = TokenRejectTransaction()
+    reject_tx.freeze_with(mock_client)
+    
+    with pytest.raises(Exception, match="Transaction is immutable; it has been frozen"):
+        reject_tx.set_owner_id(owner_account_id)
+    
+    with pytest.raises(Exception, match="Transaction is immutable; it has been frozen"):
+        reject_tx.set_token_ids(token_ids)
+    
+    with pytest.raises(Exception, match="Transaction is immutable; it has been frozen"):
+        reject_tx.set_nft_ids(nft_ids)
+
+def test_reject_transaction_can_execute(mock_account_ids):
+    """Test that a reject transaction can be executed successfully."""
+    account_id, owner_account_id, _, token_id, _ = mock_account_ids
+    token_ids = [token_id]
+
+    # Create test transaction responses
+    ok_response = TransactionResponseProto()
+    ok_response.nodeTransactionPrecheckCode = ResponseCode.OK
+    
+    # Create a mock receipt for a successful token reject
+    mock_receipt_proto = TransactionReceiptProto(
+        status=ResponseCode.SUCCESS
+    )
+    
+    # Create a response for the receipt query
+    receipt_query_response = response_pb2.Response(
+        transactionGetReceipt=transaction_get_receipt_pb2.TransactionGetReceiptResponse(
+            header=response_header_pb2.ResponseHeader(
+                nodeTransactionPrecheckCode=ResponseCode.OK
+            ),
+            receipt=mock_receipt_proto
+        )
+    )
+    
+    response_sequences = [
+        [ok_response, receipt_query_response],
+    ]
+    
+    with mock_hedera_servers(response_sequences) as client:
+        transaction = (
+            TokenRejectTransaction()
+            .set_owner_id(owner_account_id)
+            .set_token_ids(token_ids)
+        )
+        
+        receipt = transaction.execute(client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, "Transaction should have succeeded"

--- a/tests/unit/test_token_reject_transaction.py
+++ b/tests/unit/test_token_reject_transaction.py
@@ -184,15 +184,11 @@ def test_reject_transaction_can_execute(mock_account_ids):
         
         assert receipt.status == ResponseCode.SUCCESS, "Transaction should have succeeded"
 
-def test_reject_transaction_from_proto(mock_account_ids, mock_client):
+def test_reject_transaction_from_proto(mock_account_ids):
     """Test that a reject transaction can be created from a protobuf object."""
     _, owner_account_id, _, token_id, _ = mock_account_ids
     token_ids = [token_id]
     nft_ids = [NftId(tokenId=token_id, serialNumber=1)]
-
-    reject_tx = TokenRejectTransaction(owner_id=owner_account_id, token_ids=token_ids, nft_ids=nft_ids)    
-    reject_tx.freeze_with(mock_client)
-    reject_tx.sign(mock_client.operator_private_key)
 
     # Create protobuf object with both fungible token and NFT rejections
     proto = TokenRejectTransactionBody(


### PR DESCRIPTION
**Description**:
Implement `TokenRejectTransaction` class that allows users to reject tokens.

* Implement `TokenRejectTransaction` class
* Add `opts` parameter to token creation functions in `utils_for_test.py` for flexible token creation
* Add unit/integration tests for `TokenRejectTransaction`
* Update documentation in README and docstrings
* Update `__init__.py` file with `TokenRejectTransaction` class definitions in `__all__` list

**Related issue(s)**:

Fixes #20 

**Notes for reviewer**:
I added additional parameter `opts` in both `create_nft_token()` and `create_fungible_token()` in `utils_for_test.py` file. This makes the token creation more flexible by allowing custom modifications to the transaction before execution.  I added docstrings for both functions so the user can see how to use the new paramter.

**Checklist**

- [X] Documented (Code comments, README)
- [X] Tested (unit, integration)
