### PR TITLE
fix: ECDSA key integration tests issues

### DIFF
--- a/src/hiero_sdk_python/crypto/private_key.py
+++ b/src/hiero_sdk_python/crypto/private_key.py
@@ -8,6 +8,9 @@ from cryptography.hazmat.primitives.asymmetric import utils as asym_utils
 from hiero_sdk_python.crypto.public_key import PublicKey
 from hiero_sdk_python.utils.crypto_utils import keccak256
 
+_LEGACY_ECDSA_PRIVATE_KEY_PREFIX = "3030020100300706052b8104000a04220420"
+
+
 class PrivateKey:
     """
     Represents a private key that can be either Ed25519 or ECDSA (secp256k1).
@@ -197,6 +200,12 @@ class PrivateKey:
         Attempt to parse the bytes as a DER-encoded private key.
         Auto-detect Ed25519 vs. ECDSA(secp256k1). Return None on failure.
         """
+        # Try to parse the key as a legacy ECDSA key first
+        try:
+            return PrivateKey._parse_legacy_ecdsa_der_key(key_bytes)
+        except Exception:
+            pass
+
         try:
             private_key = serialization.load_der_private_key(key_bytes, password=None)
             # Check Ed25519
@@ -245,6 +254,13 @@ class PrivateKey:
         Interpret bytes as a DER-encoded private key.
         Auto-detect Ed25519 vs. ECDSA(secp256k1).
         """
+        # Try to parse the key as a legacy ECDSA key first
+        try:
+            private_key = PrivateKey._parse_legacy_ecdsa_der_key(der_data)
+            return cls(private_key)
+        except Exception:
+            pass
+
         try:
             private_key = serialization.load_der_private_key(der_data, password=None)
         except Exception as e:
@@ -399,3 +415,53 @@ class PrivateKey:
         if self.is_ed25519():
             return f"<PrivateKey (Ed25519) hex={self.to_string_raw()}>"
         return f"<PrivateKey (ECDSA) hex={self.to_string_raw()}>"
+
+    #
+    # ---------------------------------
+    # Helper methods
+    # ---------------------------------
+    #
+    @staticmethod
+    def _parse_legacy_ecdsa_der_key(key_bytes: bytes) -> "ec.EllipticCurvePrivateKey":
+        """
+        Parse a legacy ECDSA private key from DER-encoded bytes.
+
+        Legacy keys have a specific prefix that needs to be removed before parsing.
+
+        Args:
+            key_bytes: DER-encoded bytes containing the legacy ECDSA private key
+
+        Returns:
+            EllipticCurvePrivateKey: The parsed ECDSA private key
+
+        Raises:
+            ValueError: If the key format is invalid or parsing fails
+        """
+        if not key_bytes.hex().startswith(_LEGACY_ECDSA_PRIVATE_KEY_PREFIX):
+            raise ValueError("Missing legacy ECDSA prefix")
+
+        # Remove the legacy prefix
+        hex_without_prefix = key_bytes.hex().removeprefix(
+            _LEGACY_ECDSA_PRIVATE_KEY_PREFIX
+        )
+
+        try:
+            raw_key_bytes = bytes.fromhex(hex_without_prefix)
+        except ValueError as exc:
+            raise ValueError("Invalid hex data after prefix removal") from exc
+
+        # ECDSA private keys must be exactly 32 bytes
+        if len(raw_key_bytes) != 32:
+            raise ValueError(
+                f"Invalid key length: {len(raw_key_bytes)} bytes (expected 32)"
+            )
+
+        private_int = int.from_bytes(raw_key_bytes, "big")
+
+        if private_int == 0:
+            raise ValueError("ECDSA private key scalar cannot be zero")
+
+        try:
+            return ec.derive_private_key(private_int, ec.SECP256K1())
+        except Exception as exc:
+            raise ValueError(f"Failed to derive ECDSA private key: {exc}") from exc

--- a/src/hiero_sdk_python/query/query.py
+++ b/src/hiero_sdk_python/query/query.py
@@ -214,9 +214,16 @@ class Query(_Executable):
         public_key_bytes = payer_private_key.public_key().to_bytes_raw()
 
         # Create signature pair
-        sig_pair = basic_types_pb2.SignaturePair(
-            pubKeyPrefix=public_key_bytes, ed25519=signature
-        )
+        if payer_private_key.is_ed25519():
+            sig_pair = basic_types_pb2.SignaturePair(
+                pubKeyPrefix=public_key_bytes,
+                ed25519=signature
+                )
+        else:
+            sig_pair = basic_types_pb2.SignaturePair(
+                pubKeyPrefix=public_key_bytes,
+                ECDSA_secp256k1=signature
+            )
 
         # Create signature map
         signature_map = basic_types_pb2.SignatureMap(sigPair=[sig_pair])

--- a/src/hiero_sdk_python/tokens/token_create_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_create_transaction.py
@@ -365,18 +365,17 @@ class TokenCreateTransaction(Transaction):
     def _to_proto_key(self, private_key):
         """
         Helper method to convert a private key to protobuf Key format.
-        
+
         Args:
             private_key: The private key to convert, or None
-            
+
         Returns:
-            basic_types_pb2.Key or None: The protobuf key or None if private_key is None
+            Key or None: The protobuf key or None if private_key is None
         """
         if not private_key:
             return None
 
-        public_key_bytes = private_key.public_key().to_bytes_raw()
-        return basic_types_pb2.Key(ed25519=public_key_bytes)
+        return private_key.public_key()._to_proto()
 
     def build_transaction_body(self):
         """

--- a/tests/integration/topic_create_transaction_e2e_test.py
+++ b/tests/integration/topic_create_transaction_e2e_test.py
@@ -38,8 +38,8 @@ def test_integration_topic_create_transaction_can_execute():
         
         assert topic_info.memo == topic_memo
         assert topic_info.sequence_number == 0
-        assert env.client.operator_private_key.public_key().to_string() == topic_info.admin_key.ed25519.hex()
-        
+        assert env.client.operator_private_key.public_key()._to_proto() == topic_info.admin_key
+
         delete_transaction = TopicDeleteTransaction(topic_id=topic_id)
         
         delete_transaction.freeze_with(env.client)

--- a/tests/integration/topic_info_query_e2e_test.py
+++ b/tests/integration/topic_info_query_e2e_test.py
@@ -29,8 +29,8 @@ def test_integration_topic_info_query_can_execute():
         
         assert topic_info.memo == "Topic for info query"
         assert topic_info.sequence_number == 0
-        assert env.client.operator.private_key.public_key().to_string() == topic_info.admin_key.ed25519.hex()
-        
+        assert env.client.operator_private_key.public_key()._to_proto() == topic_info.admin_key
+
         delete_transaction = TopicDeleteTransaction(topic_id=topic_id)
         delete_transaction.freeze_with(env.client)
         delete_receipt = delete_transaction.execute(env.client)

--- a/tests/integration/topic_update_transaction_e2e_test.py
+++ b/tests/integration/topic_update_transaction_e2e_test.py
@@ -28,8 +28,8 @@ def test_integration_topic_update_transaction_can_execute():
 
         assert info.memo == "Original memo"
         assert info.sequence_number == 0
-        assert env.client.operator.private_key.public_key().to_string() == info.admin_key.ed25519.hex()
-        
+        assert env.client.operator_private_key.public_key()._to_proto() == info.admin_key
+
         update_transaction = TopicUpdateTransaction(
             topic_id=topic_id,
             memo="Updated memo"
@@ -44,8 +44,8 @@ def test_integration_topic_update_transaction_can_execute():
         
         assert info.memo == "Updated memo"
         assert info.sequence_number == 0
-        assert env.client.operator.private_key.public_key().to_string() == info.admin_key.ed25519.hex()
-        
+        assert env.client.operator_private_key.public_key()._to_proto() == info.admin_key
+
         transaction = TopicDeleteTransaction(topic_id=topic_id)
         transaction.freeze_with(env.client)
         receipt = transaction.execute(env.client)

--- a/tests/unit/test_token_create_transaction.py
+++ b/tests/unit/test_token_create_transaction.py
@@ -36,6 +36,8 @@ from hiero_sdk_python.hapi.services import (
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.exceptions import PrecheckError
+from hiero_sdk_python.crypto.private_key import PrivateKey
+from hiero_sdk_python.hapi.services import basic_types_pb2
 
 pytestmark = pytest.mark.unit
 
@@ -89,35 +91,13 @@ def test_build_transaction_body(mock_account_ids):
     """Test building a token creation transaction body with valid values and admin, supply and freeze keys."""
     treasury_account, _, node_account_id, _, _ = mock_account_ids
 
-    # Mock admin key
-    private_key_admin = MagicMock()
-    private_key_admin.sign.return_value = b"admin_signature"
-    private_key_admin.public_key().to_bytes_raw.return_value = b"admin_public_key"
-
-    # Mock supply key
-    private_key_supply = MagicMock()
-    private_key_supply.sign.return_value = b"supply_signature"
-    private_key_supply.public_key().to_bytes_raw.return_value = b"supply_public_key"
-
-    # Mock freeze key
-    private_key_freeze = MagicMock()
-    private_key_freeze.sign.return_value = b"freeze_signature"
-    private_key_freeze.public_key().to_bytes_raw.return_value = b"freeze_public_key"
-
-    # Mock wipe key
-    private_key_wipe = MagicMock()
-    private_key_wipe.sign.return_value = b"wipe_signature"
-    private_key_wipe.public_key().to_bytes_raw.return_value = b"wipe_public_key"
-    
-    # Mock metadata key
-    private_key_metadata = MagicMock()
-    private_key_metadata.sign.return_value = b"metadata_signature"
-    private_key_metadata.public_key().to_bytes_raw.return_value = b"metadata_public_key"
-    
-    # Mock kyc key
-    private_key_kyc = MagicMock()
-    private_key_kyc.sign.return_value = b"kyc_signature"
-    private_key_kyc.public_key().to_bytes_raw.return_value = b"kyc_public_key"
+    # Generate real private keys for all key types
+    private_key_admin = PrivateKey.generate_ed25519()
+    private_key_supply = PrivateKey.generate_ed25519()
+    private_key_freeze = PrivateKey.generate_ed25519()
+    private_key_wipe = PrivateKey.generate_ed25519()
+    private_key_metadata = PrivateKey.generate_ed25519()
+    private_key_kyc = PrivateKey.generate_ed25519()
 
     token_tx = TokenCreateTransaction()
     token_tx.set_token_name("MyToken")
@@ -143,12 +123,12 @@ def test_build_transaction_body(mock_account_ids):
     assert transaction_body.tokenCreation.decimals == 2
     assert transaction_body.tokenCreation.initialSupply == 1000
 
-    assert transaction_body.tokenCreation.adminKey.ed25519 == b"admin_public_key"
-    assert transaction_body.tokenCreation.supplyKey.ed25519 == b"supply_public_key"
-    assert transaction_body.tokenCreation.freezeKey.ed25519 == b"freeze_public_key"
-    assert transaction_body.tokenCreation.wipeKey.ed25519 == b"wipe_public_key"
-    assert transaction_body.tokenCreation.metadata_key.ed25519 == b"metadata_public_key"
-    assert transaction_body.tokenCreation.kycKey.ed25519 == b"kyc_public_key"
+    assert transaction_body.tokenCreation.adminKey == private_key_admin.public_key()._to_proto()
+    assert transaction_body.tokenCreation.supplyKey == private_key_supply.public_key()._to_proto()
+    assert transaction_body.tokenCreation.freezeKey == private_key_freeze.public_key()._to_proto()
+    assert transaction_body.tokenCreation.wipeKey == private_key_wipe.public_key()._to_proto()
+    assert transaction_body.tokenCreation.metadata_key == private_key_metadata.public_key()._to_proto()
+    assert transaction_body.tokenCreation.kycKey == private_key_kyc.public_key()._to_proto()
 
 @pytest.mark.parametrize(
     "token_name, token_symbol, decimals, initial_supply, token_type, expected_error",
@@ -272,30 +252,31 @@ def test_sign_transaction(mock_account_ids, mock_client):
     private_key_admin = MagicMock()
     private_key_admin.sign.return_value = b"admin_signature"
     private_key_admin.public_key().to_bytes_raw.return_value = b"admin_public_key"
+    private_key_admin.public_key()._to_proto.return_value = basic_types_pb2.Key(ed25519=b"admin_public_key")
 
     private_key_supply = MagicMock()
     private_key_supply.sign.return_value = b"supply_signature"
-    private_key_supply.public_key().to_bytes_raw.return_value = b"supply_public_key"
+    private_key_supply.public_key()._to_proto.return_value = basic_types_pb2.Key(ed25519=b"supply_public_key")
 
     private_key_freeze = MagicMock()
     private_key_freeze.sign.return_value = b"freeze_signature"
-    private_key_freeze.public_key().to_bytes_raw.return_value = b"freeze_public_key"
-    
+    private_key_freeze.public_key()._to_proto.return_value = basic_types_pb2.Key(ed25519=b"freeze_public_key")
+
     private_key_wipe = MagicMock()
     private_key_wipe.sign.return_value = b"wipe_signature"
-    private_key_wipe.public_key().to_bytes_raw.return_value = b"wipe_public_key"
+    private_key_wipe.public_key()._to_proto.return_value = basic_types_pb2.Key(ed25519=b"wipe_public_key")
 
     private_key_metadata = MagicMock()
     private_key_metadata.sign.return_value = b"metadata_signature"
-    private_key_metadata.public_key().to_bytes_raw.return_value = b"metadata_public_key"
+    private_key_metadata.public_key()._to_proto.return_value = basic_types_pb2.Key(ed25519=b"metadata_public_key")
 
     private_key_pause = MagicMock()
     private_key_pause.sign.return_value = b"pause_signature"
-    private_key_pause.public_key().to_bytes_raw.return_value = b"pause_public_key"
+    private_key_pause.public_key()._to_proto.return_value = basic_types_pb2.Key(ed25519=b"pause_public_key")
 
     private_key_kyc = MagicMock()
     private_key_kyc.sign.return_value = b"kyc_signature"
-    private_key_kyc.public_key().to_bytes_raw.return_value = b"kyc_public_key"
+    private_key_kyc.public_key()._to_proto.return_value = basic_types_pb2.Key(ed25519=b"kyc_public_key")
 
     token_tx = TokenCreateTransaction()
     token_tx.set_token_name("MyToken")
@@ -393,35 +374,15 @@ def test_to_proto_with_keys(mock_account_ids, mock_client):
     """Test converting the token creation transaction to protobuf format after signing."""
     treasury_account, _, _, _, _ = mock_account_ids
 
-    # Mock keys
-    private_key = MagicMock()
-    private_key.sign.return_value = b"signature"
-    private_key.public_key().to_bytes_raw.return_value = b"public_key"
+    # Generate real private keys for all key types
+    private_key = PrivateKey.generate_ed25519()
+    private_key_admin = PrivateKey.generate_ed25519()
+    private_key_supply = PrivateKey.generate_ed25519()
+    private_key_freeze = PrivateKey.generate_ed25519()
+    private_key_wipe = PrivateKey.generate_ed25519()
+    private_key_metadata = PrivateKey.generate_ed25519()
+    private_key_kyc = PrivateKey.generate_ed25519()
 
-    private_key_admin = MagicMock()
-    private_key_admin.sign.return_value = b"admin_signature"
-    private_key_admin.public_key().to_bytes_raw.return_value = b"admin_public_key"
-
-    private_key_supply = MagicMock()
-    private_key_supply.sign.return_value = b"supply_signature"
-    private_key_supply.public_key().to_bytes_raw.return_value = b"supply_public_key"
-
-    private_key_freeze = MagicMock()
-    private_key_freeze.sign.return_value = b"freeze_signature"
-    private_key_freeze.public_key().to_bytes_raw.return_value = b"freeze_public_key"
-
-    private_key_wipe = MagicMock()
-    private_key_wipe.sign.return_value = b"wipe_signature"
-    private_key_wipe.public_key().to_bytes_raw.return_value = b"wipe_public_key"
-
-    private_key_metadata = MagicMock()
-    private_key_metadata.sign.return_value = b"metadata_signature"
-    private_key_metadata.public_key().to_bytes_raw.return_value = b"metadata_public_key"
-    
-    private_key_kyc = MagicMock()
-    private_key_kyc.sign.return_value = b"kyc_signature"
-    private_key_kyc.public_key().to_bytes_raw.return_value = b"kyc_public_key"
-    
     # Build the transaction
     token_tx = TokenCreateTransaction()
     token_tx.set_token_name("MyToken")
@@ -462,12 +423,13 @@ def test_to_proto_with_keys(mock_account_ids, mock_client):
 
     # Confirm fields set in the token creation portion of the TransactionBody
     assert tx_body.tokenCreation.name == "MyToken"
-    assert tx_body.tokenCreation.adminKey.ed25519 == b"admin_public_key"
-    assert tx_body.tokenCreation.supplyKey.ed25519 == b"supply_public_key"
-    assert tx_body.tokenCreation.freezeKey.ed25519 == b"freeze_public_key"
-    assert tx_body.tokenCreation.wipeKey.ed25519 == b"wipe_public_key"
-    assert tx_body.tokenCreation.metadata_key.ed25519 == b"metadata_public_key"
-    assert tx_body.tokenCreation.kycKey.ed25519 == b"kyc_public_key"
+    assert tx_body.tokenCreation.adminKey == private_key_admin.public_key()._to_proto()
+    assert tx_body.tokenCreation.supplyKey == private_key_supply.public_key()._to_proto()
+    assert tx_body.tokenCreation.freezeKey == private_key_freeze.public_key()._to_proto()
+    assert tx_body.tokenCreation.wipeKey == private_key_wipe.public_key()._to_proto()
+    assert tx_body.tokenCreation.metadata_key == private_key_metadata.public_key()._to_proto()
+    assert tx_body.tokenCreation.kycKey == private_key_kyc.public_key()._to_proto()
+
 # This test uses fixture mock_account_ids as parameter
 def test_freeze_status_without_freeze_key(mock_account_ids):
     """
@@ -710,30 +672,31 @@ def test_build_and_sign_nft_transaction_to_proto(mock_account_ids, mock_client):
     private_key_admin = MagicMock()
     private_key_admin.sign.return_value = b"admin_signature"
     private_key_admin.public_key().to_bytes_raw.return_value = b"admin_public_key"
+    private_key_admin.public_key()._to_proto.return_value = basic_types_pb2.Key(ed25519=b"admin_public_key")
 
     private_key_supply = MagicMock()
     private_key_supply.sign.return_value = b"supply_signature"
-    private_key_supply.public_key().to_bytes_raw.return_value = b"supply_public_key"
+    private_key_supply.public_key()._to_proto.return_value = basic_types_pb2.Key(ed25519=b"supply_public_key")
 
     private_key_freeze = MagicMock()
     private_key_freeze.sign.return_value = b"freeze_signature"
-    private_key_freeze.public_key().to_bytes_raw.return_value = b"freeze_public_key"
+    private_key_freeze.public_key()._to_proto.return_value = basic_types_pb2.Key(ed25519=b"freeze_public_key")
 
     private_key_wipe = MagicMock()
     private_key_wipe.sign.return_value = b"wipe_signature"
-    private_key_wipe.public_key().to_bytes_raw.return_value = b"wipe_public_key"
+    private_key_wipe.public_key()._to_proto.return_value = basic_types_pb2.Key(ed25519=b"wipe_public_key")
 
     private_key_metadata = MagicMock()
     private_key_metadata.sign.return_value = b"metadata_signature"
-    private_key_metadata.public_key().to_bytes_raw.return_value = b"metadata_public_key"
-    
+    private_key_metadata.public_key()._to_proto.return_value = basic_types_pb2.Key(ed25519=b"metadata_public_key")
+
     private_key_pause = MagicMock()
     private_key_pause.sign.return_value = b"pause_signature"
-    private_key_pause.public_key().to_bytes_raw.return_value = b"pause_public_key"
-    
+    private_key_pause.public_key()._to_proto.return_value = basic_types_pb2.Key(ed25519=b"pause_public_key")
+
     private_key_kyc = MagicMock()
     private_key_kyc.sign.return_value = b"kyc_signature"
-    private_key_kyc.public_key().to_bytes_raw.return_value = b"kyc_public_key"
+    private_key_kyc.public_key()._to_proto.return_value = basic_types_pb2.Key(ed25519=b"kyc_public_key")
 
     # Build the transaction
     token_tx = TokenCreateTransaction()


### PR DESCRIPTION
**Description**:

* Added `_parse_legacy_ecdsa_der_key()` method to handle legacy ECDSA DER encoded key parsing
* Query payment transaction building was hardcoded to only accept Ed25519 keys - updated to support both Ed25519 and ECDSA keys
* TokenCreateTransaction `_to_proto_key()` method was hardcoded to only create Ed25519 protobuf keys - updated to properly handle both Ed25519 and ECDSA key types using the `PrivateKey._to_proto()` method
* Fixed integration tests for topics and unit tests for token creation

**Related issue(s)**:

Fixes #243 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
