### PR TITLE
feat: add `TransactionRecordQuery`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -43,6 +43,8 @@ You can choose either syntax or even mix both styles in your projects.
   - [Deleting a Topic](#deleting-a-topic)
   - [Querying Topic](#querying-topic)
   - [Querying Topic Message](#querying-topic-message)
+- [Miscellaneous Queries](#miscellaneous-queries)
+  - [Querying Transaction Record](#querying-transaction-record)
 
 
 ## Account Transactions
@@ -801,4 +803,37 @@ query = (
     )
 
 query.subscribe(client)
+```
+
+## Miscellaneous Queries
+
+### Querying Transaction Record
+
+#### Pythonic Syntax:
+```
+query = TransactionRecordQuery(
+    transaction_id=transaction_id
+)
+
+record = query.execute(client)
+
+print(f"Transaction ID: {record.transaction_id}")
+print(f"Transaction Fee: {record.transaction_fee}")
+print(f"Transaction Hash: {record.transaction_hash}")
+print(f"Transaction Memo: {record.transaction_memo}")
+print(f"Transaction Account ID: {record.receipt.accountId}")
+```
+#### Method Chaining:
+```
+record = (
+    TransactionRecordQuery()
+    .set_transaction_id(transaction_id)
+    .execute(client)
+)
+
+print(f"Transaction ID: {record.transaction_id}")
+print(f"Transaction Fee: {record.transaction_fee}")
+print(f"Transaction Hash: {record.transaction_hash}")
+print(f"Transaction Memo: {record.transaction_memo}")
+print(f"Transaction Account ID: {record.receipt.accountId}")
 ```

--- a/examples/query_record.py
+++ b/examples/query_record.py
@@ -1,0 +1,180 @@
+import os
+import sys
+from dotenv import load_dotenv
+
+from hiero_sdk_python import (
+    Client,
+    AccountId,
+    PrivateKey,
+    Network,
+    Hbar,
+)
+from hiero_sdk_python.account.account_create_transaction import AccountCreateTransaction
+from hiero_sdk_python.query.transaction_record_query import TransactionRecordQuery
+from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.tokens.supply_type import SupplyType
+from hiero_sdk_python.tokens.token_associate_transaction import TokenAssociateTransaction
+from hiero_sdk_python.tokens.token_create_transaction import TokenCreateTransaction
+from hiero_sdk_python.tokens.token_type import TokenType
+from hiero_sdk_python.transaction.transfer_transaction import TransferTransaction
+
+load_dotenv()
+
+def setup_client():
+    """Initialize and set up the client with operator account"""
+    # Initialize network and client
+    network = Network(network='testnet')
+    client = Client(network)
+
+    # Set up operator account
+    operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
+    operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+    client.set_operator(operator_id, operator_key)
+    
+    return client, operator_id, operator_key
+
+def create_account_transaction(client):
+    """Create a new account to get a transaction ID for record query"""
+    # Generate a new key pair for the account
+    new_account_key = PrivateKey.generate_ed25519()
+    
+    # Create the account
+    receipt = (
+        AccountCreateTransaction()
+        .set_key(new_account_key.public_key())
+        .set_initial_balance(Hbar(1))
+        .execute(client)
+    )
+    
+    # Check if account creation was successful
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Account creation failed with status: {ResponseCode(receipt.status).name}")
+        sys.exit(1)
+    
+    # Get the new account ID and transaction ID from receipt
+    new_account_id = receipt.accountId
+    transaction_id = receipt.transaction_id
+    
+    print(f"Account created with ID: {new_account_id}")
+    
+    return new_account_id, new_account_key, transaction_id
+
+def create_fungible_token(client: 'Client', account_id, account_private_key):
+    """Create a fungible token"""
+    receipt = (
+        TokenCreateTransaction()
+        .set_token_name("MyExampleFT")
+        .set_token_symbol("EXFT")
+        .set_decimals(2)
+        .set_initial_supply(100)
+        .set_treasury_account_id(account_id)
+        .set_token_type(TokenType.FUNGIBLE_COMMON)
+        .set_supply_type(SupplyType.FINITE)
+        .set_max_supply(1000)
+        .set_admin_key(account_private_key)
+        .set_supply_key(account_private_key)
+        .execute(client)
+    )
+    
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Fungible token creation failed with status: {ResponseCode(receipt.status).name}")
+        sys.exit(1)
+    
+    token_id = receipt.tokenId
+    print(f"\nFungible token created with ID: {token_id}")
+    
+    return token_id
+
+def associate_token(client, token_id, receiver_id, receiver_private_key):
+    """Associate token with an account"""
+    # Associate the token_id with the new account
+    receipt = (
+        TokenAssociateTransaction()
+        .set_account_id(receiver_id)
+        .add_token_id(token_id)
+        .freeze_with(client)
+        .sign(receiver_private_key) # Has to be signed here by receiver's key
+        .execute(client)
+    )
+    
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Token association failed with status: {ResponseCode(receipt.status).name}")
+        sys.exit(1)
+    
+    print(f"Token successfully associated with account: {receiver_id}")
+
+def transfer_tokens(client, treasury_id, treasury_private_key, receiver_id, token_id, amount=10):
+    """Transfer tokens to the receiver account so we can later reject them"""
+    # Transfer tokens to the receiver account
+    receipt = (
+        TransferTransaction()
+        .add_token_transfer(token_id, treasury_id, -amount)
+        .add_token_transfer(token_id, receiver_id, amount)
+        .freeze_with(client)
+        .sign(treasury_private_key)
+        .execute(client)
+    )
+    
+    # Check if transfer was successful
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Transfer failed with status: {ResponseCode(receipt.status).name}")
+        sys.exit(1)
+    
+    print(f"Successfully transferred {amount} tokens to receiver account {receiver_id}")
+    
+    return receipt
+
+def print_transaction_record(record):
+    """Print the transaction record"""
+    print(f"Transaction ID: {record.transaction_id}")
+    print(f"Transaction Fee: {record.transaction_fee}")
+    print(f"Transaction Hash: {record.transaction_hash.hex()}")
+    print(f"Transaction Memo: {record.transaction_memo}")
+    print(f"Transaction Account ID: {record.receipt.accountId}")
+    
+    print(f"\nTransfers made in the transaction:")
+    for account_id, amount in record.transfers.items():
+        print(f"  Account: {account_id}, Amount: {amount}")
+
+def query_record():
+    """
+    Demonstrates the transaction record query functionality by performing the following steps:
+    1. Creating a new account transaction to get a transaction ID
+    2. Querying and displaying the transaction record for account creation
+    3. Creating a fungible token and associating it with the new account
+    4. Transferring tokens from operator to new account
+    5. Querying and displaying the transaction record for token transfer
+    """
+    client, operator_id, operator_key = setup_client()
+    
+    # Create a transaction to get a transaction ID
+    new_account_id, new_account_key, transaction_id = create_account_transaction(client)
+    
+    record = (
+        TransactionRecordQuery()
+        .set_transaction_id(transaction_id)
+        .execute(client)
+    )
+    print("Transaction record for account creation:")
+    print_transaction_record(record)
+    
+    token_id = create_fungible_token(client, operator_id, operator_key)
+    associate_token(client, token_id, new_account_id, new_account_key)
+    transfer_receipt = transfer_tokens(client, operator_id, operator_key, new_account_id, token_id)
+    
+    transfer_record = (
+        TransactionRecordQuery()
+        .set_transaction_id(transfer_receipt.transaction_id)
+        .execute(client)
+    )
+    print("Transaction record for token transfer:")
+    print_transaction_record(transfer_record)
+    
+    print(f"\nToken Transfer Record:")
+    for token_id, transfers in transfer_record.token_transfers.items():
+        print(f"  Token ID: {token_id}")
+        for account_id, amount in transfers.items():
+            print(f"    Account: {account_id}, Amount: {amount}")
+
+if __name__ == "__main__":
+    query_record()

--- a/src/hiero_sdk_python/__init__.py
+++ b/src/hiero_sdk_python/__init__.py
@@ -34,6 +34,7 @@ from .transaction.transfer_transaction import TransferTransaction
 from .transaction.transaction_id import TransactionId
 from .transaction.transaction_receipt import TransactionReceipt
 from .transaction.transaction_response import TransactionResponse
+from .transaction.transaction_record import TransactionRecord
 
 # Response / Codes
 from .response_code import ResponseCode
@@ -58,6 +59,7 @@ from .consensus.topic_id import TopicId
 from .query.topic_info_query import TopicInfoQuery
 from .query.topic_message_query import TopicMessageQuery
 from .query.transaction_get_receipt_query import TransactionGetReceiptQuery
+from .query.transaction_record_query import TransactionRecordQuery
 from .query.account_balance_query import CryptoGetAccountBalanceQuery
 from .query.token_nft_info_query import TokenNftInfoQuery
 from .query.token_info_query import TokenInfoQuery
@@ -108,6 +110,7 @@ __all__ = [
     "TransactionId",
     "TransactionReceipt",
     "TransactionResponse",
+    "TransactionRecord",
 
     # Response
     "ResponseCode",
@@ -123,6 +126,7 @@ __all__ = [
     "TopicInfoQuery",
     "TopicMessageQuery",
     "TransactionGetReceiptQuery",
+    "TransactionRecordQuery",
     "CryptoGetAccountBalanceQuery",
     "TokenNftInfoQuery",
     "TokenInfoQuery",

--- a/src/hiero_sdk_python/account/account_id.py
+++ b/src/hiero_sdk_python/account/account_id.py
@@ -53,6 +53,12 @@ class AccountId:
         """
         return f"{self.shard}.{self.realm}.{self.num}"
 
+    def __repr__(self):
+        """
+        Returns the repr representation of the AccountId.
+        """
+        return f"AccountId(shard={self.shard}, realm={self.realm}, num={self.num})"
+
     def __eq__(self, other):
             if not isinstance(other, AccountId):
                 return False

--- a/src/hiero_sdk_python/query/transaction_get_receipt_query.py
+++ b/src/hiero_sdk_python/query/transaction_get_receipt_query.py
@@ -215,7 +215,7 @@ class TransactionGetReceiptQuery(Query):
         self._before_execute(client)
         response = self._execute(client)
 
-        return TransactionReceipt._from_proto(response.transactionGetReceipt.receipt)
+        return TransactionReceipt._from_proto(response.transactionGetReceipt.receipt, self.transaction_id)
 
     def _get_query_response(self, response):
         """

--- a/src/hiero_sdk_python/query/transaction_record_query.py
+++ b/src/hiero_sdk_python/query/transaction_record_query.py
@@ -1,0 +1,200 @@
+from hiero_sdk_python.hapi.services import query_header_pb2, transaction_get_record_pb2, query_pb2
+from hiero_sdk_python.query.query import Query
+from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.transaction.transaction_id import TransactionId
+from hiero_sdk_python.channels import _Channel
+from hiero_sdk_python.executable import _Method
+from hiero_sdk_python.exceptions import PrecheckError, ReceiptStatusError
+from hiero_sdk_python.transaction.transaction_receipt import TransactionReceipt
+from hiero_sdk_python.transaction.transaction_record import TransactionRecord
+from hiero_sdk_python.executable import _ExecutionState
+
+
+class TransactionRecordQuery(Query):
+    """
+    Represents a query for a transaction record on the Hedera network.
+    """
+
+    def __init__(self, transaction_id: TransactionId = None):
+        """
+        Initializes the TransactionRecordQuery with the provided transaction ID.
+        """
+        super().__init__()
+        self.transaction_id : TransactionId = transaction_id
+        
+    def set_transaction_id(self, transaction_id: TransactionId):
+        """
+        Sets the transaction ID for the query.
+        
+        Args:
+            transaction_id (TransactionId): The ID of the transaction to query.
+        Returns:
+            TransactionRecordQuery: This query instance.
+        """
+        self.transaction_id = transaction_id
+        return self
+
+    def _make_request(self):
+        """
+        Constructs the protobuf request for the transaction record query.
+        
+        Builds a TransactionGetRecordQuery protobuf message with the
+        appropriate header and transaction ID.
+
+        Returns:
+            Query: The protobuf Query object containing the transaction record query.
+
+        Raises:
+            ValueError: If the transaction ID is not set.
+            AttributeError: If the Query protobuf structure is invalid.
+            Exception: If any other error occurs during request construction.
+        """
+        try:
+            if not self.transaction_id:
+                raise ValueError("Transaction ID must be set before making the request.")
+
+            query_header = self._make_request_header()
+            transaction_get_record = transaction_get_record_pb2.TransactionGetRecordQuery()
+            transaction_get_record.header.CopyFrom(query_header)
+            transaction_get_record.transactionID.CopyFrom(self.transaction_id._to_proto())
+            
+            query = query_pb2.Query()
+            if not hasattr(query, 'transactionGetRecord'):
+                raise AttributeError("Query object has no attribute 'transactionGetRecord'")
+            query.transactionGetRecord.CopyFrom(transaction_get_record)
+            
+            return query
+        except Exception as e:
+            print(f"Exception in _make_request: {e}")
+            raise
+
+    def _get_method(self, channel: _Channel) -> _Method:
+        """
+        Returns the appropriate gRPC method for the transaction receipt query.
+        
+        Implements the abstract method from Query to provide the specific
+        gRPC method for getting transaction receipts.
+
+        Args:
+            channel (_Channel): The channel containing service stubs
+
+        Returns:
+            _Method: The method wrapper containing the query function
+        """
+        return _Method(
+            transaction_func=None,
+            query_func=channel.crypto.getTxRecordByTxID
+        )
+
+    def _should_retry(self, response):
+        """
+        Determines whether the query should be retried based on the response.
+        
+        Implements the abstract method from Query to decide whether to retry
+        the query based on the response status code. First checks the header status,
+        then the receipt status.
+
+        Args:
+            response: The response from the network
+
+        Returns:
+            _ExecutionState: The execution state indicating what to do next
+        """
+        status = response.transactionGetRecord.header.nodeTransactionPrecheckCode
+        
+        retryable_statuses = {
+            ResponseCode.UNKNOWN,
+            ResponseCode.BUSY,
+            ResponseCode.RECEIPT_NOT_FOUND,
+            ResponseCode.RECORD_NOT_FOUND,
+            ResponseCode.PLATFORM_NOT_ACTIVE
+        }
+        
+        if status == ResponseCode.OK:
+            if response.transactionGetRecord.header.responseType == query_header_pb2.ResponseType.COST_ANSWER:
+                return _ExecutionState.FINISHED
+            pass
+        elif status in retryable_statuses or status == ResponseCode.PLATFORM_TRANSACTION_NOT_CREATED:
+            return _ExecutionState.RETRY
+        else:
+            return _ExecutionState.ERROR
+    
+        status = response.transactionGetRecord.transactionRecord.receipt.status
+        
+        if status in retryable_statuses or status == ResponseCode.OK:
+            return _ExecutionState.RETRY
+        elif status == ResponseCode.SUCCESS:
+            return _ExecutionState.FINISHED
+        else:
+            return _ExecutionState.ERROR
+        
+    def _map_status_error(self, response):
+        """
+        Maps a response status code to an appropriate error object.
+        
+        Implements the abstract method from Executable to create error objects
+        from response status codes. Checks both the header status and receipt status.
+
+        Args:
+            response: The response from the network
+
+        Returns:
+            PrecheckError: An error object representing the error status
+            ReceiptStatusError: An error object representing the receipt status
+        """
+        status = response.transactionGetRecord.header.nodeTransactionPrecheckCode
+        retryable_statuses = {
+            ResponseCode.PLATFORM_TRANSACTION_NOT_CREATED,
+            ResponseCode.BUSY,
+            ResponseCode.UNKNOWN,
+            ResponseCode.RECEIPT_NOT_FOUND,
+            ResponseCode.RECORD_NOT_FOUND,
+            ResponseCode.OK
+        }
+        
+        if status not in retryable_statuses:
+            return PrecheckError(status)
+        
+        receipt = response.transactionGetRecord.transactionRecord.receipt
+        
+        return ReceiptStatusError(status, self.transaction_id, TransactionReceipt._from_proto(receipt))
+        
+    def execute(self, client):
+        """
+        Executes the transaction record query.
+        
+        Sends the query to the Hedera network and processes the response
+        to return a TransactionRecord object.
+        
+        This function delegates the core logic to `_execute()`, and may propagate exceptions raised by it.
+
+        Args:
+            client (Client): The client instance to use for execution
+
+        Returns:
+            TransactionRecord: The transaction record from the network
+
+        Raises:
+            PrecheckError: If the query fails with a non-retryable error
+            MaxAttemptsError: If the query fails after the maximum number of attempts
+            ReceiptStatusError: If the transaction record contains an error status
+        """
+        self._before_execute(client)
+        response = self._execute(client)
+
+        return TransactionRecord._from_proto(response.transactionGetRecord.transactionRecord, self.transaction_id)
+
+    def _get_query_response(self, response):
+        """
+        Extracts the transaction record response from the full response.
+        
+        Implements the abstract method from Query to extract the
+        specific transaction record response object.
+        
+        Args:
+            response: The full response from the network
+            
+        Returns:
+            The transaction get record response object
+        """
+        return response.transactionGetRecord

--- a/src/hiero_sdk_python/tokens/token_nft_transfer.py
+++ b/src/hiero_sdk_python/tokens/token_nft_transfer.py
@@ -38,6 +38,18 @@ class TokenNftTransfer:
             is_approval=self.is_approved
         )
     
+    @classmethod
+    def _from_proto(cls, proto: basic_types_pb2.NftTransfer):
+        """
+        Creates a TokenNftTransfer from a protobuf representation.
+        """
+        return cls(
+            sender_id=AccountId._from_proto(proto.senderAccountID),
+            receiver_id=AccountId._from_proto(proto.receiverAccountID),
+            serial_number=proto.serialNumber,
+            is_approved=proto.is_approval
+        )
+
     def __str__(self):
         """
         Returns a string representation of this TokenNftTransfer instance.

--- a/src/hiero_sdk_python/transaction/transaction_receipt.py
+++ b/src/hiero_sdk_python/transaction/transaction_receipt.py
@@ -15,13 +15,14 @@ class TransactionReceipt:
         _receipt_proto (TransactionReceiptProto): The underlying protobuf receipt.
     """
 
-    def __init__(self, receipt_proto):
+    def __init__(self, receipt_proto, transaction_id=None):
         """
         Initializes the TransactionReceipt with the provided protobuf receipt.
 
         Args:
             receipt_proto (TransactionReceiptProto): The protobuf transaction receipt.
         """
+        self._transaction_id = transaction_id
         self.status = receipt_proto.status
         self._receipt_proto = receipt_proto
 
@@ -74,6 +75,16 @@ class TransactionReceipt:
         """
         return self._receipt_proto.serialNumbers
 
+    @property
+    def transaction_id(self):
+        """
+        Returns the transaction ID associated with this receipt.
+
+        Returns:
+            TransactionId: The transaction ID.
+        """
+        return self._transaction_id
+
     def _to_proto(self):
         """
         Returns the underlying protobuf transaction receipt.
@@ -84,5 +95,5 @@ class TransactionReceipt:
         return self._receipt_proto
 
     @classmethod
-    def _from_proto(cls, proto):
-        return cls(receipt_proto=proto)
+    def _from_proto(cls, proto, transaction_id=None):
+        return cls(receipt_proto=proto, transaction_id=transaction_id)

--- a/src/hiero_sdk_python/transaction/transaction_record.py
+++ b/src/hiero_sdk_python/transaction/transaction_record.py
@@ -1,0 +1,137 @@
+from collections import defaultdict
+from functools import cached_property
+from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.tokens.token_id import TokenId
+from hiero_sdk_python.tokens.token_nft_transfer import TokenNftTransfer
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
+from hiero_sdk_python.transaction.transaction_receipt import TransactionReceipt
+from hiero_sdk_python.hapi.services import transaction_record_pb2
+
+
+class TransactionRecord():
+    """
+    Represents a transaction record on the network.
+    """
+
+    def __init__(self, record_proto : 'transaction_record_pb2.TransactionRecord', transaction_id : TransactionId = None):
+        """
+        Initializes the TransactionRecord with the provided protobuf record.
+        """
+        self._transaction_id : TransactionId = transaction_id
+        self._record_proto = record_proto
+
+    @cached_property
+    def receipt(self):
+        """
+        Returns the receipt associated with the transaction record.
+        """
+        return TransactionReceipt._from_proto(self._record_proto.receipt)
+
+    @property
+    def transaction_id(self):
+        """
+        Returns the transaction ID of the transaction record.
+        """
+        return self._transaction_id
+
+    @property
+    def transaction_hash(self):
+        """
+        Returns the transaction hash of the transaction record.
+        """
+        return self._record_proto.transactionHash
+
+    @property
+    def transaction_memo(self):
+        """
+        Returns the transaction memo of the transaction record.
+        """
+        return self._record_proto.memo
+
+    @property
+    def transaction_fee(self):
+        """
+        Returns the transaction fee of the transaction record.
+        """
+        return self._record_proto.transactionFee
+
+    @cached_property
+    def token_transfers(self):
+        """
+        Returns the token transfers associated with the transaction record.
+
+        Returns:
+            dict[TokenId, dict[AccountId, int]]: A nested dictionary mapping token IDs to account transfer amounts
+        """
+        token_transfers = defaultdict(lambda: defaultdict(int))
+        
+        for token_transfer_list in self._record_proto.tokenTransferLists:
+            token_id = TokenId._from_proto(token_transfer_list.token)
+            for transfer in token_transfer_list.transfers:
+                account_id = AccountId._from_proto(transfer.accountID)
+                token_transfers[token_id][account_id] = transfer.amount
+        
+        return token_transfers
+
+    @cached_property
+    def nft_transfers(self):
+        """
+        Returns a dictionary mapping TokenId to a list of NFT transfers that occurred in this transaction.
+
+        Returns:
+            dict[TokenId, list[TokenNftTransfer]]: A dictionary mapping token IDs to their NFT transfers
+        """
+        nft_transfers = defaultdict(list[TokenNftTransfer])
+         
+        for token_transfer_list in self._record_proto.tokenTransferLists:
+            token_id = TokenId._from_proto(token_transfer_list.token)
+            for nft_transfer in token_transfer_list.nftTransfers:
+                sender = AccountId._from_proto(nft_transfer.senderAccountID)
+                receiver = AccountId._from_proto(nft_transfer.receiverAccountID)
+                nft_transfers[token_id].append(TokenNftTransfer(
+                    sender,
+                    receiver, 
+                    nft_transfer.serialNumber,
+                    nft_transfer.is_approval
+                ))
+                 
+        return nft_transfers
+
+    @cached_property
+    def transfers(self):
+        """
+        Returns a dictionary mapping AccountId to HBAR amount for all transfers in this transaction.
+        This includes:
+        - The node fee payment
+        - The network/service fee
+        - The transaction fee
+        - Any other HBAR transfers that were part of the transaction
+        
+        Returns:
+            dict[AccountId, int]: A dictionary mapping account IDs to transfer amounts
+        """
+        transfers = defaultdict(int)
+        
+        for transfer in self._record_proto.transferList.accountAmounts:
+            account_id = AccountId._from_proto(transfer.accountID)
+            transfers[account_id] += transfer.amount
+        
+        return transfers
+    
+    @classmethod
+    def _from_proto(cls, proto, transaction_id=None):
+        """
+        Creates a TransactionRecord from a protobuf record.
+
+        Args:
+            proto: The protobuf transaction record
+            transaction_id: Optional transaction ID to associate with the record
+        """
+        return cls(proto, transaction_id)
+
+    def _to_proto(self):
+        """
+        Returns the underlying protobuf transaction record.
+        """
+        return self._record_proto

--- a/src/hiero_sdk_python/transaction/transaction_record.py
+++ b/src/hiero_sdk_python/transaction/transaction_record.py
@@ -13,15 +13,32 @@ class TransactionRecord:
     """
     Represents a transaction record on the network.
     """
-    transaction_id: TransactionId = None
-    transaction_hash: bytes = None
-    transaction_memo: str = None
-    transaction_fee: int = None
-    receipt: TransactionReceipt = None
+    transaction_id: Optional[TransactionId] = None
+    transaction_hash: Optional[bytes] = None
+    transaction_memo: Optional[str] = None
+    transaction_fee: Optional[int] = None
+    receipt: Optional[TransactionReceipt] = None
     
     token_transfers: defaultdict[TokenId, defaultdict[AccountId, int]] = field(default_factory=lambda: defaultdict(lambda: defaultdict(int)))
     nft_transfers: defaultdict[TokenId, list[TokenNftTransfer]] = field(default_factory=lambda: defaultdict(list[TokenNftTransfer]))
     transfers: defaultdict[AccountId, int] = field(default_factory=lambda: defaultdict(int))
+
+    def __repr__(self) -> str:
+        status = None
+        if self.receipt:
+            try:
+                from hiero_sdk_python.response_code import ResponseCode
+                status = ResponseCode(self.receipt.status).name
+            except (ValueError, AttributeError):
+                status = self.receipt.status
+        return (f"TransactionRecord(transaction_id='{self.transaction_id}', "
+                f"transaction_hash={self.transaction_hash}, "
+                f"transaction_memo='{self.transaction_memo}', "
+                f"transaction_fee={self.transaction_fee}, "
+                f"receipt_status='{status}', "
+                f"token_transfers={dict(self.token_transfers)}, "
+                f"nft_transfers={dict(self.nft_transfers)}, "
+                f"transfers={dict(self.transfers)})")
 
     @classmethod
     def _from_proto(cls, proto: transaction_record_pb2.TransactionRecord, transaction_id: Optional[TransactionId] = None) -> 'TransactionRecord':

--- a/tests/integration/transaction_record_query_e2e_test.py
+++ b/tests/integration/transaction_record_query_e2e_test.py
@@ -1,0 +1,145 @@
+import pytest
+from hiero_sdk_python.crypto.private_key import PrivateKey
+from hiero_sdk_python.hbar import Hbar
+from hiero_sdk_python.account.account_create_transaction import AccountCreateTransaction
+from hiero_sdk_python.query.transaction_record_query import TransactionRecordQuery
+from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.tokens.nft_id import NftId
+from hiero_sdk_python.tokens.token_associate_transaction import TokenAssociateTransaction
+from hiero_sdk_python.tokens.token_mint_transaction import TokenMintTransaction
+from hiero_sdk_python.transaction.transfer_transaction import TransferTransaction
+from tests.integration.utils_for_test import IntegrationTestEnv, create_fungible_token, create_nft_token
+
+@pytest.mark.integration
+def test_transaction_record_query_can_execute():
+    env = IntegrationTestEnv()
+    
+    try:
+        # Generate new key
+        new_account_private_key = PrivateKey.generate_ed25519()
+        new_account_public_key = new_account_private_key.public_key()
+        
+        # Create new account
+        receipt = (
+            AccountCreateTransaction()
+            .set_key(new_account_public_key)
+            .set_initial_balance(Hbar(1))
+            .execute(env.client)
+            )
+        assert receipt.status == ResponseCode.SUCCESS, "Account creation failed"
+        
+        record = TransactionRecordQuery(receipt.transaction_id).execute(env.client)
+        
+        # Verify transaction details
+        assert record.transaction_id == receipt.transaction_id, "Transaction ID should match the queried record"
+        assert record.transaction_fee > 0, "Transaction fee should be greater than zero"
+        assert record.transaction_memo == "", "Transaction memo should be empty by default"
+        assert record.transaction_hash is not None, "Transaction hash should not be None"
+    finally:
+        env.close()
+
+@pytest.mark.integration
+def test_transaction_record_query_can_execute_nft_transfer():
+    env = IntegrationTestEnv()
+    
+    try:
+        new_account = env.create_account()
+        
+        token_id = create_nft_token(env)
+        
+        # Mint NFTs
+        receipt = (
+            TokenMintTransaction()
+            .set_token_id(token_id)
+            .set_metadata([b"NFT 1", b"NFT 2"])
+            .execute(env.client)
+        )
+        assert receipt.status == ResponseCode.SUCCESS, f"NFT mint failed with status: {ResponseCode(receipt.status).name}"
+        serial_numbers = receipt.serial_numbers
+        
+        assert len(serial_numbers) == 2, "Expected two NFTs to be minted"
+        
+        # Associate token with new account
+        receipt = (
+            TokenAssociateTransaction()
+            .set_account_id(new_account.id)
+            .add_token_id(token_id)
+            .freeze_with(env.client)
+            .sign(new_account.key)
+            .execute(env.client)
+        )
+        
+        assert receipt.status == ResponseCode.SUCCESS, f"Token association failed with status: {ResponseCode(receipt.status).name}"
+        
+        # Transfer NFTs
+        receipt = (
+            TransferTransaction()
+            .add_nft_transfer(NftId(token_id, serial_numbers[0]), env.operator_id, new_account.id)
+            .add_nft_transfer(NftId(token_id, serial_numbers[1]), env.operator_id, new_account.id)
+            .execute(env.client)
+        )
+        assert receipt.status == ResponseCode.SUCCESS, f"NFT transfer failed with status: {ResponseCode(receipt.status).name}"
+        
+        # Query the record
+        record = TransactionRecordQuery(receipt.transaction_id).execute(env.client)
+        
+        # Verify NFT transfers
+        assert len(record.nft_transfers) == 1
+        assert len(record.nft_transfers[token_id]) == 2, "Expected two NFT transfers in the record"
+        for i, transfer in enumerate(record.nft_transfers[token_id]):
+            assert transfer.sender_id == env.operator_id, "Sender should be the operator account"
+            assert transfer.receiver_id == new_account.id, "Receiver should be the new account"
+            assert transfer.serial_number == serial_numbers[i], "Serial number should match the minted NFT"
+        
+        # Verify transaction details
+        assert record.transaction_id == receipt.transaction_id, "Transaction ID should match the queried record"
+        assert record.transaction_fee > 0, "Transaction fee should be greater than zero"
+        assert record.transaction_memo == "", "Transaction memo should be empty by default"
+        assert record.transaction_hash is not None, "Transaction hash should not be None"
+    finally:
+        env.close()
+
+def test_transaction_record_query_can_execute_fungible_transfer():
+    env = IntegrationTestEnv()
+    
+    try:
+        new_account = env.create_account()
+        
+        token_id = create_fungible_token(env)
+        
+        # Associate token with new account
+        receipt = (
+            TokenAssociateTransaction()
+            .set_account_id(new_account.id)
+            .add_token_id(token_id)
+            .freeze_with(env.client)
+            .sign(new_account.key)
+            .execute(env.client)
+        )
+        assert receipt.status == ResponseCode.SUCCESS, f"Token association failed with status: {ResponseCode(receipt.status).name}"
+        
+        # Transfer tokens
+        transfer_amount = 1000
+        receipt = (
+            TransferTransaction()
+            .add_token_transfer(token_id, env.operator_id, -transfer_amount)
+            .add_token_transfer(token_id, new_account.id, transfer_amount)
+            .execute(env.client)
+        )
+        assert receipt.status == ResponseCode.SUCCESS, f"Token transfer failed with status: {ResponseCode(receipt.status).name}"
+        
+        # Query the record
+        record = TransactionRecordQuery(receipt.transaction_id).execute(env.client)
+        
+        # Verify token transfers
+        assert len(record.token_transfers) == 1
+        assert record.token_transfers[token_id][env.operator_id] == -transfer_amount, "Operator should have sent tokens"
+        assert record.token_transfers[token_id][new_account.id] == transfer_amount, "New account should have received tokens"
+        
+        # Verify transaction details
+        assert record.transaction_id == receipt.transaction_id, "Transaction ID should match the queried record"
+        assert record.transaction_fee > 0, "Transaction fee should be greater than zero"
+        assert record.transaction_memo == "", "Transaction memo should be empty by default"
+        assert record.transaction_hash is not None, "Transaction hash should not be None"
+    finally:
+        env.close()

--- a/tests/unit/test_token_nft_transfer.py
+++ b/tests/unit/test_token_nft_transfer.py
@@ -1,5 +1,6 @@
 import pytest
 
+from hiero_sdk_python.hapi.services import basic_types_pb2
 from hiero_sdk_python.tokens.token_nft_transfer import TokenNftTransfer
 
 pytestmark = pytest.mark.unit
@@ -61,3 +62,21 @@ def test_to_proto(mock_account_ids):
     
     assert proto.serialNumber == serial_number
     assert proto.is_approval is is_approved
+    
+def test_from_proto(mock_account_ids):
+    """Test converting a protobuf object to a TokenNftTransfer"""
+    sender_id, receiver_id, _, _, _ = mock_account_ids
+    serial_number = 789
+    is_approved = True
+    
+    proto = basic_types_pb2.NftTransfer(
+        senderAccountID=sender_id._to_proto(),
+        receiverAccountID=receiver_id._to_proto(),
+        serialNumber=serial_number,
+        is_approval=is_approved
+    )
+    
+    nft_transfer = TokenNftTransfer._from_proto(proto)
+    
+    assert nft_transfer.sender_id == sender_id
+    assert nft_transfer.receiver_id == receiver_id

--- a/tests/unit/test_transaction_record.py
+++ b/tests/unit/test_transaction_record.py
@@ -1,0 +1,196 @@
+import pytest
+from collections import defaultdict
+from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.tokens.token_id import TokenId
+from hiero_sdk_python.tokens.token_nft_transfer import TokenNftTransfer
+from hiero_sdk_python.transaction.transaction_record import TransactionRecord
+from hiero_sdk_python.transaction.transaction_receipt import TransactionReceipt
+from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.hapi.services import (
+    transaction_record_pb2,
+    transaction_receipt_pb2,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def transaction_record(transaction_id):
+    """Create a mock transaction record."""
+    receipt = TransactionReceipt(
+        receipt_proto=transaction_receipt_pb2.TransactionReceipt(
+            status=ResponseCode.SUCCESS
+        ),
+        transaction_id=transaction_id
+    )
+    
+    return TransactionRecord(
+        transaction_id=transaction_id,
+        transaction_hash=b'\x01\x02\x03\x04' * 12,
+        transaction_memo="Test transaction memo",
+        transaction_fee=100000,
+        receipt=receipt,
+        token_transfers=defaultdict(lambda: defaultdict(int)),
+        nft_transfers=defaultdict(list[TokenNftTransfer]),
+        transfers=defaultdict(int)
+    )
+
+@pytest.fixture
+def proto_transaction_record(transaction_id):
+    """Create a mock transaction record protobuf."""
+    proto = transaction_record_pb2.TransactionRecord(
+        transactionHash=b'\x01\x02\x03\x04' * 12,
+        memo="Test transaction memo",
+        transactionFee=100000,
+        receipt=transaction_receipt_pb2.TransactionReceipt(
+            status=ResponseCode.SUCCESS
+        ),
+        transactionID=transaction_id._to_proto()
+    )
+    return proto
+
+def test_transaction_record_initialization(transaction_record, transaction_id):
+    """Test the initialization of the TransactionRecord class"""
+    assert transaction_record.transaction_id == transaction_id
+    assert transaction_record.transaction_hash == b'\x01\x02\x03\x04' * 12
+    assert transaction_record.transaction_memo == "Test transaction memo"
+    assert transaction_record.transaction_fee == 100000
+    assert isinstance(transaction_record.receipt, TransactionReceipt)
+    assert transaction_record.receipt.status == ResponseCode.SUCCESS
+
+def test_transaction_record_default_initialization():
+    """Test the default initialization of the TransactionRecord class"""
+    record = TransactionRecord()
+    assert record.transaction_id is None
+    assert record.transaction_hash is None
+    assert record.transaction_memo is None
+    assert record.transaction_fee is None
+    assert record.receipt is None
+    assert record.token_transfers == defaultdict(lambda: defaultdict(int))
+    assert record.nft_transfers == defaultdict(list[TokenNftTransfer])
+    assert record.transfers == defaultdict(int)
+
+def test_from_proto(proto_transaction_record, transaction_id):
+    """Test the from_proto method of the TransactionRecord class"""
+    record = TransactionRecord._from_proto(proto_transaction_record, transaction_id)
+
+    assert record.transaction_id == transaction_id
+    assert record.transaction_hash == b'\x01\x02\x03\x04' * 12
+    assert record.transaction_memo == "Test transaction memo"
+    assert record.transaction_fee == 100000
+    assert isinstance(record.receipt, TransactionReceipt)
+    assert record.receipt.status == ResponseCode.SUCCESS
+
+def test_from_proto_with_transfers(transaction_id):
+    """Test from_proto with HBAR transfers"""
+    proto = transaction_record_pb2.TransactionRecord()
+    transfer = proto.transferList.accountAmounts.add()
+    transfer.accountID.CopyFrom(AccountId(0, 0, 200)._to_proto())
+    transfer.amount = 1000
+
+    record = TransactionRecord._from_proto(proto, transaction_id)
+    assert record.transfers[AccountId(0, 0, 200)] == 1000
+
+def test_from_proto_with_token_transfers(transaction_id):
+    """Test from_proto with token transfers"""
+    proto = transaction_record_pb2.TransactionRecord()
+    token_list = proto.tokenTransferLists.add()
+    token_list.token.CopyFrom(TokenId(0, 0, 300)._to_proto())
+    
+    transfer = token_list.transfers.add()
+    transfer.accountID.CopyFrom(AccountId(0, 0, 200)._to_proto())
+    transfer.amount = 500
+
+    record = TransactionRecord._from_proto(proto, transaction_id)
+    assert record.token_transfers[TokenId(0, 0, 300)][AccountId(0, 0, 200)] == 500
+
+def test_from_proto_with_nft_transfers(transaction_id):
+    """Test from_proto with NFT transfers"""
+    proto = transaction_record_pb2.TransactionRecord()
+    token_list = proto.tokenTransferLists.add()
+    token_list.token.CopyFrom(TokenId(0, 0, 300)._to_proto())
+    
+    nft = token_list.nftTransfers.add()
+    nft.senderAccountID.CopyFrom(AccountId(0, 0, 100)._to_proto())
+    nft.receiverAccountID.CopyFrom(AccountId(0, 0, 200)._to_proto())
+    nft.serialNumber = 1
+    nft.is_approval = False
+
+    record = TransactionRecord._from_proto(proto, transaction_id)
+    assert len(record.nft_transfers[TokenId(0, 0, 300)]) == 1
+    transfer = record.nft_transfers[TokenId(0, 0, 300)][0]
+    assert transfer.sender_id == AccountId(0, 0, 100)
+    assert transfer.receiver_id == AccountId(0, 0, 200)
+    assert transfer.serial_number == 1
+    assert transfer.is_approved == False
+
+def test_to_proto(transaction_record, transaction_id):
+    """Test the to_proto method of the TransactionRecord class"""
+    proto = transaction_record._to_proto()
+
+    assert proto.transactionHash == b'\x01\x02\x03\x04' * 12
+    assert proto.memo == "Test transaction memo"
+    assert proto.transactionFee == 100000
+    assert proto.receipt.status == ResponseCode.SUCCESS
+    assert proto.transactionID == transaction_id._to_proto()
+
+def test_proto_conversion(transaction_record):
+    """Test converting TransactionRecord to proto and back preserves data"""
+    proto = transaction_record._to_proto()
+    converted = TransactionRecord._from_proto(proto, transaction_record.transaction_id)
+
+    assert converted.transaction_id == transaction_record.transaction_id
+    assert converted.transaction_hash == transaction_record.transaction_hash
+    assert converted.transaction_memo == transaction_record.transaction_memo
+    assert converted.transaction_fee == transaction_record.transaction_fee
+    assert converted.receipt.status == transaction_record.receipt.status
+
+def test_proto_conversion_with_transfers():
+    """Test proto conversion preserves transfer data"""
+    record = TransactionRecord()
+    record.transfers = defaultdict(int)
+    record.transfers[AccountId(0, 0, 100)] = -1000
+    record.transfers[AccountId(0, 0, 200)] = 1000
+
+    proto = record._to_proto()
+    converted = TransactionRecord._from_proto(proto, None)
+
+    assert converted.transfers[AccountId(0, 0, 100)] == -1000
+    assert converted.transfers[AccountId(0, 0, 200)] == 1000
+
+def test_proto_conversion_with_token_transfers():
+    """Test proto conversion preserves token transfer data"""
+    record = TransactionRecord()
+    token_id = TokenId(0, 0, 300)
+    record.token_transfers = defaultdict(lambda: defaultdict(int))
+    record.token_transfers[token_id][AccountId(0, 0, 100)] = -500
+    record.token_transfers[token_id][AccountId(0, 0, 200)] = 500
+
+    proto = record._to_proto()
+    converted = TransactionRecord._from_proto(proto, None)
+
+    assert converted.token_transfers[token_id][AccountId(0, 0, 100)] == -500
+    assert converted.token_transfers[token_id][AccountId(0, 0, 200)] == 500
+
+def test_proto_conversion_with_nft_transfers():
+    """Test proto conversion preserves NFT transfer data"""
+    record = TransactionRecord()
+    token_id = TokenId(0, 0, 300)
+    nft_transfer = TokenNftTransfer(
+        sender_id=AccountId(0, 0, 100),
+        receiver_id=AccountId(0, 0, 200),
+        serial_number=1,
+        is_approved=False
+    )
+    record.nft_transfers = defaultdict(list[TokenNftTransfer])
+    record.nft_transfers[token_id].append(nft_transfer)
+
+    proto = record._to_proto()
+    converted = TransactionRecord._from_proto(proto, None)
+
+    assert len(converted.nft_transfers[token_id]) == 1
+    transfer = converted.nft_transfers[token_id][0]
+    assert transfer.sender_id == AccountId(0, 0, 100)
+    assert transfer.receiver_id == AccountId(0, 0, 200)
+    assert transfer.serial_number == 1
+    assert transfer.is_approved == False

--- a/tests/unit/test_transaction_record.py
+++ b/tests/unit/test_transaction_record.py
@@ -194,3 +194,71 @@ def test_proto_conversion_with_nft_transfers():
     assert transfer.receiver_id == AccountId(0, 0, 200)
     assert transfer.serial_number == 1
     assert transfer.is_approved == False
+
+def test_repr_method(transaction_id):
+    """Test the __repr__ method of TransactionRecord."""
+    # Test with default values
+    record_default = TransactionRecord()
+    expected_repr_default = ("TransactionRecord(transaction_id='None', "
+                           "transaction_hash=None, "
+                           "transaction_memo='None', "
+                           "transaction_fee=None, "
+                           "receipt_status='None', "
+                           "token_transfers={}, "
+                           "nft_transfers={}, "
+                           "transfers={})")
+    assert repr(record_default) == expected_repr_default
+    
+    # Test with receipt only
+    receipt = TransactionReceipt(
+        receipt_proto=transaction_receipt_pb2.TransactionReceipt(
+            status=ResponseCode.SUCCESS
+        ),
+        transaction_id=transaction_id
+    )
+    record_with_receipt = TransactionRecord(transaction_id=transaction_id, receipt=receipt)
+    expected_repr_with_receipt = (f"TransactionRecord(transaction_id='{transaction_id}', "
+                                f"transaction_hash=None, "
+                                f"transaction_memo='None', "
+                                f"transaction_fee=None, "
+                                f"receipt_status='SUCCESS', "
+                                f"token_transfers={{}}, "
+                                f"nft_transfers={{}}, "
+                                f"transfers={{}})")
+    assert repr(record_with_receipt) == expected_repr_with_receipt
+    
+    # Test with all parameters set
+    record_full = TransactionRecord(
+        transaction_id=transaction_id,
+        transaction_hash=b'\x01\x02\x03\x04',
+        transaction_memo="Test memo",
+        transaction_fee=100000,
+        receipt=receipt
+    )
+    expected_repr_full = (f"TransactionRecord(transaction_id='{transaction_id}', "
+                         f"transaction_hash=b'\\x01\\x02\\x03\\x04', "
+                         f"transaction_memo='Test memo', "
+                         f"transaction_fee=100000, "
+                         f"receipt_status='SUCCESS', "
+                         f"token_transfers={{}}, "
+                         f"nft_transfers={{}}, "
+                         f"transfers={{}})")
+    assert repr(record_full) == expected_repr_full
+    
+    # Test with transfers
+    record_with_transfers = TransactionRecord(
+        transaction_id=transaction_id,
+        receipt=receipt
+    )
+    record_with_transfers.transfers[AccountId(0, 0, 100)] = -1000
+    record_with_transfers.transfers[AccountId(0, 0, 200)] = 1000
+    
+    expected_repr_with_transfers = (f"TransactionRecord(transaction_id='{transaction_id}', "
+                                  f"transaction_hash=None, "
+                                  f"transaction_memo='None', "
+                                  f"transaction_fee=None, "
+                                  f"receipt_status='SUCCESS', "
+                                  f"token_transfers={{}}, "
+                                  f"nft_transfers={{}}, "
+                                  f"transfers={{AccountId(shard=0, realm=0, num=100): -1000, AccountId(shard=0, realm=0, num=200): 1000}})")
+    assert repr(record_with_transfers) == expected_repr_with_transfers

--- a/tests/unit/test_transaction_record_query.py
+++ b/tests/unit/test_transaction_record_query.py
@@ -73,38 +73,7 @@ def test_transaction_record_query_execute(transaction_id):
         transactionFee=100000
     )
 
-    responses = [
-        response_pb2.Response(
-            transactionGetRecord=transaction_get_record_pb2.TransactionGetRecordResponse(
-                header=response_header_pb2.ResponseHeader(
-                    nodeTransactionPrecheckCode=ResponseCode.OK,
-                    responseType=ResponseType.COST_ANSWER,
-                    cost=2
-                )
-            )
-        ),
-        response_pb2.Response(
-            transactionGetRecord=transaction_get_record_pb2.TransactionGetRecordResponse(
-                header=response_header_pb2.ResponseHeader(
-                    nodeTransactionPrecheckCode=ResponseCode.OK,
-                    responseType=ResponseType.COST_ANSWER,
-                    cost=2
-                )
-            )
-        ),
-        response_pb2.Response(
-            transactionGetRecord=transaction_get_record_pb2.TransactionGetRecordResponse(
-                header=response_header_pb2.ResponseHeader(
-                    nodeTransactionPrecheckCode=ResponseCode.OK,
-                    responseType=ResponseType.ANSWER_ONLY,
-                    cost=2
-                ),
-                transactionRecord=transaction_record
-            )
-        )
-    ]
-    
-    response_sequences = [responses]
+    response_sequences = get_transaction_record_responses(transaction_record)
     
     with mock_hedera_servers(response_sequences) as client:
         query = TransactionRecordQuery(transaction_id)
@@ -123,3 +92,35 @@ def test_transaction_record_query_execute(transaction_id):
         assert result.transaction_fee == 100000
         assert result.transaction_hash == b'\x01' * 48
         assert result.transaction_memo == "Test transaction"
+        
+def get_transaction_record_responses(transaction_record):
+        return [[
+            response_pb2.Response(
+                transactionGetRecord=transaction_get_record_pb2.TransactionGetRecordResponse(
+                    header=response_header_pb2.ResponseHeader(
+                        nodeTransactionPrecheckCode=ResponseCode.OK,
+                        responseType=ResponseType.COST_ANSWER,
+                        cost=2
+                    )
+                )
+            ),
+            response_pb2.Response(
+                transactionGetRecord=transaction_get_record_pb2.TransactionGetRecordResponse(
+                    header=response_header_pb2.ResponseHeader(
+                        nodeTransactionPrecheckCode=ResponseCode.OK,
+                        responseType=ResponseType.COST_ANSWER,
+                        cost=2
+                    )
+                )
+            ),
+            response_pb2.Response(
+                transactionGetRecord=transaction_get_record_pb2.TransactionGetRecordResponse(
+                    header=response_header_pb2.ResponseHeader(
+                        nodeTransactionPrecheckCode=ResponseCode.OK,
+                        responseType=ResponseType.ANSWER_ONLY,
+                        cost=2
+                    ),
+                    transactionRecord=transaction_record
+                )
+            )
+        ]]

--- a/tests/unit/test_transaction_record_query.py
+++ b/tests/unit/test_transaction_record_query.py
@@ -1,0 +1,125 @@
+import pytest
+from unittest.mock import Mock
+
+from hiero_sdk_python.hapi.services.query_header_pb2 import ResponseType
+from hiero_sdk_python.query.transaction_record_query import TransactionRecordQuery
+from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.hapi.services import (
+    response_pb2,
+    response_header_pb2,
+    transaction_get_record_pb2,
+    transaction_record_pb2,
+    transaction_receipt_pb2,
+)
+
+from tests.unit.mock_server import mock_hedera_servers
+
+pytestmark = pytest.mark.unit
+
+def test_constructor(transaction_id):
+    """Test initialization of TransactionRecordQuery."""
+    query = TransactionRecordQuery()
+    assert query.transaction_id is None
+    
+    query = TransactionRecordQuery(transaction_id)
+    assert query.transaction_id == transaction_id
+
+def test_set_transaction_id(transaction_id):
+    """Test setting transaction ID."""
+    query = TransactionRecordQuery()
+    result = query.set_transaction_id(transaction_id)
+    
+    assert query.transaction_id == transaction_id
+    assert result == query  # Should return self for chaining
+
+def test_execute_fails_with_missing_transaction_id(mock_client):
+    """Test request creation with missing Transaction ID."""
+    query = TransactionRecordQuery()
+    
+    with pytest.raises(ValueError, match="Transaction ID must be set before making the request."):
+        query.execute(mock_client)
+
+def test_get_method():
+    """Test retrieving the gRPC method for the query."""
+    query = TransactionRecordQuery()
+    
+    mock_channel = Mock()
+    mock_crypto_stub = Mock()
+    mock_channel.crypto = mock_crypto_stub
+    
+    method = query._get_method(mock_channel)
+    
+    assert method.transaction is None
+    assert method.query == mock_crypto_stub.getTxRecordByTxID
+
+def test_is_payment_required():
+    """Test that transaction record query doesn't require payment."""
+    query = TransactionRecordQuery()
+    assert query._is_payment_required() is True
+
+def test_transaction_record_query_execute(transaction_id):
+    """Test basic functionality of TransactionRecordQuery with mock server."""
+    # Create a mock transaction receipt
+    receipt = transaction_receipt_pb2.TransactionReceipt(
+        status=ResponseCode.SUCCESS
+    )
+    
+    # Create a mock transaction record
+    transaction_record = transaction_record_pb2.TransactionRecord(
+        receipt=receipt,
+        transactionHash=b'\x01' * 48,
+        transactionID=transaction_id._to_proto(),
+        memo="Test transaction",
+        transactionFee=100000
+    )
+
+    responses = [
+        response_pb2.Response(
+            transactionGetRecord=transaction_get_record_pb2.TransactionGetRecordResponse(
+                header=response_header_pb2.ResponseHeader(
+                    nodeTransactionPrecheckCode=ResponseCode.OK,
+                    responseType=ResponseType.COST_ANSWER,
+                    cost=2
+                )
+            )
+        ),
+        response_pb2.Response(
+            transactionGetRecord=transaction_get_record_pb2.TransactionGetRecordResponse(
+                header=response_header_pb2.ResponseHeader(
+                    nodeTransactionPrecheckCode=ResponseCode.OK,
+                    responseType=ResponseType.COST_ANSWER,
+                    cost=2
+                )
+            )
+        ),
+        response_pb2.Response(
+            transactionGetRecord=transaction_get_record_pb2.TransactionGetRecordResponse(
+                header=response_header_pb2.ResponseHeader(
+                    nodeTransactionPrecheckCode=ResponseCode.OK,
+                    responseType=ResponseType.ANSWER_ONLY,
+                    cost=2
+                ),
+                transactionRecord=transaction_record
+            )
+        )
+    ]
+    
+    response_sequences = [responses]
+    
+    with mock_hedera_servers(response_sequences) as client:
+        query = TransactionRecordQuery(transaction_id)
+        
+        try:
+            # Get the cost of executing the query - should be 2 tinybars based on the mock response
+            cost = query.get_cost(client)
+            assert cost.to_tinybars() == 2
+            
+            result = query.execute(client)
+        except Exception as e:
+            pytest.fail(f"Unexpected exception raised: {e}")
+        
+        assert result.transaction_id == transaction_id
+        assert result.receipt.status == ResponseCode.SUCCESS
+        assert result.transaction_fee == 100000
+        assert result.transaction_hash == b'\x01' * 48
+        assert result.transaction_memo == "Test transaction"


### PR DESCRIPTION
## Description
Implemented the `TransactionRecordQuery` class that retrieves transaction records from the network.

* Add `TransactionRecord` class with transaction record data
* Add unit tests for `TransactionRecord` class
* Add `TransactionRecordQuery` class implementation for querying transaction records by transaction ID
* Add `_from_proto()` method to `TokenNftTransfer` class for easier protobuf deserialization
* Refactor `TransactionReceipt` to include `transaction_id` field so we can use it to execute `TransactionRecordQuery`
* Add transaction record query example
* Add integration/unit tests for `TransactionRecordQuery`
* Update `README.md` in examples with transaction record query documentation
* Update `__init__.py` file with `TransactionRecord` and `TransactionRecordQuery` class definitions

**Related issue(s)**:

Fixes #138 

**Notes for reviewer**:
Please, careful see the `TransactionRecord` and see if you like the way it is done.

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
