### PR TITLE
feat: add `FileUpdateTransaction`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -50,6 +50,7 @@ You can choose either syntax or even mix both styles in your projects.
   - [Creating a File](#creating-a-file)
   - [Querying File Info](#querying-file-info)
   - [Querying File Contents](#querying-file-contents)
+  - [Updating a File](#updating-a-file)
   - [Deleting a File](#deleting-a-file)
 - [Miscellaneous Queries](#miscellaneous-queries)
   - [Querying Transaction Record](#querying-transaction-record)
@@ -186,8 +187,8 @@ transaction = TokenMintTransaction(
     amount=amount,  # lowest denomination, must be positive and not zero
 ).freeze_with(client)
 
-transaction.sign(operator_key)  
-transaction.sign(supply_key)  
+transaction.sign(operator_key)
+transaction.sign(supply_key)
 transaction.execute(client)
 ```
 #### Method Chaining:
@@ -198,8 +199,8 @@ transaction = (
     .set_amount(amount) # lowest denomination, must be positive and not zero
     .freeze_with(client)
 )
-transaction.sign(operator_key)  
-transaction.sign(admin_key)  
+transaction.sign(operator_key)
+transaction.sign(admin_key)
 transaction.execute(client)
 ```
 
@@ -212,8 +213,8 @@ transaction = TokenMintTransaction(
     metadata=metadata  # Bytes for non-fungible tokens (NFTs)
 ).freeze_with(client)
 
-transaction.sign(operator_key)  
-transaction.sign(supply_key)  
+transaction.sign(operator_key)
+transaction.sign(supply_key)
 transaction.execute(client)
 ```
 #### Method Chaining:
@@ -224,8 +225,8 @@ transaction = (
     .set_metadata(metadata)  # Bytes for non-fungible tokens (NFTs)
     .freeze_with(client)
 )
-transaction.sign(operator_key)  
-transaction.sign(admin_key)  
+transaction.sign(operator_key)
+transaction.sign(admin_key)
 transaction.execute(client)
 ```
 
@@ -286,8 +287,8 @@ transaction = (
 transaction = TransferTransaction(
     token_transfers={
         token_id: {
-            operator_id: -amount,  
-            recipient_id: amount   
+            operator_id: -amount,
+            recipient_id: amount
         }
     }
 ).freeze_with(client)
@@ -560,7 +561,7 @@ transaction.execute(client)
     transaction = (
         TokenUpdateNftsTransaction()
         .set_token_id(nft_token_id)
-        .set_serial_numbers(serial_numbers) 
+        .set_serial_numbers(serial_numbers)
         .set_metadata(new_metadata)
         .freeze_with(client)
         .sign(metadata_key)
@@ -628,7 +629,7 @@ transaction = TokenUpdateTransaction(
     token_id=token_id,
     token_params=TokenUpdateParams(
         token_name="UpdateToken",
-        token_symbol="UPD", 
+        token_symbol="UPD",
         token_memo="Updated memo",
         metadata="Updated metadata",
         treasury_account_id=new_account_id
@@ -751,7 +752,7 @@ transaction.execute(client)
     transaction = (
         TransferTransaction()
         .add_hbar_transfer(operator_id, -100000000)  # send 1 HBAR (in tinybars)
-        .add_hbar_transfer(recipient_id, 100000000)  
+        .add_hbar_transfer(recipient_id, 100000000)
         .freeze_with(client)
     )
 
@@ -776,7 +777,7 @@ transaction.execute(client)
     transaction.execute(client)
 ```
 #### Method Chaining:
-``` 
+```
 transaction = (
     TopicCreateTransaction()
     .set_memo("My Super Topic Memo")
@@ -904,10 +905,10 @@ query.subscribe(client)
 ```
 query = (
     TopicMessageQuery()
-    .set_topic_id(topic_id) 
-    .set_start_time(datetime.now(timezone.utc)) 
-    .set_chunking_enabled(True) 
-    .set_limit(0) 
+    .set_topic_id(topic_id)
+    .set_start_time(datetime.now(timezone.utc))
+    .set_chunking_enabled(True)
+    .set_limit(0)
     )
 
 query.subscribe(client)
@@ -981,6 +982,39 @@ file_contents = (
     .execute(client)
 )
 print(str(file_contents)) # decode bytes to string
+
+```
+
+### Updating a File
+
+#### Pythonic Syntax:
+```
+transaction = FileUpdateTransaction(
+    file_id=file_id,
+    keys=[new_file_public_key],
+    contents=b"New File Contents",
+    file_memo="Updated file memo"
+).freeze_with(client)
+
+transaction.sign(current_file_private_key)
+transaction.sign(new_file_private_key)
+transaction.execute(client)
+```
+
+#### Method Chaining:
+```
+    transaction = (
+        FileUpdateTransaction()
+        .set_file_id(file_id)
+        .set_keys([new_file_public_key])
+        .set_contents(b"New File Contents")
+        .set_file_memo("Updated file memo")
+        .freeze_with(client)
+        .sign(current_file_private_key)
+        .sign(new_file_private_key)
+    )
+
+    transaction.execute(client)
 
 ```
 

--- a/examples/file_update.py
+++ b/examples/file_update.py
@@ -1,0 +1,101 @@
+import os
+import sys
+
+from dotenv import load_dotenv
+
+from hiero_sdk_python import AccountId, Client, Network, PrivateKey
+from hiero_sdk_python.file.file_create_transaction import FileCreateTransaction
+from hiero_sdk_python.file.file_info_query import FileInfoQuery
+from hiero_sdk_python.file.file_update_transaction import FileUpdateTransaction
+from hiero_sdk_python.response_code import ResponseCode
+
+load_dotenv()
+
+
+def setup_client():
+    """Initialize and set up the client with operator account"""
+    network = Network(network="testnet")
+    client = Client(network)
+
+    operator_id = AccountId.from_string(os.getenv("OPERATOR_ID"))
+    operator_key = PrivateKey.from_string(os.getenv("OPERATOR_KEY"))
+    client.set_operator(operator_id, operator_key)
+
+    return client
+
+
+def create_file(client):
+    """Create a test file"""
+    file_private_key = PrivateKey.generate_ed25519()
+
+    receipt = (
+        FileCreateTransaction()
+        .set_keys(file_private_key.public_key())
+        .set_contents(b"Hello, this is a test file for querying!")
+        .set_file_memo("Test file for query")
+        .freeze_with(client)
+        .sign(file_private_key)
+        .execute(client)
+    )
+
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"File creation failed with status: {ResponseCode(receipt.status).name}")
+        sys.exit(1)
+
+    file_id = receipt.file_id
+    print(f"\nFile created with ID: {file_id}")
+
+    return file_id, file_private_key
+
+
+def query_file_info(client, file_id):
+    info = FileInfoQuery().set_file_id(file_id).execute(client)
+
+    print(info)
+
+
+def file_update():
+    """
+    Demonstrates querying file info by:
+    1. Setting up client with operator account
+    2. Creating a test file
+    3. Querying the file info
+    4. Updating the file info
+    5. Querying the file info again
+    """
+    client = setup_client()
+
+    # Create a test file first
+    file_id, file_private_key = create_file(client)
+
+    print("File info before update:")
+    # Query the file info
+    query_file_info(client, file_id)
+
+    # Generate a new private key that will add to the existing key
+    new_private_key = PrivateKey.generate_ed25519()
+
+    # Update the file
+    receipt = (
+        FileUpdateTransaction()
+        .set_file_id(file_id)
+        .set_keys([file_private_key.public_key(), new_private_key.public_key()])
+        .set_contents(b"Updated contents!")
+        .set_file_memo("Updated memo!")
+        .freeze_with(client)
+        .sign(new_private_key)
+        .sign(file_private_key)
+        .execute(client)
+    )
+
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"File update failed with status: {ResponseCode(receipt.status).name}")
+        sys.exit(1)
+
+    print("File info after update:")
+    # Query the file info again
+    query_file_info(client, file_id)
+
+
+if __name__ == "__main__":
+    file_update()

--- a/src/hiero_sdk_python/__init__.py
+++ b/src/hiero_sdk_python/__init__.py
@@ -84,6 +84,7 @@ from .file.file_create_transaction import FileCreateTransaction
 from .file.file_info_query import FileInfoQuery
 from .file.file_info import FileInfo
 from .file.file_contents_query import FileContentsQuery
+from .file.file_update_transaction import FileUpdateTransaction
 from .file.file_delete_transaction import FileDeleteTransaction
 
 __all__ = [
@@ -169,5 +170,6 @@ __all__ = [
     "FileInfoQuery",
     "FileInfo",
     "FileContentsQuery",
+    "FileUpdateTransaction",
     "FileDeleteTransaction",
 ]

--- a/src/hiero_sdk_python/file/file_update_transaction.py
+++ b/src/hiero_sdk_python/file/file_update_transaction.py
@@ -1,0 +1,208 @@
+"""
+Transaction to update a file's contents, metadata, or keys on the network.
+"""
+
+from typing import Optional
+
+# pylint: disable=no-name-in-module
+from google.protobuf.wrappers_pb2 import StringValue
+
+from hiero_sdk_python.channels import _Channel
+from hiero_sdk_python.crypto.public_key import PublicKey
+from hiero_sdk_python.executable import _Method
+from hiero_sdk_python.file.file_id import FileId
+from hiero_sdk_python.hapi.services.basic_types_pb2 import KeyList as KeyListProto
+from hiero_sdk_python.hapi.services.file_update_pb2 import FileUpdateTransactionBody
+from hiero_sdk_python.hbar import Hbar
+from hiero_sdk_python.timestamp import Timestamp
+from hiero_sdk_python.transaction.transaction import Transaction
+
+DEFAULT_TRANSACTION_FEE = Hbar(2).to_tinybars()
+
+
+class FileUpdateTransaction(Transaction):
+    """
+    Represents a file update transaction on the network.
+
+    This transaction updates the metadata and/or contents of a file. If a field is not set
+    in the transaction body, the corresponding file attribute will be unchanged. This transaction
+    must be signed by all the keys in the top level of a key list  of the file being updated.
+    If the keys themselves are being updated, then the transaction must
+    also be signed by all the new keys.
+
+    Inherits from the base Transaction class and implements the required methods
+    to build and execute a file update transaction.
+    """
+
+    def __init__(
+        self,
+        file_id: Optional[FileId] = None,
+        keys: Optional[list[PublicKey]] = None,
+        contents: Optional[str | bytes] = None,
+        expiration_time: Optional[Timestamp] = None,
+        file_memo: Optional[str] = None,
+    ):  # pylint: [disable=too-many-arguments, disable=too-many-positional-arguments]
+        """
+        Initializes a new FileUpdateTransaction instance with the specified parameters.
+
+        Args:
+            file_id (Optional[FileId], optional): The ID of the file to update.
+            keys (Optional[list[PublicKey]], optional): The new keys that are allowed to
+            update/delete the file.
+            contents (Optional[str | bytes], optional): The new contents of the file.
+            Strings will be automatically encoded as UTF-8 bytes.
+            expiration_time (Optional[Timestamp], optional): The new expiration time for the file.
+            file_memo (Optional[str], optional): The new memo for the file.
+        """
+        super().__init__()
+        self.file_id: Optional[FileId] = file_id
+        self.keys: Optional[list[PublicKey]] = keys
+        self.contents: Optional[bytes] = self._encode_contents(contents)
+        self.expiration_time: Optional[Timestamp] = expiration_time
+        self.file_memo: Optional[str] = file_memo
+        self._default_transaction_fee = DEFAULT_TRANSACTION_FEE
+
+    def _encode_contents(self, contents: Optional[str | bytes]) -> Optional[bytes]:
+        """
+        Helper method to encode string contents to UTF-8 bytes.
+
+        Args:
+            contents (Optional[str | bytes]): The contents to encode.
+
+        Returns:
+            Optional[bytes]: The encoded contents or None if input is None.
+        """
+        if contents is None:
+            return None
+        if isinstance(contents, str):
+            return contents.encode("utf-8")
+        return contents
+
+    def set_file_id(self, file_id: Optional[FileId]) -> "FileUpdateTransaction":
+        """
+        Sets the FileID to be updated.
+
+        Args:
+            file_id (Optional[FileId]): The ID of the file to update.
+
+        Returns:
+            FileUpdateTransaction: This transaction instance.
+        """
+        self._require_not_frozen()
+        self.file_id = file_id
+        return self
+
+    def set_keys(
+        self, keys: Optional[list[PublicKey]] | PublicKey
+    ) -> "FileUpdateTransaction":
+        """
+        Sets the new list of keys that can modify or delete the file.
+
+        Args:
+            keys (Optional[list[PublicKey]] | PublicKey): The new keys to set for the file.
+                Can be a list of PublicKey objects, a single PublicKey, or None.
+
+        Returns:
+            FileUpdateTransaction: This transaction instance.
+        """
+        self._require_not_frozen()
+        if isinstance(keys, PublicKey):
+            self.keys = [keys]
+        else:
+            self.keys = keys
+        return self
+
+    def set_expiration_time(
+        self, expiration_time: Optional[Timestamp]
+    ) -> "FileUpdateTransaction":
+        """
+        Sets the new expiry time for the file.
+
+        Args:
+            expiration_time (Optional[Timestamp]): The new expiration time for the file.
+
+        Returns:
+            FileUpdateTransaction: This transaction instance.
+        """
+        self._require_not_frozen()
+        self.expiration_time = expiration_time
+        return self
+
+    def set_contents(self, contents: Optional[bytes | str]) -> "FileUpdateTransaction":
+        """
+        Sets the new contents that should overwrite the file's current contents.
+
+        Args:
+            contents (Optional[bytes | str]): The new contents for the file.
+            Strings will be automatically encoded as UTF-8 bytes.
+
+        Returns:
+            FileUpdateTransaction: This transaction instance.
+        """
+        self._require_not_frozen()
+        self.contents = self._encode_contents(contents)
+        return self
+
+    def set_file_memo(self, file_memo: Optional[str]) -> "FileUpdateTransaction":
+        """
+        Sets the new memo to be associated with the file (UTF-8 encoding max 100 bytes).
+
+        Args:
+            file_memo (Optional[str]): The new memo for the file.
+
+        Returns:
+            FileUpdateTransaction: This transaction instance.
+        """
+        self._require_not_frozen()
+        self.file_memo = file_memo
+        return self
+
+    def build_transaction_body(self):
+        """
+        Builds the transaction body for this file update transaction.
+
+        Returns:
+            TransactionBody: The built transaction body.
+
+        Raises:
+            ValueError: If file_id is not set.
+        """
+        if self.file_id is None:
+            raise ValueError("Missing required FileID")
+
+        file_update_body = FileUpdateTransactionBody(
+            fileID=self.file_id._to_proto(),
+            keys=(
+                KeyListProto(keys=[key._to_proto() for key in self.keys])
+                if self.keys
+                else None
+            ),
+            contents=self.contents if self.contents is not None else b"",
+            expirationTime=(
+                self.expiration_time._to_protobuf() if self.expiration_time else None
+            ),
+            memo=(
+                StringValue(value=self.file_memo)
+                if self.file_memo is not None
+                else None
+            ),
+        )
+
+        transaction_body = self.build_base_transaction_body()
+        transaction_body.fileUpdate.CopyFrom(file_update_body)
+        return transaction_body
+
+    def _get_method(self, channel: _Channel) -> _Method:
+        """
+        Gets the method to execute the file update transaction.
+
+        This internal method returns a _Method object containing the appropriate gRPC
+        function to call when executing this transaction on the Hedera network.
+
+        Args:
+            channel (_Channel): The channel containing service stubs
+
+        Returns:
+            _Method: An object containing the transaction function to update a file.
+        """
+        return _Method(transaction_func=channel.file.updateFile, query_func=None)

--- a/tests/integration/file_update_transaction_e2e_test.py
+++ b/tests/integration/file_update_transaction_e2e_test.py
@@ -1,0 +1,139 @@
+"""
+Integration tests for the FileUpdateTransaction class.
+"""
+
+import pytest
+
+from hiero_sdk_python import PrivateKey
+from hiero_sdk_python.file.file_create_transaction import FileCreateTransaction
+from hiero_sdk_python.file.file_id import FileId
+from hiero_sdk_python.file.file_info_query import FileInfoQuery
+from hiero_sdk_python.file.file_update_transaction import FileUpdateTransaction
+from hiero_sdk_python.response_code import ResponseCode
+from tests.integration.utils_for_test import env
+
+
+@pytest.mark.integration
+def test_integration_file_update_transaction_can_execute(env):
+    """Test that the FileUpdateTransaction can be executed."""
+    # Create initial file
+    file_private_key = PrivateKey.generate_ed25519()
+    receipt = (
+        FileCreateTransaction()
+        .set_keys(file_private_key.public_key())
+        .set_contents("Initial contents")
+        .set_file_memo("python sdk e2e tests")
+        .freeze_with(env.client)
+        .sign(file_private_key)
+        .execute(env.client)
+    )
+    assert (
+        receipt.status == ResponseCode.SUCCESS
+    ), f"File creation failed with status: {ResponseCode.get_name(receipt.status)}"
+
+    file_id = receipt.file_id
+    assert file_id is not None, "File ID should not be None"
+
+    new_private_key = PrivateKey.generate_ed25519()
+
+    # Update file contents
+    new_contents = "Update contents!"
+    new_memo = "Update memo"
+
+    receipt = (
+        FileUpdateTransaction()
+        .set_file_id(file_id)
+        .set_keys(new_private_key.public_key())
+        .set_contents(new_contents)
+        .set_file_memo(new_memo)
+        .freeze_with(env.client)
+        .sign(new_private_key)
+        .sign(file_private_key)
+        .execute(env.client)
+    )
+    assert (
+        receipt.status == ResponseCode.SUCCESS
+    ), f"File update failed with status: {ResponseCode.get_name(receipt.status)}"
+
+    # Query file info and check if everything is updated
+    info = FileInfoQuery().set_file_id(file_id).execute(env.client)
+
+    assert info.file_id == file_id, "File ID should match"
+    assert info.file_memo == new_memo, "File memo should match"
+    assert info.is_deleted is False, "File should not be deleted"
+    assert info.size == len(new_contents.encode("utf-8")), "File size should match"
+    assert len(info.keys) == 1, "File should have one key"
+    assert info.keys[0].to_bytes_raw() == new_private_key.public_key().to_bytes_raw()
+
+
+@pytest.mark.integration
+def test_integration_file_update_transaction_fails_with_invalid_file_id(env):
+    """Test that the FileUpdateTransaction fails when updating an invalid file ID."""
+    # Create a file ID that doesn't exist on the network
+    file_id = FileId(0, 0, 999999999)
+
+    receipt = FileUpdateTransaction().set_file_id(file_id).execute(env.client)
+    assert receipt.status == ResponseCode.INVALID_FILE_ID, (
+        f"File update should have failed with INVALID_FILE_ID status but got: "
+        f"{ResponseCode(receipt.status).name}"
+    )
+
+
+@pytest.mark.integration
+def test_integration_file_update_transaction_cannot_update_immutable_file(env):
+    """Test that the FileUpdateTransaction fails when updating an immutable file."""
+    receipt = FileCreateTransaction().set_contents("Immutable file").execute(env.client)
+    assert (
+        receipt.status == ResponseCode.SUCCESS
+    ), f"File creation failed with status: {ResponseCode.get_name(receipt.status)}"
+
+    file_id = receipt.file_id
+    assert file_id is not None, "File ID should not be None"
+
+    # Update file contents
+    new_contents = "Update contents!"
+
+    receipt = (
+        FileUpdateTransaction()
+        .set_file_id(file_id)
+        .set_contents(new_contents)
+        .freeze_with(env.client)
+        .execute(env.client)
+    )
+    assert receipt.status == ResponseCode.UNAUTHORIZED, (
+        f"File update should have failed with UNAUTHORIZED status but got: "
+        f"{ResponseCode(receipt.status).name}"
+    )
+
+
+@pytest.mark.integration
+def test_integration_file_update_transaction_fails_when_key_is_invalid(env):
+    """Test that the FileUpdateTransaction fails when the key is invalid."""
+    # Create initial file
+    file_private_key = PrivateKey.generate_ed25519()
+    receipt = (
+        FileCreateTransaction()
+        .set_keys(file_private_key.public_key())
+        .set_contents("Initial contents")
+        .freeze_with(env.client)
+        .sign(file_private_key)
+        .execute(env.client)
+    )
+    assert (
+        receipt.status == ResponseCode.SUCCESS
+    ), f"File creation failed with status: {ResponseCode.get_name(receipt.status)}"
+
+    file_id = receipt.file_id
+    assert file_id is not None, "File ID should not be None"
+
+    # Update file contents
+    receipt = (
+        FileUpdateTransaction()
+        .set_file_id(file_id)
+        .set_contents("Update contents!")
+        .execute(env.client)
+    )
+    assert receipt.status == ResponseCode.INVALID_SIGNATURE, (
+        f"File update should have failed with INVALID_SIGNATURE status but got: "
+        f"{ResponseCode(receipt.status).name}"
+    )

--- a/tests/unit/test_file_update_transaction.py
+++ b/tests/unit/test_file_update_transaction.py
@@ -1,0 +1,317 @@
+"""
+Test cases for the FileUpdateTransaction class.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+# pylint: disable=no-name-in-module
+from google.protobuf.wrappers_pb2 import StringValue
+
+from hiero_sdk_python.crypto.private_key import PrivateKey
+from hiero_sdk_python.file.file_id import FileId
+from hiero_sdk_python.file.file_update_transaction import FileUpdateTransaction
+from hiero_sdk_python.hapi.services import (
+    basic_types_pb2,
+    response_header_pb2,
+    response_pb2,
+    transaction_get_receipt_pb2,
+)
+from hiero_sdk_python.hapi.services.transaction_receipt_pb2 import (
+    TransactionReceipt as TransactionReceiptProto,
+)
+from hiero_sdk_python.hapi.services.transaction_response_pb2 import (
+    TransactionResponse as TransactionResponseProto,
+)
+from hiero_sdk_python.hbar import Hbar
+from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.timestamp import Timestamp
+from tests.unit.mock_server import mock_hedera_servers
+
+pytestmark = pytest.mark.unit
+
+
+def test_constructor_with_parameters(file_id):
+    """Test creating a file update transaction with constructor parameters."""
+    private_key = PrivateKey.generate()
+    public_key = private_key.public_key()
+    key_list = [public_key]
+    contents = b"Updated file content"
+    file_memo = "Updated memo"
+    expiration_time = Timestamp(1704067200, 0)
+
+    file_tx = FileUpdateTransaction(
+        file_id=file_id,
+        keys=key_list,
+        contents=contents,
+        expiration_time=expiration_time,
+        file_memo=file_memo,
+    )
+
+    assert file_tx.file_id == file_id
+    assert file_tx.keys == key_list
+    assert file_tx.contents == contents
+    assert file_tx.expiration_time == expiration_time
+    assert file_tx.file_memo == file_memo
+    assert file_tx._default_transaction_fee == Hbar(2).to_tinybars()
+
+
+def test_constructor_without_parameters():
+    """Test creating a file update transaction without parameters."""
+    file_tx = FileUpdateTransaction()
+
+    assert file_tx.file_id is None
+    assert file_tx.keys is None
+    assert file_tx.contents is None
+    assert file_tx.expiration_time is None
+    assert file_tx.file_memo is None
+    assert file_tx._default_transaction_fee == Hbar(2).to_tinybars()
+
+
+def test_set_methods():
+    """Test the set methods of FileUpdateTransaction."""
+    private_key = PrivateKey.generate()
+    public_key = private_key.public_key()
+    key_list = [public_key]
+    contents = b"Test content"
+    file_memo = "Test memo"
+    expiration_time = Timestamp(1704067200, 0)  # Jan 1, 2024
+
+    file_tx = FileUpdateTransaction()
+
+    test_cases = [
+        ("set_keys", key_list, "keys"),
+        ("set_contents", contents, "contents"),
+        ("set_file_memo", file_memo, "file_memo"),
+        ("set_expiration_time", expiration_time, "expiration_time"),
+    ]
+
+    for method_name, value, attr_name in test_cases:
+        tx_after_set = getattr(file_tx, method_name)(value)
+        assert tx_after_set is file_tx
+        assert getattr(file_tx, attr_name) == value
+
+
+def test_set_keys_variations():
+    """Test setting keys with different input types."""
+    file_tx = FileUpdateTransaction()
+    private_key1 = PrivateKey.generate()
+    private_key2 = PrivateKey.generate()
+    public_key1 = private_key1.public_key()
+    public_key2 = private_key2.public_key()
+
+    # Test with single PublicKey
+    file_tx.set_keys(public_key1)
+    assert isinstance(file_tx.keys, list)
+    assert len(file_tx.keys) == 1
+    assert file_tx.keys[0] == public_key1
+
+    # Test with list of PublicKeys
+    file_tx.set_keys([public_key1, public_key2])
+    assert isinstance(file_tx.keys, list)
+    assert len(file_tx.keys) == 2
+
+    # Test with KeyList
+    key_list = [public_key1]
+    file_tx.set_keys(key_list)
+    assert file_tx.keys is key_list
+
+
+def test_set_methods_require_not_frozen(mock_client, file_id):
+    """Test that set methods raise exception when transaction is frozen."""
+    private_key = PrivateKey.generate()
+    public_key = private_key.public_key()
+
+    file_tx = FileUpdateTransaction(file_id=file_id)
+    file_tx.freeze_with(mock_client)
+
+    test_cases = [
+        ("set_file_id", FileId(0, 0, 999)),
+        ("set_keys", [public_key]),
+        ("set_contents", b"new content"),
+        ("set_file_memo", "new memo"),
+        ("set_expiration_time", Timestamp(1704067200, 0)),
+    ]
+
+    for method_name, value in test_cases:
+        with pytest.raises(
+            Exception, match="Transaction is immutable; it has been frozen"
+        ):
+            getattr(file_tx, method_name)(value)
+
+
+def test_build_transaction_body(mock_account_ids, file_id):
+    """Test building a file update transaction body with valid values."""
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    private_key = PrivateKey.generate()
+    public_key = private_key.public_key()
+    key_list = [public_key]
+    contents = b"Updated content"
+    file_memo = "Updated memo"
+    expiration_time = Timestamp(1704067200, 0)
+
+    file_tx = FileUpdateTransaction(
+        file_id=file_id,
+        keys=key_list,
+        contents=contents,
+        expiration_time=expiration_time,
+        file_memo=file_memo,
+    )
+
+    # Set operator and node account IDs needed for building transaction body
+    file_tx.operator_account_id = operator_id
+    file_tx.node_account_id = node_account_id
+
+    transaction_body = file_tx.build_transaction_body()
+
+    assert transaction_body.fileUpdate.fileID == file_id._to_proto()
+    expected_keys = basic_types_pb2.KeyList(keys=[key._to_proto() for key in key_list])
+    assert transaction_body.fileUpdate.keys == expected_keys
+    assert transaction_body.fileUpdate.contents == contents
+    assert transaction_body.fileUpdate.expirationTime == expiration_time._to_protobuf()
+    assert transaction_body.fileUpdate.memo == StringValue(value=file_memo)
+
+
+def test_build_transaction_body_with_optional_fields(mock_account_ids, file_id):
+    """Test building transaction body with some optional fields set to None."""
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    file_tx = FileUpdateTransaction(file_id=file_id)
+    file_tx.operator_account_id = operator_id
+    file_tx.node_account_id = node_account_id
+
+    transaction_body = file_tx.build_transaction_body()
+
+    assert transaction_body.fileUpdate.fileID == file_id._to_proto()
+    # When keys is None, the keys field should not be set in the protobuf
+    assert not transaction_body.fileUpdate.HasField("keys")
+    # When contents is None, the contents field should be empty bytes
+    assert transaction_body.fileUpdate.contents == b""
+    # When expiration_time is None, the expirationTime field should not be set in the protobuf
+    assert not transaction_body.fileUpdate.HasField("expirationTime")
+    # When file_memo is None, the memo field should not be set in the protobuf
+    assert not transaction_body.fileUpdate.HasField("memo")
+
+
+def test_missing_file_id():
+    """Test that building a transaction without setting file_id raises a ValueError."""
+    file_tx = FileUpdateTransaction()
+
+    with pytest.raises(ValueError, match="Missing required FileID"):
+        file_tx.build_transaction_body()
+
+
+def test_sign_transaction(mock_client, file_id):
+    """Test signing the file update transaction with a private key."""
+    file_tx = FileUpdateTransaction(file_id=file_id)
+
+    private_key = MagicMock()
+    private_key.sign.return_value = b"signature"
+    private_key.public_key().to_bytes_raw.return_value = b"public_key"
+
+    file_tx.freeze_with(mock_client)
+
+    file_tx.sign(private_key)
+
+    node_id = mock_client.network.current_node._account_id
+    body_bytes = file_tx._transaction_body_bytes[node_id]
+
+    assert len(file_tx._signature_map[body_bytes].sigPair) == 1
+    sig_pair = file_tx._signature_map[body_bytes].sigPair[0]
+    assert sig_pair.pubKeyPrefix == b"public_key"
+    assert sig_pair.ed25519 == b"signature"
+
+
+def test_to_proto(mock_client, file_id):
+    """Test converting the file update transaction to protobuf format after signing."""
+    file_tx = FileUpdateTransaction(file_id=file_id)
+
+    private_key = MagicMock()
+    private_key.sign.return_value = b"signature"
+    private_key.public_key().to_bytes_raw.return_value = b"public_key"
+
+    file_tx.freeze_with(mock_client)
+
+    file_tx.sign(private_key)
+    proto = file_tx._to_proto()
+
+    assert proto.signedTransactionBytes
+    assert len(proto.signedTransactionBytes) > 0
+
+
+@mock_hedera_servers
+def test_file_update_transaction_can_execute(file_id):
+    """Test that a file update transaction can be executed successfully."""
+    # Create test transaction responses
+    ok_response = TransactionResponseProto()
+    ok_response.nodeTransactionPrecheckCode = ResponseCode.OK
+
+    # Create a mock receipt for successful file update
+    mock_receipt_proto = TransactionReceiptProto(status=ResponseCode.SUCCESS)
+
+    # Create a response for the receipt query
+    receipt_query_response = response_pb2.Response(
+        transactionGetReceipt=transaction_get_receipt_pb2.TransactionGetReceiptResponse(
+            header=response_header_pb2.ResponseHeader(
+                nodeTransactionPrecheckCode=ResponseCode.OK
+            ),
+            receipt=mock_receipt_proto,
+        )
+    )
+
+    response_sequences = [
+        [ok_response, receipt_query_response],
+    ]
+
+    with mock_hedera_servers(response_sequences) as client:
+        private_key = PrivateKey.generate()
+        public_key = private_key.public_key()
+
+        transaction = (
+            FileUpdateTransaction()
+            .set_file_id(file_id)
+            .set_keys([public_key])
+            .set_contents(b"Updated file content")
+            .set_file_memo("Updated memo")
+        )
+
+        receipt = transaction.execute(client)
+
+        assert (
+            receipt.status == ResponseCode.SUCCESS
+        ), "Transaction should have succeeded"
+
+
+def test_get_method():
+    """Test retrieving the gRPC method for the transaction."""
+    file_tx = FileUpdateTransaction()
+
+    mock_channel = MagicMock()
+    mock_file_stub = MagicMock()
+    mock_channel.file = mock_file_stub
+
+    method = file_tx._get_method(mock_channel)
+
+    assert method.query is None
+    assert method.transaction == mock_file_stub.updateFile
+
+
+def test_encode_contents_string():
+    """Test encoding string contents to bytes."""
+    file_tx = FileUpdateTransaction()
+
+    # Test string encoding
+    string_content = "Hello, World!"
+    encoded = file_tx._encode_contents(string_content)
+    assert encoded == b"Hello, World!"
+
+    # Test bytes pass-through
+    bytes_content = b"Hello, bytes!"
+    encoded = file_tx._encode_contents(bytes_content)
+    assert encoded == bytes_content
+
+    # Test None handling
+    encoded = file_tx._encode_contents(None)
+    assert encoded is None


### PR DESCRIPTION
**Description**:
Implemented the `FileUpdateTransaction` class that allows updating file contents, metadata, and keys on the network.

* Add `FileUpdateTransaction` class implementation
* Add integration tests for `FileUpdateTransaction`
* Add unit tests for `FileUpdateTransaction` class
* Add file update example
* Add `FileUpdateTransaction` documentation in examples README
* Add `FileUpdateTransaction` to `__init__.py` file in `__all__` list

**Related issue(s)**:

Fixes #149, #215

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
