### PR TITLE
feat: add `TokenRevokeKycTransaction`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -32,6 +32,7 @@ You can choose either syntax or even mix both styles in your projects.
   - [Token Update NFTs](#token-update-nfts)
   - [Pausing a Token](#pausing-a-token)
   - [Token Grant KYC](#token-grant-kyc)
+  - [Token Revoke KYC](#token-revoke-kyc)
   - [Querying NFT Info](#querying-nft-info)
   - [Querying Fungible Token Info](#querying-fungible-token-info)
 - [HBAR Transactions](#hbar-transactions)
@@ -577,6 +578,31 @@ transaction.execute(client)
         .set_account_id(account_id)
         .freeze_with(client)
         .sign(kyc_key)   # KYC key is required for granting KYC approval
+    )
+
+    transaction.execute(client)
+```
+
+### Token Revoke KYC
+
+#### Pythonic Syntax:
+```
+transaction = TokenRevokeKycTransaction(
+    token_id=token_id,
+    account_id=account_id
+).freeze_with(client)
+
+transaction.sign(kyc_key)   # KYC key is required for revoking KYC approval
+transaction.execute(client)
+```
+#### Method Chaining:
+```
+    transaction = (
+        TokenRevokeKycTransaction()
+        .set_token_id(token_id)
+        .set_account_id(account_id)
+        .freeze_with(client)
+        .sign(kyc_key)   # KYC key is required for revoking KYC approval
     )
 
     transaction.execute(client)

--- a/examples/token_revoke_kyc.py
+++ b/examples/token_revoke_kyc.py
@@ -50,7 +50,7 @@ def create_fungible_token(client, operator_id, operator_key, kyc_private_key):
     )
     
     if receipt.status != ResponseCode.SUCCESS:
-        print(f"Fungible token creation failed with status: {ResponseCode.get_name(receipt.status)}")
+        print(f"Fungible token creation failed with status: {ResponseCode(receipt.status).name}")
         sys.exit(1)
     
     token_id = receipt.tokenId

--- a/examples/token_revoke_kyc.py
+++ b/examples/token_revoke_kyc.py
@@ -1,0 +1,168 @@
+import os
+import sys
+from dotenv import load_dotenv
+
+from hiero_sdk_python import (
+    Client,
+    AccountId,
+    PrivateKey,
+    Network,
+)
+from hiero_sdk_python.account.account_create_transaction import AccountCreateTransaction
+from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenType
+from hiero_sdk_python.hbar import Hbar
+from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.tokens.supply_type import SupplyType
+from hiero_sdk_python.tokens.token_associate_transaction import TokenAssociateTransaction
+from hiero_sdk_python.tokens.token_grant_kyc_transaction import TokenGrantKycTransaction
+from hiero_sdk_python.tokens.token_revoke_kyc_transaction import TokenRevokeKycTransaction
+from hiero_sdk_python.tokens.token_create_transaction import TokenCreateTransaction
+
+load_dotenv()
+
+def setup_client():
+    """Initialize and set up the client with operator account"""
+    network = Network(network='testnet')
+    client = Client(network)
+
+    operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
+    operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+    client.set_operator(operator_id, operator_key)
+    
+    return client, operator_id, operator_key
+
+def create_fungible_token(client, operator_id, operator_key, kyc_private_key):
+    """Create a fungible token"""
+    receipt = (
+        TokenCreateTransaction()
+        .set_token_name("MyExampleFT")
+        .set_token_symbol("EXFT")
+        .set_decimals(2)
+        .set_initial_supply(100)
+        .set_treasury_account_id(operator_id)
+        .set_token_type(TokenType.FUNGIBLE_COMMON)
+        .set_supply_type(SupplyType.FINITE)
+        .set_max_supply(1000)
+        .set_admin_key(operator_key)
+        .set_supply_key(operator_key)
+        .set_kyc_key(kyc_private_key)  # Required key for granting/revoking KYC approval to accounts
+        .execute(client)
+    )
+    
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Fungible token creation failed with status: {ResponseCode.get_name(receipt.status)}")
+        sys.exit(1)
+    
+    token_id = receipt.tokenId
+    print(f"Fungible token created with ID: {token_id}")
+    
+    return token_id
+
+def associate_token(client, token_id, account_id, account_private_key):
+    """Associate a token with an account"""
+    associate_transaction = (
+        TokenAssociateTransaction()
+        .set_account_id(account_id)
+        .add_token_id(token_id)
+        .freeze_with(client)
+        .sign(account_private_key) # Has to be signed by new account's key
+    )
+    
+    receipt = associate_transaction.execute(client)
+    
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Token association failed with status: {ResponseCode.get_name(receipt.status)}")
+        sys.exit(1)
+    
+    print("Token successfully associated with account")
+
+def create_test_account(client):
+    """Create a new account for testing"""
+    # Generate private key for new account
+    new_account_private_key = PrivateKey.generate()
+    new_account_public_key = new_account_private_key.public_key()
+    
+    # Create new account with initial balance of 1 HBAR
+    transaction = (
+        AccountCreateTransaction()
+        .set_key(new_account_public_key)
+        .set_initial_balance(Hbar(1))
+        .freeze_with(client)
+    )
+    
+    receipt = transaction.execute(client)
+    
+    # Check if account creation was successful
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}")
+        sys.exit(1)
+    
+    # Get account ID from receipt
+    account_id = receipt.accountId
+    print(f"New account created with ID: {account_id}")
+    
+    return account_id, new_account_private_key
+
+def grant_kyc(client, token_id, account_id, kyc_private_key):
+    """Grant KYC to an account"""
+    receipt = (
+        TokenGrantKycTransaction()
+        .set_token_id(token_id)
+        .set_account_id(account_id)
+        .freeze_with(client)
+        .sign(kyc_private_key)  # Has to be signed by the KYC key
+        .execute(client)
+    )
+    
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Token grant KYC failed with status: {ResponseCode.get_name(receipt.status)}")
+        sys.exit(1)
+    
+    print(f"Granted KYC for account {account_id} on token {token_id}")
+
+def token_revoke_kyc():
+    """
+    Demonstrates the token revoke KYC functionality by:
+    1. Setting up client with operator account
+    2. Creating a fungible token with KYC key
+    3. Creating a new account
+    4. Associating the token with the new account
+    5. Granting KYC to the new account
+    6. Revoking KYC from the new account
+    """
+    client, operator_id, operator_key = setup_client()
+    
+    # Create KYC key
+    kyc_private_key = PrivateKey.generate_ed25519()
+    
+    # Create a fungible token with KYC key
+    token_id = create_fungible_token(client, operator_id, operator_key, kyc_private_key)
+    
+    # Create a new account
+    account_id, account_private_key = create_test_account(client)
+    
+    # Associate the token with the new account
+    associate_token(client, token_id, account_id, account_private_key)
+    
+    # Grant KYC to the new account first
+    grant_kyc(client, token_id, account_id, kyc_private_key)
+    
+    # Revoke KYC from the new account
+    receipt = (
+        TokenRevokeKycTransaction()
+        .set_token_id(token_id)
+        .set_account_id(account_id)
+        .freeze_with(client)
+        .sign(kyc_private_key)  # Has to be signed by the KYC key
+        .execute(client)
+    )
+    
+    # Check if the transaction was successful
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Token revoke KYC failed with status: {ResponseCode.get_name(receipt.status)}")
+        sys.exit(1)
+    
+    print(f"Revoked KYC for account {account_id} on token {token_id}")
+
+if __name__ == "__main__":
+    token_revoke_kyc() 

--- a/src/hiero_sdk_python/__init__.py
+++ b/src/hiero_sdk_python/__init__.py
@@ -24,6 +24,7 @@ from .tokens.token_reject_transaction import TokenRejectTransaction
 from .tokens.token_update_nfts_transaction import TokenUpdateNftsTransaction
 from .tokens.token_burn_transaction import TokenBurnTransaction
 from .tokens.token_grant_kyc_transaction import TokenGrantKycTransaction
+from .tokens.token_revoke_kyc_transaction import TokenRevokeKycTransaction
 from .tokens.token_id import TokenId
 from .tokens.nft_id import NftId
 from .tokens.token_nft_transfer import TokenNftTransfer
@@ -102,6 +103,7 @@ __all__ = [
     "TokenUpdateNftsTransaction",
     "TokenBurnTransaction",
     "TokenGrantKycTransaction",
+    "TokenRevokeKycTransaction",
 
     # Transaction
     "TransferTransaction",

--- a/src/hiero_sdk_python/tokens/token_revoke_kyc_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_revoke_kyc_transaction.py
@@ -1,0 +1,111 @@
+from hiero_sdk_python.hapi.services.token_revoke_kyc_pb2 import TokenRevokeKycTransactionBody
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.channels import _Channel
+from hiero_sdk_python.executable import _Method
+from hiero_sdk_python.tokens.token_id import TokenId
+from hiero_sdk_python.account.account_id import AccountId
+
+class TokenRevokeKycTransaction(Transaction):
+    """
+    Represents a token revoke KYC transaction on the network.
+    
+    This transaction revokes KYC (Know Your Customer) status from an account for a specific token.
+    
+    Inherits from the base Transaction class and implements the required methods
+    to build and execute a token revoke KYC transaction.
+    """
+    def __init__(self, token_id: TokenId = None, account_id: AccountId = None):
+        """
+        Initializes a new TokenRevokeKycTransaction instance with the token ID and account ID.
+
+        Args:
+            token_id (TokenId, optional): The ID of the token to revoke KYC from.
+            account_id (AccountId, optional): The ID of the account to revoke KYC from.
+        """
+        super().__init__()
+        self.token_id: TokenId = token_id
+        self.account_id: AccountId = account_id
+    
+    def set_token_id(self, token_id: TokenId):
+        """
+        Sets the token ID for this revoke KYC transaction.
+
+        Args:
+            token_id (TokenId): The ID of the token to revoke KYC from.
+
+        Returns:
+            TokenRevokeKycTransaction: This transaction instance.
+        """
+        self._require_not_frozen()
+        self.token_id = token_id
+        return self
+    
+    def set_account_id(self, account_id: AccountId):
+        """
+        Sets the account ID for this revoke KYC transaction.
+
+        Args:
+            account_id (AccountId): The ID of the account to revoke KYC from.
+
+        Returns:
+            TokenRevokeKycTransaction: This transaction instance.
+        """
+        self._require_not_frozen()
+        self.account_id = account_id
+        return self
+    
+    def build_transaction_body(self):
+        """
+        Builds the transaction body for this token revoke KYC transaction.
+
+        Returns:
+            TransactionBody: The built transaction body.
+            
+        Raises:
+            ValueError: If the token ID or account ID is not set.
+        """
+        if self.token_id is None:
+            raise ValueError("Missing token ID")
+        
+        if self.account_id is None:
+            raise ValueError("Missing account ID")
+        
+        token_revoke_kyc_body = TokenRevokeKycTransactionBody(
+            token=self.token_id._to_proto(),
+            account=self.account_id._to_proto()
+        )
+        transaction_body = self.build_base_transaction_body()
+        transaction_body.tokenRevokeKyc.CopyFrom(token_revoke_kyc_body)
+        return transaction_body
+    
+    def _get_method(self, channel: _Channel) -> _Method:
+        """
+        Gets the method to execute the token revoke KYC transaction.
+
+        This internal method returns a _Method object containing the appropriate gRPC
+        function to call when executing this transaction on the Hedera network.
+
+        Args:
+            channel (_Channel): The channel containing service stubs
+        
+        Returns:
+            _Method: An object containing the transaction function to revoke KYC.
+        """
+        return _Method(
+            transaction_func=channel.token.revokeKycFromTokenAccount,
+            query_func=None
+        )
+
+    def _from_proto(self, proto: TokenRevokeKycTransactionBody):
+        """
+        Initializes a new TokenRevokeKycTransaction instance from a protobuf object.
+
+        Args:
+            proto (TokenRevokeKycTransactionBody): The protobuf object to initialize from.
+
+        Returns:
+            TokenRevokeKycTransaction: This transaction instance.
+        """
+        self.token_id = TokenId._from_proto(proto.token)
+        self.account_id = AccountId._from_proto(proto.account)
+        return self 

--- a/tests/integration/token_revoke_kyc_transaction_e2e_test.py
+++ b/tests/integration/token_revoke_kyc_transaction_e2e_test.py
@@ -1,0 +1,146 @@
+import pytest
+
+from hiero_sdk_python.crypto.private_key import PrivateKey
+from hiero_sdk_python.hbar import Hbar
+from hiero_sdk_python.tokens.token_associate_transaction import TokenAssociateTransaction
+from hiero_sdk_python.account.account_create_transaction import AccountCreateTransaction
+from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.tokens.token_grant_kyc_transaction import TokenGrantKycTransaction
+from hiero_sdk_python.tokens.token_revoke_kyc_transaction import TokenRevokeKycTransaction
+from tests.integration.utils_for_test import IntegrationTestEnv, create_fungible_token
+
+@pytest.mark.integration
+def test_token_revoke_kyc_transaction_can_execute():
+    env = IntegrationTestEnv()
+    
+    try:
+        new_account_private_key = PrivateKey.generate_ed25519()
+        new_account_public_key = new_account_private_key.public_key()
+        
+        # Create a new account
+        receipt = (
+            AccountCreateTransaction()
+            .set_key(new_account_public_key)
+            .set_initial_balance(Hbar(2))
+            .execute(env.client)
+        )
+        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        account_id = receipt.accountId
+
+        # Create a new token and set the kyc key to be the operator's key
+        token_id = create_fungible_token(env, [lambda tx: tx.set_kyc_key(env.operator_key)])
+        
+        # Associate the token to the new account
+        receipt = (
+            TokenAssociateTransaction()
+            .set_account_id(account_id)
+            .add_token_id(token_id)
+            .freeze_with(env.client)
+            .sign(new_account_private_key)
+            .execute(env.client)
+        )
+        assert receipt.status == ResponseCode.SUCCESS, f"Token association failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Grant KYC to the new account first
+        receipt = (
+            TokenGrantKycTransaction()
+            .set_account_id(account_id)
+            .set_token_id(token_id)
+            .execute(env.client)
+        )
+        assert receipt.status == ResponseCode.SUCCESS, f"Token grant KYC failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Revoke KYC from the new account
+        receipt = (
+            TokenRevokeKycTransaction()
+            .set_account_id(account_id)
+            .set_token_id(token_id)
+            .execute(env.client)
+        )
+        assert receipt.status == ResponseCode.SUCCESS, f"Token revoke KYC failed with status: {ResponseCode.get_name(receipt.status)}"
+    finally:
+        env.close()
+
+@pytest.mark.integration
+def test_token_revoke_kyc_transaction_fails_with_no_kyc_key():
+    env = IntegrationTestEnv()
+    
+    try:
+        new_account_private_key = PrivateKey.generate_ed25519()
+        new_account_public_key = new_account_private_key.public_key()
+        
+        # Create a new account
+        receipt = (
+            AccountCreateTransaction()
+            .set_key(new_account_public_key)
+            .set_initial_balance(Hbar(2))
+            .execute(env.client)
+        )
+        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        account_id = receipt.accountId
+        
+        # Create a new token without KYC key
+        token_id = create_fungible_token(env)
+        
+        # Associate the token to the new account
+        receipt = (
+            TokenAssociateTransaction()
+            .set_account_id(account_id)
+            .add_token_id(token_id)
+            .freeze_with(env.client)
+            .sign(new_account_private_key)
+            .execute(env.client)
+        )
+        assert receipt.status == ResponseCode.SUCCESS, f"Token association failed with status: {ResponseCode.get_name(receipt.status)}"
+        
+        # Try to revoke KYC for token without KYC key - should fail with TOKEN_HAS_NO_KYC_KEY
+        receipt = (
+            TokenRevokeKycTransaction()
+            .set_account_id(account_id)
+            .set_token_id(token_id)
+            .execute(env.client)
+        )
+        assert receipt.status == ResponseCode.TOKEN_HAS_NO_KYC_KEY, f"Token revoke KYC should have failed with TOKEN_HAS_NO_KYC_KEY status but got: {ResponseCode.get_name(receipt.status)}"
+        
+        # Try to revoke KYC with non-KYC key - should fail with TOKEN_HAS_NO_KYC_KEY
+        receipt = (
+            TokenRevokeKycTransaction()
+            .set_account_id(account_id)
+            .set_token_id(token_id)
+            .execute(env.client)
+        )
+        assert receipt.status == ResponseCode.TOKEN_HAS_NO_KYC_KEY, f"Token revoke KYC should have failed with TOKEN_HAS_NO_KYC_KEY status but got: {ResponseCode.get_name(receipt.status)}"
+    finally:
+        env.close()
+        
+@pytest.mark.integration
+def test_token_revoke_kyc_transaction_fails_when_account_not_associated():
+    env = IntegrationTestEnv()
+    
+    try:
+        new_account_private_key = PrivateKey.generate_ed25519()
+        new_account_public_key = new_account_private_key.public_key()
+        
+        # Create a new account
+        receipt = (
+            AccountCreateTransaction()
+            .set_key(new_account_public_key)
+            .set_initial_balance(Hbar(2))
+            .execute(env.client)
+        )
+        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        account_id = receipt.accountId
+        
+        # Create a new token and set the kyc key to be the operator's key
+        token_id = create_fungible_token(env, [lambda tx: tx.set_kyc_key(env.operator_key)])
+        
+        # Revoke KYC from the new account - should fail with TOKEN_NOT_ASSOCIATED_TO_ACCOUNT
+        receipt = (
+            TokenRevokeKycTransaction()
+            .set_account_id(account_id)
+            .set_token_id(token_id)
+            .execute(env.client)
+        )
+        assert receipt.status == ResponseCode.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT, f"Token revoke KYC should have failed with TOKEN_NOT_ASSOCIATED_TO_ACCOUNT status but got: {ResponseCode.get_name(receipt.status)}"
+    finally:
+        env.close()

--- a/tests/unit/test_token_revoke_kyc_transaction.py
+++ b/tests/unit/test_token_revoke_kyc_transaction.py
@@ -1,0 +1,151 @@
+import pytest
+
+from hiero_sdk_python.hapi.services.token_revoke_kyc_pb2 import TokenRevokeKycTransactionBody
+from hiero_sdk_python.hapi.services.transaction_receipt_pb2 import TransactionReceipt as TransactionReceiptProto
+from hiero_sdk_python.hapi.services.transaction_response_pb2 import TransactionResponse as TransactionResponseProto
+from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.tokens.token_revoke_kyc_transaction import TokenRevokeKycTransaction
+from hiero_sdk_python.hapi.services import response_header_pb2, response_pb2, transaction_get_receipt_pb2
+from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.tokens.token_id import TokenId
+
+from tests.unit.mock_server import mock_hedera_servers
+
+pytestmark = pytest.mark.unit
+
+def test_build_transaction_body(mock_account_ids):
+    """Test building a token revoke KYC transaction body with valid values."""
+    account_id, _, node_account_id, token_id, _ = mock_account_ids
+    
+    revoke_kyc_tx = (
+        TokenRevokeKycTransaction()
+        .set_token_id(token_id)
+        .set_account_id(account_id)
+    )
+    
+    # Set operator and node account IDs needed for building transaction body
+    revoke_kyc_tx.operator_account_id = account_id
+    revoke_kyc_tx.node_account_id = node_account_id
+    
+    transaction_body = revoke_kyc_tx.build_transaction_body()
+    
+    assert transaction_body.tokenRevokeKyc.token == token_id._to_proto()
+    assert transaction_body.tokenRevokeKyc.account == account_id._to_proto()
+
+def test_build_transaction_body_validation(mock_account_ids):
+    """Test validation when building transaction body."""
+    account_id, _, _, token_id, _ = mock_account_ids
+    
+    # Test missing token ID
+    revoke_kyc_tx = TokenRevokeKycTransaction(account_id=account_id)
+    
+    with pytest.raises(ValueError, match="Missing token ID"):
+        revoke_kyc_tx.build_transaction_body()
+        
+    # Test missing account ID
+    revoke_kyc_tx = TokenRevokeKycTransaction(token_id=token_id)
+    
+    with pytest.raises(ValueError, match="Missing account ID"):
+        revoke_kyc_tx.build_transaction_body()
+
+def test_constructor_with_parameters(mock_account_ids):
+    """Test creating a token revoke KYC transaction with constructor parameters."""
+    account_id, _, _, token_id, _ = mock_account_ids
+
+    revoke_kyc_tx = TokenRevokeKycTransaction(
+        token_id=token_id,
+        account_id=account_id
+    )
+
+    assert revoke_kyc_tx.token_id == token_id
+    assert revoke_kyc_tx.account_id == account_id
+
+def test_set_methods(mock_account_ids):
+    """Test the set methods of TokenRevokeKycTransaction."""
+    account_id, _, _, token_id, _ = mock_account_ids
+    
+    revoke_kyc_tx = TokenRevokeKycTransaction()
+    
+    # Test method chaining
+    tx_after_set = revoke_kyc_tx.set_token_id(token_id)
+    assert tx_after_set is revoke_kyc_tx
+    assert revoke_kyc_tx.token_id == token_id
+    
+    tx_after_set = revoke_kyc_tx.set_account_id(account_id)
+    assert tx_after_set is revoke_kyc_tx
+    assert revoke_kyc_tx.account_id == account_id
+
+def test_set_methods_require_not_frozen(mock_account_ids, mock_client):
+    """Test that set methods raise exception when transaction is frozen."""
+    account_id, _, _, token_id, _ = mock_account_ids
+    
+    revoke_kyc_tx = TokenRevokeKycTransaction(token_id=token_id, account_id=account_id)
+    revoke_kyc_tx.freeze_with(mock_client)
+    
+    with pytest.raises(Exception, match="Transaction is immutable; it has been frozen"):
+        revoke_kyc_tx.set_token_id(token_id)
+    
+    with pytest.raises(Exception, match="Transaction is immutable; it has been frozen"):
+        revoke_kyc_tx.set_account_id(account_id)
+
+def test_revoke_kyc_transaction_can_execute(mock_account_ids):
+    """Test that a revoke KYC transaction can be executed successfully."""
+    account_id, _, _, token_id, _ = mock_account_ids
+    
+    # Create test transaction responses
+    ok_response = TransactionResponseProto()
+    ok_response.nodeTransactionPrecheckCode = ResponseCode.OK
+    
+    # Create a mock receipt for a successful token revoke KYC
+    mock_receipt_proto = TransactionReceiptProto(
+        status=ResponseCode.SUCCESS
+    )
+    
+    # Create a response for the receipt query
+    receipt_query_response = response_pb2.Response(
+        transactionGetReceipt=transaction_get_receipt_pb2.TransactionGetReceiptResponse(
+            header=response_header_pb2.ResponseHeader(
+                nodeTransactionPrecheckCode=ResponseCode.OK
+            ),
+            receipt=mock_receipt_proto
+        )
+    )
+    
+    response_sequences = [
+        [ok_response, receipt_query_response],
+    ]
+    
+    with mock_hedera_servers(response_sequences) as client:
+        transaction = (
+            TokenRevokeKycTransaction()
+            .set_token_id(token_id)
+            .set_account_id(account_id)
+        )
+        
+        receipt = transaction.execute(client)
+        
+        assert receipt.status == ResponseCode.SUCCESS, "Transaction should have succeeded"
+
+def test_revoke_kyc_transaction_from_proto(mock_account_ids):
+    """Test that a revoke KYC transaction can be created from a protobuf object."""
+    account_id, _, _, token_id, _ = mock_account_ids
+    
+    # Create protobuf object
+    proto = TokenRevokeKycTransactionBody(
+        token=token_id._to_proto(),
+        account=account_id._to_proto()
+    )
+    
+    # Deserialize the protobuf object
+    from_proto = TokenRevokeKycTransaction()._from_proto(proto)
+    
+    # Verify deserialized transaction matches original data
+    assert from_proto.token_id == token_id
+    assert from_proto.account_id == account_id
+    
+    # Deserialize empty protobuf
+    from_proto = TokenRevokeKycTransaction()._from_proto(TokenRevokeKycTransactionBody())
+    
+    # Verify empty protobuf deserializes to empty/default values
+    assert from_proto.token_id == TokenId(0,0,0)
+    assert from_proto.account_id == AccountId() 


### PR DESCRIPTION
**Description**:
Implemented the `TokenRevokeKycTransaction` class that enables revoking KYC approval from accounts for specific tokens.

* Add `TokenRevokeKycTransaction` class implementation
* Add token revoke KYC example
* Add integration/unit tests for `TokenRevokeKycTransaction`
* Update `README.md` in examples folder
* Update `__init__.py` file with `TokenRevokeKycTransaction` class definition in `__all__` list

**Related issue(s)**:

Fixes #133

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
