### PR TITLE
fix: Implement `PublicKey.from_proto()` and improve test organization

### DIFF
--- a/src/hiero_sdk_python/crypto/public_key.py
+++ b/src/hiero_sdk_python/crypto/public_key.py
@@ -264,6 +264,24 @@ class PublicKey:
 
     #
     # ---------------------------------
+    # From proto
+    # ---------------------------------
+    #
+    
+    @classmethod
+    def from_proto(cls, proto: Key) -> "PublicKey":
+        """
+        Load a public key from a protobuf Key message.
+        """
+        if proto.ed25519:
+            return cls.from_bytes_ed25519(proto.ed25519)
+        elif proto.ECDSA_secp256k1:
+            return cls.from_bytes_ecdsa(proto.ECDSA_secp256k1)
+        else:
+            raise ValueError("Unsupported public key type in protobuf")
+
+    #
+    # ---------------------------------
     # To proto
     # ---------------------------------
     #

--- a/src/hiero_sdk_python/tokens/token_info.py
+++ b/src/hiero_sdk_python/tokens/token_info.py
@@ -99,17 +99,17 @@ class TokenInfo:
             maxSupply=proto_obj.maxSupply,
             ledger_id=proto_obj.ledger_id
         )
-        if proto_obj.adminKey.ECDSA_secp256k1 or proto_obj.adminKey.ed25519:
+        if proto_obj.adminKey.WhichOneof("key"):
             tokenInfoObject.set_admin_key(PublicKey.from_proto(proto_obj.adminKey))
-        if proto_obj.kycKey.ECDSA_secp256k1 or proto_obj.kycKey.ed25519:
+        if proto_obj.kycKey.WhichOneof("key"):
             tokenInfoObject.set_kycKey(PublicKey.from_proto(proto_obj.kycKey))
-        if proto_obj.freezeKey.ECDSA_secp256k1 or proto_obj.freezeKey.ed25519:
+        if proto_obj.freezeKey.WhichOneof("key"):
             tokenInfoObject.set_freezeKey(PublicKey.from_proto(proto_obj.freezeKey))
-        if proto_obj.wipeKey.ECDSA_secp256k1 or proto_obj.wipeKey.ed25519:
+        if proto_obj.wipeKey.WhichOneof("key"):
             tokenInfoObject.set_wipeKey(PublicKey.from_proto(proto_obj.wipeKey))
-        if proto_obj.supplyKey.ECDSA_secp256k1 or proto_obj.supplyKey.ed25519:
+        if proto_obj.supplyKey.WhichOneof("key"):
             tokenInfoObject.set_supplyKey(PublicKey.from_proto(proto_obj.supplyKey))
-        if proto_obj.fee_schedule_key.ECDSA_secp256k1 or proto_obj.fee_schedule_key.ed25519:
+        if proto_obj.fee_schedule_key.WhichOneof("key"):
             tokenInfoObject.set_fee_schedule_key(PublicKey.from_proto(proto_obj.fee_schedule_key))
         if proto_obj.defaultFreezeStatus:
             tokenInfoObject.set_default_freeze_status(TokenFreezeStatus.from_proto(proto_obj.defaultFreezeStatus))
@@ -121,7 +121,7 @@ class TokenInfo:
             tokenInfoObject.set_auto_renew_period(Duration.from_proto(proto_obj.autoRenewPeriod))
         if proto_obj.expiry:
             tokenInfoObject.set_expiry(Timestamp.from_protobuf(proto_obj.expiry))
-        if proto_obj.pause_key.ECDSA_secp256k1 or proto_obj.pause_key.ed25519:
+        if proto_obj.pause_key.WhichOneof("key"):
             tokenInfoObject.set_pause_key(PublicKey.from_proto(proto_obj.pause_key))
         if proto_obj.pause_status:
             tokenInfoObject.set_pause_status(TokenPauseStatus.from_proto(proto_obj.pause_status))

--- a/tests/unit/test_keys_private.py
+++ b/tests/unit/test_keys_private.py
@@ -8,6 +8,7 @@ from cryptography.hazmat.primitives import serialization
 from hiero_sdk_python.crypto.public_key import PublicKey
 from hiero_sdk_python.crypto.private_key import PrivateKey
 
+pytestmark = pytest.mark.unit
 
 def test_generate_ed25519():
     """

--- a/tests/unit/test_token_info.py
+++ b/tests/unit/test_token_info.py
@@ -9,6 +9,8 @@ from hiero_sdk_python.tokens.token_freeze_status import TokenFreezeStatus
 from hiero_sdk_python.tokens.token_pause_status import TokenPauseStatus
 from hiero_sdk_python.hapi.services.token_get_info_pb2 import TokenInfo as proto_TokenInfo
 
+pytestmark = pytest.mark.unit
+
 @pytest.fixture
 def token_info():
     return TokenInfo(
@@ -132,7 +134,7 @@ def test_from_proto(proto_token_info):
     proto_token_info.pause_status = hiero_sdk_python.hapi.services.basic_types_pb2.Paused
     proto_token_info.supplyType = hiero_sdk_python.hapi.services.basic_types_pb2.INFINITE
 
-    token_info = TokenInfo.from_proto(proto_token_info)
+    token_info = TokenInfo._from_proto(proto_token_info)
 
     assert token_info.tokenId == TokenId(0, 0, 100)
     assert token_info.name == "TestToken"
@@ -177,7 +179,7 @@ def test_to_proto(token_info):
     token_info.set_pause_status(TokenPauseStatus.PAUSED)
     token_info.set_supply_type(SupplyType.INFINITE)
 
-    proto = token_info.to_proto()
+    proto = token_info._to_proto()
 
     assert proto.tokenId == TokenId(0, 0, 100).to_proto()
     assert proto.name == "TestToken"


### PR DESCRIPTION
**Description**:
Implement `PublicKey.from_proto()` and improve test organization

This PR addresses a bug where `TokenInfo._from_proto()` fails to convert protobuf key messages to `PublicKey` objects due to missing implementation.
Additionally, it adds pytest unit markers to test files so they can be properly discovered and run.

* Add` from_proto()` method to `PublicKey` class to handle protobuf key messages
* Simplify key type checks using `WhichOneof` for better maintainability
* Update `test_token_info.py` to use correct private methods (`_from_proto` and `_to_proto`)
* Reorganize test files into unit directory structure
* Add unit test markers where missing

**Related issue(s)**:

Fixes #110

**Notes for reviewer**:
I implemented `PublicKey.from_proto()` to handle both `Ed25519` and `ECDSA` key types. 
In `TokenInfo._from_proto()` I refactored key type checks to use `WhichOneof` method, making the code more maintainable and ready for future key type additions.
There were test files that had missing pytest unit markers and were not in `tests/unit` folder so I moved them.

**Checklist**

- [x] Documented (Code comments)
- [x] Tested (unit, integration)