### PR TITLE
fix: correct ECDSA signature format and transaction signing logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "grpcio==1.68.1",
     "cryptography==44.0.0",
     "python-dotenv==1.0.1",
-    "requests==2.32.3"
+    "requests==2.32.3",
+    "pycryptodome==3.23.0",
 ]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/src/hiero_sdk_python/crypto/private_key.py
+++ b/src/hiero_sdk_python/crypto/private_key.py
@@ -3,7 +3,9 @@ from typing import Optional, Union
 
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519, ec
+from cryptography.hazmat.primitives.asymmetric import utils as asym_utils
 from hiero_sdk_python.crypto.public_key import PublicKey
+from hiero_sdk_python.utils.crypto_utils import keccak256
 
 class PrivateKey:
     """
@@ -261,8 +263,11 @@ class PrivateKey:
             # Ed25519 automatically handles the hashing internally
             return self._private_key.sign(data)
         else:
-            # ECDSA requires specifying a hash algorithm
-            return self._private_key.sign(data, ec.ECDSA(hashes.SHA256()))
+            data_hash = keccak256(data)
+            signature_der = self._private_key.sign(data_hash, ec.ECDSA(asym_utils.Prehashed(hashes.SHA256())))
+            r, s = asym_utils.decode_dss_signature(signature_der)
+            signature = r.to_bytes(32, "big") + s.to_bytes(32, "big")
+            return signature
 
     def public_key(self) -> PublicKey:
         return PublicKey(self._private_key.public_key())

--- a/src/hiero_sdk_python/transaction/transaction.py
+++ b/src/hiero_sdk_python/transaction/transaction.py
@@ -163,11 +163,16 @@ class Transaction(_Executable):
             signature = private_key.sign(body_bytes)
 
             public_key_bytes = private_key.public_key().to_bytes_raw()
-
-            sig_pair = basic_types_pb2.SignaturePair(
-                pubKeyPrefix=public_key_bytes,
-                ed25519=signature
-            )
+            if private_key.is_ed25519():
+                sig_pair = basic_types_pb2.SignaturePair(
+                    pubKeyPrefix=public_key_bytes,
+                    ed25519=signature
+                )
+            else:
+                sig_pair = basic_types_pb2.SignaturePair(
+                    pubKeyPrefix=public_key_bytes,
+                    ECDSA_secp256k1=signature
+                )
 
             # We initialize the signature map for this body_bytes if it doesn't exist yet
             self._signature_map.setdefault(body_bytes, basic_types_pb2.SignatureMap())


### PR DESCRIPTION
**Description**:
- Fix ECDSA signing to use keccak256 hash and convert DER signature to raw 64-byte format
- Fix transaction signing to use appropriate signature field based on key type (ed25519 vs ECDSA_secp256k1)


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
