### PR TITLE
feat: implement `get_cost()` functionality

### DIFF
--- a/examples/query_payment.py
+++ b/examples/query_payment.py
@@ -1,0 +1,169 @@
+import os
+import sys
+from dotenv import load_dotenv
+
+from hiero_sdk_python import (
+    Client,
+    AccountId,
+    PrivateKey,
+    Network,
+)
+from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenType
+from hiero_sdk_python.query.account_balance_query import CryptoGetAccountBalanceQuery
+from hiero_sdk_python.hbar import Hbar
+from hiero_sdk_python.query.token_info_query import TokenInfoQuery
+from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.tokens.supply_type import SupplyType
+from hiero_sdk_python.tokens.token_create_transaction import TokenCreateTransaction
+
+load_dotenv()
+
+def setup_client():
+    """Initialize and set up the client with operator account"""
+    network = Network(network='testnet')
+    client = Client(network)
+
+    operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
+    operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+    client.set_operator(operator_id, operator_key)
+    
+    return client, operator_id, operator_key
+
+def create_fungible_token(client, operator_id, operator_key):
+    """Create a fungible token"""
+    
+    receipt = (
+        TokenCreateTransaction()
+        .set_token_name("MyExampleFT")
+        .set_token_symbol("EXFT")
+        .set_decimals(2)
+        .set_initial_supply(100)
+        .set_treasury_account_id(operator_id)
+        .set_token_type(TokenType.FUNGIBLE_COMMON)
+        .set_supply_type(SupplyType.FINITE)
+        .set_max_supply(1000)
+        .set_admin_key(operator_key)
+        .set_supply_key(operator_key)
+        .execute(client)
+    )
+    
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Fungible token creation failed with status: {ResponseCode.get_name(receipt.status)}")
+        sys.exit(1)
+    
+    token_id = receipt.tokenId
+    print(f"Fungible token created with ID: {token_id}")
+    
+    return token_id
+
+def demonstrate_zero_cost_balance_query(client, account_id):
+    """
+    Demonstrate cost calculation for queries that don't require payment.
+    
+    CryptoGetAccountBalanceQuery is an example of a query that doesn't require payment.
+    For such queries:
+    - get_cost() returns 0 Hbar when no payment is set
+    - get_cost() returns the set payment amount when payment is set
+    """
+    print("\nQueries that DON'T require payment:\n")
+    
+    # Case 1: No payment set - should return 0 Hbar cost
+    print("When no payment is set:")
+    query_no_payment = CryptoGetAccountBalanceQuery().set_account_id(account_id)
+    
+    cost_no_payment = query_no_payment.get_cost(client)
+    print(f"Cost: {cost_no_payment} Hbar")
+    print("Expected: 0 Hbar (payment not required)")
+    
+    # Execute the query (should work without payment)
+    print("\nExecuting query without payment...")
+    result = query_no_payment.execute(client)
+    print(f"Query executed successfully!")
+    print(f"    Account balance (only hbars): {result.hbars}")
+    
+    # Case 2: Payment set - should return the set payment amount
+    print("\nWhen custom payment is set:")
+    custom_payment = Hbar(2)
+    query_with_payment = (
+        CryptoGetAccountBalanceQuery()
+        .set_account_id(account_id)
+        .set_query_payment(custom_payment)
+    )
+    
+    cost_with_payment = query_with_payment.get_cost(client)
+    print(f"Cost: {cost_with_payment} Hbar")
+    print(f"Expected: {custom_payment} Hbar")
+    
+    # Execute the query (should work with custom payment)
+    print("\nExecuting query with custom payment...")
+    result = query_with_payment.execute(client)
+    print(f"Query executed successfully!")
+    print(f"    Account balance (only hbars): {result.hbars}")
+
+def demonstrate_payment_required_queries(client, token_id):
+    """
+    Demonstrate cost calculation for queries that require payment.
+    
+    TokenInfoQuery is an example of a query that requires payment.
+    For such queries:
+    - get_cost() asks the network for the actual cost when no payment is set
+    - get_cost() returns the set payment amount when payment is set
+    """
+    print("\nQueries that DO require payment:\n")
+    
+    # Case 1: No payment set - should ask network for cost
+    print("When no payment is set:")
+    query_no_payment = TokenInfoQuery().set_token_id(token_id)
+    
+    print("Asking network for query cost...")
+    cost_from_network = query_no_payment.get_cost(client)
+    print(f"Cost: {cost_from_network} Hbar")
+    print("This is the actual cost calculated by the network")
+    
+    # Execute the query (should work with network-determined cost)
+    print("\nExecuting query with network-determined cost...")
+    result = query_no_payment.execute(client)
+    print(f"Query executed successfully!")
+    print(f"    Token info: {result}")
+    
+    # Case 2: Payment set - should return the set payment amount
+    print("\nWhen custom payment is set:")
+    custom_payment = Hbar(2)
+    query_with_payment = (
+        TokenInfoQuery()
+        .set_token_id(token_id)
+        .set_query_payment(custom_payment)
+    )
+    
+    cost_with_payment = query_with_payment.get_cost(client)
+    print(f"Cost: {cost_with_payment} Hbar")
+    print(f"Expected: {custom_payment} Hbar")
+    
+    # Execute the query (should work with custom payment)
+    print("\nExecuting query with custom payment...")
+    result = query_with_payment.execute(client)
+    print(f"Query executed successfully!")
+    print(f"    Token info: {result}")
+    
+    # Case 3: Compare network cost vs custom payment
+    print("\nCost comparison:")
+    print(f"Network-determined cost: {cost_from_network} Hbar")
+    print(f"Custom payment: {custom_payment} Hbar")
+
+def query_payment():
+    """
+    Demonstrates the query payment by:
+    1. Setting up client with operator account
+    2. Creating a fungible token with the operator account as owner
+    3. Demonstrating queries that don't require payment (CryptoGetAccountBalanceQuery)
+    4. Demonstrating queries that do require payment (TokenInfoQuery)
+    5. Comparing network-determined cost vs custom payment amount
+    """
+    client, operator_id, operator_key = setup_client()
+    token_id = create_fungible_token(client, operator_id, operator_key)
+    
+    demonstrate_zero_cost_balance_query(client, operator_id)
+    demonstrate_payment_required_queries(client, token_id)
+
+if __name__ == "__main__":
+    query_payment()

--- a/src/hiero_sdk_python/query/account_balance_query.py
+++ b/src/hiero_sdk_python/query/account_balance_query.py
@@ -23,6 +23,7 @@ class CryptoGetAccountBalanceQuery(Query):
         """
         super().__init__()
         self.account_id = account_id
+        self._is_payment_required = False
 
     def set_account_id(self, account_id: AccountId):
         """

--- a/src/hiero_sdk_python/query/account_balance_query.py
+++ b/src/hiero_sdk_python/query/account_balance_query.py
@@ -23,7 +23,6 @@ class CryptoGetAccountBalanceQuery(Query):
         """
         super().__init__()
         self.account_id = account_id
-        self._is_payment_required = False
 
     def set_account_id(self, account_id: AccountId):
         """
@@ -127,3 +126,12 @@ class CryptoGetAccountBalanceQuery(Query):
             The crypto get account balance response object
         """
         return response.cryptogetAccountBalance
+    
+    def _is_payment_required(self):
+        """
+        Account balance query does not require payment.
+        
+        Returns:
+            bool: False
+        """
+        return False

--- a/src/hiero_sdk_python/query/query.py
+++ b/src/hiero_sdk_python/query/query.py
@@ -154,7 +154,6 @@ class Query(_Executable):
         tx.add_hbar_transfer(payer_account_id, -amount.to_tinybars())
         tx.add_hbar_transfer(node_account_id, amount.to_tinybars())
 
-        tx.transaction_fee = 100_000_000 
         tx.node_account_id = node_account_id
         tx.transaction_id = TransactionId.generate(payer_account_id)
 

--- a/src/hiero_sdk_python/query/query.py
+++ b/src/hiero_sdk_python/query/query.py
@@ -124,6 +124,7 @@ class Query(_Executable):
             self.operator is not None
             and self.node_account_id is not None
             and self.payment_amount is not None
+            and self.payment_amount.to_tinybars() > 0
         ):
             payment_tx = self._build_query_payment_transaction(
                 payer_account_id=self.operator.account_id,

--- a/src/hiero_sdk_python/query/query.py
+++ b/src/hiero_sdk_python/query/query.py
@@ -39,7 +39,7 @@ class Query(_Executable):
         self.operator = None
         self.node_index = 0
         self._user_query_payment = None
-        self._default_query_payment = Hbar(1)
+        self._is_payment_required = True
         
     def _get_query_response(self, response):
         """

--- a/src/hiero_sdk_python/query/query.py
+++ b/src/hiero_sdk_python/query/query.py
@@ -78,10 +78,13 @@ class Query(_Executable):
     def _before_execute(self, client):
         """
         Performs setup before executing the query.
+
+        Configures node accounts, operator, and payment details from the client.
+        If no payment amount was specified and payment is required for the query,
+        gets the cost from the network and sets it as the payment amount.
         
-        Sets up node list, operator, and determines if we should pay 1 Hbar by default.
-        This method is called automatically before execution.
-        
+        This method is called automatically before query execution.
+
         Args:
             client: The client instance to use for execution
         """
@@ -100,6 +103,10 @@ class Query(_Executable):
         Constructs the request header for the query.
         
         This includes a payment transaction if we have an operator and node.
+        
+        If no payment amount is specified and payment is required for the query,
+        returns a header with COST_ANSWER response type to get the cost of executing
+        the query. Otherwise returns ANSWER_ONLY response type.
         
         Returns:
             QueryHeader: The protobuf QueryHeader object

--- a/src/hiero_sdk_python/query/query.py
+++ b/src/hiero_sdk_python/query/query.py
@@ -192,11 +192,11 @@ class Query(_Executable):
             MaxAttemptsError: If the cost query fails after maximum retry attempts
             ReceiptStatusError: If the cost query fails with a receipt error
         """
-        if self.payment_amount is not None:
-            return self.payment_amount
-        
         if not self._is_payment_required():
             return Hbar.from_tinybars(0)
+        
+        if self.payment_amount is not None:
+            return self.payment_amount
         
         if client is None or client.operator is None:
             raise ValueError("Client and operator must be set to get the cost")

--- a/src/hiero_sdk_python/query/query.py
+++ b/src/hiero_sdk_python/query/query.py
@@ -58,7 +58,7 @@ class Query(_Executable):
         """
         raise NotImplementedError("_get_query_response must be implemented by subclasses.")
 
-    def set_query_payment(self, amount: Hbar):
+    def set_query_payment(self, payment_amount: Hbar):
         """
         Sets the payment amount for this query.
         
@@ -66,12 +66,12 @@ class Query(_Executable):
         If not set, the default is 1 Hbar.
         
         Args:
-            amount (Hbar): The payment amount for this query
+            payment_amount (Hbar): The payment amount for this query
             
         Returns:
             Query: The current query instance for method chaining
         """
-        self.payment_amount = amount
+        self.payment_amount = payment_amount
         return self
 
     def _before_execute(self, client):
@@ -183,8 +183,11 @@ class Query(_Executable):
             client (Client): The client instance to use for execution. Must have an operator set.
         
         Returns:
-            Hbar: The cost in Hbars that would be charged to execute this query. Returns the
-                 pre-set payment amount if one exists, or 0 if no payment is required.
+            Hbar: The cost in Hbars to execute this query. 
+                - Returns 0 if no payment is required (_is_payment_required is False),
+                  regardless of any manually set payment.
+                - Returns the manually set payment amount if one was provided for a paid query.
+                - Otherwise, fetches the cost from the network for a paid query.
             
         Raises:
             ValueError: If the client is None or the client's operator is not set

--- a/src/hiero_sdk_python/query/query.py
+++ b/src/hiero_sdk_python/query/query.py
@@ -178,7 +178,8 @@ class Query(_Executable):
             client (Client): The client instance to use for execution. Must have an operator set.
         
         Returns:
-            Hbar: The cost in Hbars that would be charged to execute this query
+            Hbar: The cost in Hbars that would be charged to execute this query. Returns the
+                 pre-set payment amount if one exists, or 0 if no payment is required.
             
         Raises:
             ValueError: If the client is None or the client's operator is not set

--- a/src/hiero_sdk_python/query/query.py
+++ b/src/hiero_sdk_python/query/query.py
@@ -113,13 +113,18 @@ class Query(_Executable):
         """
         header = query_header_pb2.QueryHeader()
         
-        # If there isn't a user query payment and payment is required, return COST_ANSWER
-        if self.payment_amount is None and self._is_payment_required():
+        # Default to ANSWER_ONLY response type
+        header.responseType = query_header_pb2.ResponseType.ANSWER_ONLY
+        
+        # If payment is not required, return header
+        if not self._is_payment_required():
+            return header
+
+        # If there isn't a user query payment, return COST_ANSWER
+        if self.payment_amount is None:
             header.responseType = query_header_pb2.ResponseType.COST_ANSWER
             return header
         
-        header.responseType = query_header_pb2.ResponseType.ANSWER_ONLY
-
         if (
             self.operator is not None
             and self.node_account_id is not None

--- a/src/hiero_sdk_python/query/query.py
+++ b/src/hiero_sdk_python/query/query.py
@@ -39,7 +39,6 @@ class Query(_Executable):
         self.operator = None
         self.node_index = 0
         self.payment_amount = None
-        self._is_payment_required = True
         
     def _get_query_response(self, response):
         """
@@ -96,7 +95,7 @@ class Query(_Executable):
         
         # If no payment amount was specified and payment is required for this query,
         # get the cost from the network and set it as the payment amount
-        if self.payment_amount is None and self._is_payment_required:
+        if self.payment_amount is None and self._is_payment_required():
             self.payment_amount = self.get_cost(client)
         
     def _make_request_header(self):
@@ -115,7 +114,7 @@ class Query(_Executable):
         header = query_header_pb2.QueryHeader()
         
         # If there isn't a user query payment and payment is required, return COST_ANSWER
-        if self.payment_amount is None and self._is_payment_required:
+        if self.payment_amount is None and self._is_payment_required():
             header.responseType = query_header_pb2.ResponseType.COST_ANSWER
             return header
         
@@ -190,7 +189,7 @@ class Query(_Executable):
         if self.payment_amount is not None:
             return self.payment_amount
         
-        if not self._is_payment_required:
+        if not self._is_payment_required():
             return Hbar.from_tinybars(0)
         
         if client is None or client.operator is None:
@@ -289,3 +288,12 @@ class Query(_Executable):
         """
         query_response = self._get_query_response(response)
         return PrecheckError(query_response.header.nodeTransactionPrecheckCode)
+
+    def _is_payment_required(self):
+        """
+        Determines if query requires payment.
+        
+        Returns:
+            bool: True if payment is required, False otherwise
+        """
+        return True

--- a/src/hiero_sdk_python/query/transaction_get_receipt_query.py
+++ b/src/hiero_sdk_python/query/transaction_get_receipt_query.py
@@ -30,6 +30,7 @@ class TransactionGetReceiptQuery(Query):
         super().__init__()
         self.transaction_id = transaction_id
         self._frozen = False
+        self._is_payment_required = False
 
     def _require_not_frozen(self):
         """
@@ -69,16 +70,6 @@ class TransactionGetReceiptQuery(Query):
         """
         self._frozen = True
         return self
-
-    def _is_payment_required(self):
-        """
-        Override the default in the base Query class:
-        This particular query does NOT require a payment.
-        
-        Returns:
-            bool: Always False, as this query doesn't require payment.
-        """
-        return False
 
     def _make_request(self):
         """

--- a/src/hiero_sdk_python/query/transaction_get_receipt_query.py
+++ b/src/hiero_sdk_python/query/transaction_get_receipt_query.py
@@ -30,7 +30,6 @@ class TransactionGetReceiptQuery(Query):
         super().__init__()
         self.transaction_id = transaction_id
         self._frozen = False
-        self._is_payment_required = False
 
     def _require_not_frozen(self):
         """
@@ -232,3 +231,12 @@ class TransactionGetReceiptQuery(Query):
             The transaction get receipt response object
         """
         return response.transactionGetReceipt
+
+    def _is_payment_required(self):
+        """
+        Transaction receipt query does not require payment.
+        
+        Returns:
+            bool: False
+        """
+        return False

--- a/tests/integration/query_e2e_test.py
+++ b/tests/integration/query_e2e_test.py
@@ -49,9 +49,6 @@ def test_integration_free_query_no_cost():
         balance_result = query.execute(env.client)
         assert balance_result.hbars.to_tinybars() == initial_balance.to_tinybars()
         
-        # Wait for transaction to be processed by network
-        time.sleep(1)
-        
         balance_after = (
             CryptoGetAccountBalanceQuery()
             .set_account_id(account_id)
@@ -106,9 +103,6 @@ def test_integration_free_query_with_manual_payment():
         
         balance_result = query.execute(env.client)
         assert balance_result.hbars.to_tinybars() == initial_balance.to_tinybars()
-        
-        # Wait for transaction to be processed by network
-        time.sleep(1)
         
         balance_after = (
             CryptoGetAccountBalanceQuery()

--- a/tests/integration/query_e2e_test.py
+++ b/tests/integration/query_e2e_test.py
@@ -1,0 +1,245 @@
+import time
+import pytest
+
+from hiero_sdk_python.account.account_create_transaction import AccountCreateTransaction
+from hiero_sdk_python.crypto.private_key import PrivateKey
+from hiero_sdk_python.exceptions import PrecheckError
+from hiero_sdk_python.hbar import Hbar
+from hiero_sdk_python.query.account_balance_query import CryptoGetAccountBalanceQuery
+from hiero_sdk_python.query.token_info_query import TokenInfoQuery
+from hiero_sdk_python.response_code import ResponseCode
+from tests.integration.utils_for_test import IntegrationTestEnv, create_fungible_token
+
+@pytest.mark.integration
+def test_integration_free_query_no_cost():
+    """Test that free queries don't cost anything and don't deduct from account balance."""
+    env = IntegrationTestEnv()
+    
+    try:
+        new_private_key = PrivateKey.generate_ed25519()
+        new_account_public_key = new_private_key.public_key()
+        
+        initial_balance = Hbar(1)
+        receipt = (
+            AccountCreateTransaction()
+            .set_key(new_account_public_key)
+            .set_initial_balance(initial_balance)
+            .execute(env.client)
+        )
+        assert receipt.status == ResponseCode.SUCCESS
+        account_id = receipt.accountId
+        assert account_id is not None
+        
+        env.client.set_operator(account_id, new_private_key)
+        
+        # Test free query (account balance query)
+        query = CryptoGetAccountBalanceQuery(account_id)
+        
+        # Cost should be 0 for free queries
+        cost = query.get_cost(env.client)
+        assert cost.to_tinybars() == 0
+        
+        # Execute query and verify balance wasn't deducted
+        balance_before = (
+            CryptoGetAccountBalanceQuery()
+            .set_account_id(account_id)
+            .execute(env.client)
+        )
+        
+        balance_result = query.execute(env.client)
+        assert balance_result.hbars.to_tinybars() == initial_balance.to_tinybars()
+        
+        # Wait for transaction to be processed by network
+        time.sleep(1)
+        
+        balance_after = (
+            CryptoGetAccountBalanceQuery()
+            .set_account_id(account_id)
+            .execute(env.client)
+        )
+        
+        # Balance should remain unchanged after free query
+        assert balance_before.hbars.to_tinybars() == balance_after.hbars.to_tinybars()
+    finally:
+        env.close()
+
+@pytest.mark.integration
+def test_integration_free_query_with_manual_payment():
+    """Test that manually setting payment on free queries still results in no cost."""
+    env = IntegrationTestEnv()
+    
+    try:
+        new_private_key = PrivateKey.generate_ed25519()
+        new_account_public_key = new_private_key.public_key()
+        
+        initial_balance = Hbar(1)
+        receipt = (
+            AccountCreateTransaction()
+            .set_key(new_account_public_key)
+            .set_initial_balance(initial_balance)
+            .execute(env.client)
+        )
+        
+        assert receipt.status == ResponseCode.SUCCESS
+        account_id = receipt.accountId
+        assert account_id is not None
+                
+        env.client.set_operator(account_id, new_private_key)
+        
+        # Test free query with manual payment set
+        query = (
+            CryptoGetAccountBalanceQuery()
+            .set_account_id(account_id)
+            .set_query_payment(Hbar(2))  # Set a high payment
+        )
+        
+        # Cost should still be 0 for free queries even with manual payment
+        cost = query.get_cost(env.client)
+        assert cost.to_tinybars() == 0
+        
+        # Execute and verify no balance deduction
+        balance_before = (
+            CryptoGetAccountBalanceQuery()
+            .set_account_id(account_id)
+            .execute(env.client)
+        )
+        
+        balance_result = query.execute(env.client)
+        assert balance_result.hbars.to_tinybars() == initial_balance.to_tinybars()
+        
+        # Wait for transaction to be processed by network
+        time.sleep(1)
+        
+        balance_after = (
+            CryptoGetAccountBalanceQuery()
+            .set_account_id(account_id)
+            .execute(env.client)
+        )
+        
+        # Balance should remain unchanged
+        assert balance_before.hbars.to_tinybars() == balance_after.hbars.to_tinybars()
+    finally:
+        env.close()
+
+@pytest.mark.integration
+def test_integration_paid_query_network_cost():
+    """Test that paid queries get actual network cost and payment amount is set correctly."""
+    env = IntegrationTestEnv()
+    
+    try:
+        token_id = create_fungible_token(env)
+        assert token_id is not None
+        
+        new_private_key = PrivateKey.generate_ed25519()
+        new_account_public_key = new_private_key.public_key()
+        
+        receipt = (
+            AccountCreateTransaction()
+            .set_key(new_account_public_key)
+            .set_initial_balance(Hbar(1))
+            .execute(env.client)
+        )
+        assert receipt.status == ResponseCode.SUCCESS
+        account_id = receipt.accountId
+        assert account_id is not None
+        
+        env.client.set_operator(account_id, new_private_key)
+        
+        # Test paid query (token info query)
+        query = TokenInfoQuery(token_id)
+        
+        # Get the network cost
+        network_cost = query.get_cost(env.client)
+        assert network_cost.to_tinybars() > 0
+        
+        # Execute the query
+        query.execute(env.client)
+        
+        # Payment amount should be set to the network cost
+        assert query.payment_amount.to_tinybars() == network_cost.to_tinybars()
+    finally:
+        env.close()
+
+@pytest.mark.integration
+def test_integration_paid_query_manual_payment():
+    """Test that manually setting payment on paid queries uses the set amount."""
+    env = IntegrationTestEnv()
+    
+    try:
+        token_id = create_fungible_token(env)
+        assert token_id is not None
+        
+        new_private_key = PrivateKey.generate_ed25519()
+        new_account_public_key = new_private_key.public_key()
+        
+        receipt = (
+            AccountCreateTransaction()
+            .set_key(new_account_public_key)
+            .set_initial_balance(Hbar(1))
+            .execute(env.client)
+        )
+        
+        assert receipt.status == ResponseCode.SUCCESS
+        account_id = receipt.accountId
+        assert account_id is not None
+        
+        env.client.set_operator(account_id, new_private_key)
+            
+        # Set a custom payment amount
+        custom_payment = Hbar.from_tinybars(5000000)  # 0.05 Hbar
+        query = (
+            TokenInfoQuery()
+            .set_token_id(token_id)
+            .set_query_payment(custom_payment)
+        )
+        
+        # get_cost should return the manually set amount
+        cost = query.get_cost(env.client)
+        assert cost.to_tinybars() == custom_payment.to_tinybars()
+        
+        # Execute the query
+        query.execute(env.client)
+        assert query.payment_amount is not None
+        
+        # Payment amount should be the custom amount
+        assert query.payment_amount.to_tinybars() == custom_payment.to_tinybars()
+    finally:
+        env.close()
+
+@pytest.mark.integration
+def test_integration_paid_query_payment_too_high_fails():
+    """Test that setting payment too high on paid queries fails."""
+    env = IntegrationTestEnv()
+    
+    try:
+        token_id = create_fungible_token(env)
+        assert token_id is not None
+        
+        new_private_key = PrivateKey.generate_ed25519()
+        new_account_public_key = new_private_key.public_key()
+        
+        receipt = (
+            AccountCreateTransaction()
+            .set_key(new_account_public_key)
+            .set_initial_balance(Hbar(1))
+            .execute(env.client)
+        )
+        
+        assert receipt.status == ResponseCode.SUCCESS
+        account_id = receipt.accountId
+        assert account_id is not None
+        
+        env.client.set_operator(account_id, new_private_key)
+        
+        # Set an unreasonably high payment amount
+        payment = Hbar(2)
+        query = (
+            TokenInfoQuery()
+            .set_token_id(token_id)
+            .set_query_payment(payment)
+        )
+        # Execute the query - should fail due to insufficient balance
+        with pytest.raises(PrecheckError, match="failed precheck with status: INSUFFICIENT_PAYER_BALANCE"):
+            query.execute(env.client)
+    finally:
+        env.close()

--- a/tests/unit/test_account_balance_query.py
+++ b/tests/unit/test_account_balance_query.py
@@ -48,3 +48,8 @@ def test_execute_account_balance_query():
             CryptoGetAccountBalanceQuery().set_account_id(AccountId(0, 0, 1800)).execute(client)
         except Exception as e:
             pytest.fail(f"Unexpected exception raised: {e}")
+
+def test_account_balance_query_does_not_require_payment():
+    """Test that the account balance query does not require payment."""
+    query = CryptoGetAccountBalanceQuery()
+    assert not query._is_payment_required()

--- a/tests/unit/test_get_receipt_query.py
+++ b/tests/unit/test_get_receipt_query.py
@@ -130,3 +130,8 @@ def test_receipt_query_receipt_status_error(transaction_id):
             query.execute(client)
         
         assert str(f"Receipt for transaction {transaction_id} contained error status: UNKNOWN ({ResponseCode.UNKNOWN})") in str(exc_info.value)
+
+def test_receipt_query_does_not_require_payment():
+    """Test that the receipt query does not require payment."""
+    query = TransactionGetReceiptQuery()
+    assert not query._is_payment_required()

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -112,6 +112,17 @@ def test_request_header_operator_set(query, mock_client):
     header = query._make_request_header()
     assert not header.HasField('payment'), "Payment field should not be present when only operator and node account are set"
 
+def test_request_header_payment_zero(query, mock_client):
+    """Test that payment field is not present in request header when payment amount is 0"""
+    # Set up operator and node account ID from mock client
+    query.operator = mock_client.operator
+    query.node_account_id = mock_client.network.current_node._account_id
+    
+    # Test with payment amount set to 0 Hbar
+    query.payment_amount = Hbar(0)
+    header = query._make_request_header()
+    assert not header.HasField('payment'), "Payment field should not be present when payment is set to 0"
+
 def test_make_request_header_with_payment(query, mock_client):
     """Test making request header with payment transaction"""
     # Setup

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import MagicMock
 
+from hiero_sdk_python.query.query import Query
 from hiero_sdk_python.query.account_balance_query import CryptoGetAccountBalanceQuery
 from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.query.token_info_query import TokenInfoQuery
@@ -211,3 +212,9 @@ def test_get_cost_when_payment_required_and_not_set(query_requires_payment, toke
         # Verify cost matches expected value of 2 tinybars
         assert result.to_tinybars() == 2
     
+def test_query_payment_requirement_defaults_to_true(query_requires_payment):
+    """Test that the base Query class and payment-requiring queries default to requiring payment."""
+    query = Query()
+    assert query._is_payment_required() == True
+    # Verify that payment-requiring query also defaults to requiring payment
+    assert query_requires_payment._is_payment_required() == True

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -1,14 +1,25 @@
 import pytest
+from unittest.mock import MagicMock
 
 from hiero_sdk_python.query.account_balance_query import CryptoGetAccountBalanceQuery
 from hiero_sdk_python.hbar import Hbar
+from hiero_sdk_python.query.token_info_query import TokenInfoQuery
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.executable import _ExecutionState
-from hiero_sdk_python.hapi.services import query_header_pb2, response_pb2, response_header_pb2, crypto_get_account_balance_pb2
+from hiero_sdk_python.hapi.services import query_header_pb2, response_pb2, response_header_pb2, crypto_get_account_balance_pb2, token_get_info_pb2
+from tests.unit.mock_server import mock_hedera_servers
 
+# By default we test query that doesn't require payment
 @pytest.fixture
 def query():
+    """Fixture for a query that doesn't require payment"""
     return CryptoGetAccountBalanceQuery()
+
+@pytest.fixture
+def query_requires_payment():
+    """Fixture for a query that requires payment"""
+    query = TokenInfoQuery()
+    return query
 
 def test_query_initialization(query):
     """Test Query initialization with default values"""
@@ -16,8 +27,7 @@ def test_query_initialization(query):
     assert query.node_account_ids == []
     assert query.operator is None
     assert query.node_index == 0
-    assert query._user_query_payment is None
-    assert query._default_query_payment.to_tinybars() == Hbar(1).to_tinybars()
+    assert query.payment_amount is None
 
 def test_set_query_payment(query):
     """Test setting custom query payment"""
@@ -25,22 +35,37 @@ def test_set_query_payment(query):
     result = query.set_query_payment(payment)
     
     assert result == query
-    assert query._user_query_payment == payment
-
-def test_before_execute_sets_defaults(query, mock_client):
-    """Test _before_execute method setup"""
+    assert query.payment_amount == payment
+    
+def test_before_execute_payment_not_required(query, mock_client):
+    """Test _before_execute method setup for query that doesn't require payment"""
+    # payment_amount is None, should not set payment_amount
     query._before_execute(mock_client)
     
     assert query.node_account_ids == mock_client.get_node_account_ids()
     assert query.operator == mock_client.operator
-    assert query._user_query_payment == query._default_query_payment
+    assert query.payment_amount is None
+
+def test_before_execute_payment_required(query_requires_payment, mock_client):
+    """Test _before_execute method setup for query that requires payment"""
+    # get_cost() should return Hbar(2)
+    mock_get_cost = MagicMock()
+    mock_get_cost.return_value = Hbar(2)
+    query_requires_payment.get_cost = mock_get_cost
     
-    # Verify the custom payment is used and default is not
-    payment = Hbar(2)
-    query.set_query_payment(payment)
-    query._before_execute(mock_client)
+    # payment_amount is None, should set payment_amount to 2 Hbars
+    query_requires_payment._before_execute(mock_client)
     
-    assert query._user_query_payment == payment
+    assert query_requires_payment.node_account_ids == mock_client.get_node_account_ids()
+    assert query_requires_payment.operator == mock_client.operator
+    assert query_requires_payment.payment_amount.to_tinybars() == Hbar(2).to_tinybars()
+
+    # payment_amount is set, should not set payment_amount to 1 Hbars
+    mock_get_cost.return_value = Hbar(1)
+    query_requires_payment.get_cost = mock_get_cost
+    query_requires_payment._before_execute(mock_client)
+    
+    assert query_requires_payment.payment_amount.to_tinybars() == Hbar(2).to_tinybars()
 
 def test_request_header_no_fields_set(query):
     """Test combinations with no fields set"""
@@ -50,7 +75,7 @@ def test_request_header_no_fields_set(query):
 def test_request_header_payment_set(query, mock_client):
     """Test combinations with payment set"""
     # Test with only query payment set
-    query._user_query_payment = Hbar(1)
+    query.payment_amount = Hbar(1)
     header = query._make_request_header()
     assert not header.HasField('payment'), "Payment field should not be present when only query payment is set"
     
@@ -68,7 +93,7 @@ def test_request_header_node_account_set(query, mock_client):
     assert not header.HasField('payment'), "Payment field should not be present when only node account is set"
 
     # Test with node account and query payment set
-    query._user_query_payment = Hbar(1)
+    query.payment_amount = Hbar(1)
     header = query._make_request_header()
     assert not header.HasField('payment'), "Payment field should not be present when only node account and payment are set"
 
@@ -145,3 +170,44 @@ def test_should_retry_error_status(query):
     
     result = query._should_retry(response)
     assert result == _ExecutionState.ERROR
+    
+def test_get_cost_when_payment_not_required(query, mock_client):
+    """Test get_cost when payment is not required and is set or not set"""
+    # Test without payment_amount
+    result = query.get_cost(mock_client)
+    assert result.to_tinybars() == Hbar(0).to_tinybars()
+
+    # Test with payment_amount
+    query.set_query_payment(Hbar(2))
+    result = query.get_cost(mock_client)
+    assert result.to_tinybars() == Hbar(2).to_tinybars()
+
+def test_get_cost_when_payment_required_and_set(query_requires_payment, mock_client):
+    """Test get_cost when payment is required and set"""
+    query_requires_payment.set_query_payment(Hbar(2))
+    result = query_requires_payment.get_cost(mock_client)
+    assert result.to_tinybars() == Hbar(2).to_tinybars()
+    
+def test_get_cost_when_payment_required_and_not_set(query_requires_payment, token_id):
+    """Test get_cost when payment is required and not set"""
+    
+    # Create mock response containing cost information (2 tinybars) for token info query
+    response = response_pb2.Response(
+        tokenGetInfo=token_get_info_pb2.TokenGetInfoResponse(
+            header=response_header_pb2.ResponseHeader(
+                nodeTransactionPrecheckCode=ResponseCode.OK,
+                responseType=query_header_pb2.ResponseType.COST_ANSWER,
+                cost=2
+            )
+        )
+    )
+    
+    response_sequences = [[response]]
+    
+    with mock_hedera_servers(response_sequences) as client:
+        # Need to set token_id before getting cost, otherwise will fail
+        query_requires_payment.set_token_id(token_id)
+        result = query_requires_payment.get_cost(client)
+        # Verify cost matches expected value of 2 tinybars
+        assert result.to_tinybars() == 2
+    

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -205,7 +205,7 @@ def test_get_cost_when_payment_not_required(query, mock_client):
     # Test with payment_amount
     query.set_query_payment(Hbar(2))
     result = query.get_cost(mock_client)
-    assert result.to_tinybars() == Hbar(2).to_tinybars()
+    assert result.to_tinybars() == Hbar(0).to_tinybars()
 
 def test_get_cost_when_payment_required_and_set(query_requires_payment, mock_client):
     """Test get_cost when payment is required and set"""

--- a/tests/unit/test_token_info_query.py
+++ b/tests/unit/test_token_info_query.py
@@ -64,7 +64,26 @@ def test_token_info_query_execute(mock_account_ids, private_key):
         wipeKey=private_key.public_key().to_proto(),
     )
 
-    response = response_pb2.Response(
+    responses = [
+        response_pb2.Response(
+            tokenGetInfo=token_get_info_pb2.TokenGetInfoResponse(
+                header=response_header_pb2.ResponseHeader(
+                    nodeTransactionPrecheckCode=ResponseCode.OK,
+                    responseType=ResponseType.COST_ANSWER,
+                    cost=2
+                )
+            )
+        ),
+        response_pb2.Response(
+            tokenGetInfo=token_get_info_pb2.TokenGetInfoResponse(
+                header=response_header_pb2.ResponseHeader(
+                    nodeTransactionPrecheckCode=ResponseCode.OK,
+                    responseType=ResponseType.COST_ANSWER,
+                    cost=2
+                )
+            )
+        ),
+        response_pb2.Response(
             tokenGetInfo=token_get_info_pb2.TokenGetInfoResponse(
                 header=response_header_pb2.ResponseHeader(
                     nodeTransactionPrecheckCode=ResponseCode.OK,
@@ -74,13 +93,18 @@ def test_token_info_query_execute(mock_account_ids, private_key):
                 tokenInfo=token_info_response
             )
         )
+    ]
     
-    response_sequences = [[response]]
+    response_sequences = [responses]
     
     with mock_hedera_servers(response_sequences) as client:
         query = TokenInfoQuery(token_id)
         
         try:
+            # Get the cost of executing the query - should be 2 tinybars based on the mock response
+            cost = query.get_cost(client)
+            assert cost.to_tinybars() == 2
+            
             result = query.execute(client)
         except Exception as e:
             pytest.fail(f"Unexpected exception raised: {e}")

--- a/tests/unit/test_token_nft_info_query.py
+++ b/tests/unit/test_token_nft_info_query.py
@@ -1,6 +1,7 @@
 import pytest
-from unittest.mock import patch, Mock
+from unittest.mock import Mock
 
+from hiero_sdk_python.hapi.services.query_header_pb2 import ResponseType
 from hiero_sdk_python.query.token_nft_info_query import TokenNftInfoQuery
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.hapi.services import (
@@ -65,24 +66,47 @@ def test_execute_token_nft_info_query(nft_id):
         creationTime=timestamp_pb2.Timestamp(seconds=1623456789),
         metadata=b'metadata'
     )
-    
-    response = response_pb2.Response(
-        tokenGetNftInfo=token_get_nft_info_pb2.TokenGetNftInfoResponse(
-            header=response_header_pb2.ResponseHeader(
-                nodeTransactionPrecheckCode=ResponseCode.OK,
-                responseType=2,
-                cost=0
-            ),
-            nft=nft_info_response
+    responses = [
+        response_pb2.Response(
+            tokenGetNftInfo=token_get_nft_info_pb2.TokenGetNftInfoResponse(
+                header=response_header_pb2.ResponseHeader(
+                    nodeTransactionPrecheckCode=ResponseCode.OK,
+                    responseType=ResponseType.COST_ANSWER,
+                    cost=2
+                )
+            )
+        ),
+        response_pb2.Response(
+            tokenGetNftInfo=token_get_nft_info_pb2.TokenGetNftInfoResponse(
+                header=response_header_pb2.ResponseHeader(
+                    nodeTransactionPrecheckCode=ResponseCode.OK,
+                    responseType=ResponseType.COST_ANSWER,
+                    cost=2
+                )
+            )
+        ),
+        response_pb2.Response(
+            tokenGetNftInfo=token_get_nft_info_pb2.TokenGetNftInfoResponse(
+                header=response_header_pb2.ResponseHeader(
+                    nodeTransactionPrecheckCode=ResponseCode.OK,
+                    responseType=ResponseType.ANSWER_ONLY,
+                    cost=2
+                ),
+                nft=nft_info_response
+            )
         )
-    )
+    ]
     
-    response_sequences = [[response]]
+    response_sequences = [responses]
     
     with mock_hedera_servers(response_sequences) as client:
         query = TokenNftInfoQuery().set_nft_id(nft_id)
         
         try:
+            # Get the cost of executing the query - should be 2 tinybars based on the mock response
+            cost = query.get_cost(client)
+            assert cost.to_tinybars() == 2
+            
             result = query.execute(client)
         except Exception as e:
             pytest.fail(f"Unexpected exception raised: {e}")


### PR DESCRIPTION
**Description**:
Implement the proper cost calculation and payment handling for queries, ensuring that paid queries are properly charged while free queries (like account balance) remain free.

* Add `_is_payment_required()` in `Query` base class to tell which queries require payment and which don't
* Add `get_cost()` functionality to calculate query execution costs
* Update `_make_request_header()` to return `COST_ANSWER` header if there isn't a user query payment set and payment is required for the query
* Remove hardcoded transaction fee for `TokenTransfer`
* Update unit tests
* Rename `_user_query_payment` to `payment_amount`
* Add integration tests

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
When a query requires payment but no payment amount is specified, the following flow occurs:

1. `_before_execute()` checks if `payment_amount` is not set and `_is_payment_required()` is true
2. If both conditions are met, it calls `_get_cost()` to determine the actual cost
3. `get_cost()` executes the query with a special cost calculation flow:
   - `_make_request()` creates the proto query
   - `_make_request_header()` returns a `COST_ANSWER` header (instead of `ANSWER_ONLY`) because `payment_amount` is not set and `_is_payment_required()` is true
4. The query is executed with `COST_ANSWER` header to get the cost
5. The returned cost is set as `payment_amount`
6. The query is then executed normally with the proper payment amount

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
