### PR TITLE
feat: add `ContractDeleteTransaction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 ### Added
+- ContractDeleteTransaction class
 - ContractExecuteTransaction class
 - setMessageAndPay() function in StatefulContract
 

--- a/examples/contract_delete.py
+++ b/examples/contract_delete.py
@@ -1,0 +1,162 @@
+"""
+Example demonstrating contract creation on the network.
+
+This module shows how to create a smart contract by:
+1. Setting up a client with operator credentials
+2. Creating a file containing contract bytecode
+3. Creating a contract using the file
+
+Usage:
+    # Due to the way the script is structured, it must be run as a module
+    # from the project root directory
+
+    # Run from the project root directory
+    python -m examples.contract_delete
+
+"""
+
+import os
+import sys
+
+from dotenv import load_dotenv
+
+from hiero_sdk_python import AccountId, Client, Network, PrivateKey
+from hiero_sdk_python.contract.contract_create_transaction import (
+    ContractCreateTransaction,
+)
+from hiero_sdk_python.contract.contract_delete_transaction import (
+    ContractDeleteTransaction,
+)
+from hiero_sdk_python.contract.contract_info_query import ContractInfoQuery
+from hiero_sdk_python.file.file_create_transaction import FileCreateTransaction
+from hiero_sdk_python.hbar import Hbar
+from hiero_sdk_python.response_code import ResponseCode
+
+# Import the bytecode for a basic smart contract (SimpleContract.sol) that can be deployed
+# The contract bytecode is pre-compiled from Solidity source code
+from .contracts import SIMPLE_CONTRACT_BYTECODE
+
+load_dotenv()
+
+
+def setup_client():
+    """Initialize and set up the client with operator account"""
+    network = Network(network="testnet")
+    client = Client(network)
+
+    operator_id = AccountId.from_string(os.getenv("OPERATOR_ID"))
+    operator_key = PrivateKey.from_string(os.getenv("OPERATOR_KEY"))
+    client.set_operator(operator_id, operator_key)
+
+    return client
+
+
+def create_contract_file(client):
+    """Create a file containing the contract bytecode"""
+    file_receipt = (
+        FileCreateTransaction()
+        .set_keys(client.operator_private_key.public_key())
+        .set_contents(SIMPLE_CONTRACT_BYTECODE)
+        .set_file_memo("Contract bytecode file")
+        .execute(client)
+    )
+
+    # Check if file creation was successful
+    if file_receipt.status != ResponseCode.SUCCESS:
+        print(
+            f"File creation failed with status: {ResponseCode(file_receipt.status).name}"
+        )
+        sys.exit(1)
+
+    return file_receipt.file_id
+
+
+def create_contract(client, file_id, initial_balance):
+    """Create a contract using the file"""
+    receipt = (
+        ContractCreateTransaction()
+        .set_admin_key(client.operator_private_key.public_key())
+        .set_initial_balance(initial_balance)
+        .set_gas(1000000)  # 1M gas
+        .set_bytecode_file_id(file_id)
+        .set_contract_memo("Simple smart contract")
+        .execute(client)
+    )
+
+    # Check if contract creation was successful
+    if receipt.status != ResponseCode.SUCCESS:
+        print(
+            f"Contract creation failed with status: {ResponseCode(receipt.status).name}"
+        )
+        sys.exit(1)
+
+    print(f"Contract created with ID: {receipt.contract_id}")
+
+    return receipt.contract_id
+
+
+def contract_delete():
+    """
+    Demonstrates deleting a contract on the network by:
+    1. Setting up client with operator account
+    2. Creating a file containing contract bytecode
+    3. Creating two contracts: one with balance, one for transfer
+    4. Deleting the contract and transferring the hbars to a transfer contract
+    5. Checking if the contract is deleted and the transfer contract has the hbars
+    6. Deleting the transfer contract and transferring the hbars to the operator account
+    7. Checking if the transfer contract is deleted
+    """
+    client = setup_client()
+
+    file_id = create_contract_file(client)
+
+    # Create contract with initial balance
+    initial_balance = Hbar(1).to_tinybars()
+    contract_id = create_contract(client, file_id, initial_balance)
+
+    # Create contract with 0 balance that will be used to transfer the hbars
+    transfer_contract_id = create_contract(client, file_id, 0)
+
+    # Delete the contract and transfer the hbars to the transfer contract
+    receipt = (
+        ContractDeleteTransaction()
+        .set_contract_id(contract_id)
+        .set_transfer_contract_id(transfer_contract_id)
+        .execute(client)
+    )
+
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Contract deletion failed with status: {ResponseCode(receipt.status).name}")
+        sys.exit(1)
+
+    print("\nSuccessfully deleted contract and transferred hbars to transfer contract")
+
+    # Check if the contract is deleted
+    contract_info = ContractInfoQuery(contract_id).execute(client)
+    print(f"Check contract is deleted: {contract_info.is_deleted}")
+
+    # Check if the transfer contract has the hbars
+    transfer_info = ContractInfoQuery(transfer_contract_id).execute(client)
+    print(f"Check transfer contract balance: {Hbar.from_tinybars(transfer_info.balance)}")
+
+    # Delete the transfer contract and transfer the hbars to the operator account
+    receipt = (
+        ContractDeleteTransaction()
+        .set_contract_id(transfer_contract_id)
+        .set_transfer_account_id(client.operator_account_id)
+        .execute(client)
+    )
+
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Transfer contract deletion failed with status: {ResponseCode(receipt.status).name}")
+        sys.exit(1)
+
+    print("\nSuccessfully deleted transfer contract and transferred hbars to operator account")
+
+    # Check if the transfer contract is deleted
+    transfer_info = ContractInfoQuery(transfer_contract_id).execute(client)
+    print(f"Check transfer contract is deleted: {transfer_info.is_deleted}")
+
+
+if __name__ == "__main__":
+    contract_delete()

--- a/examples/contract_delete.py
+++ b/examples/contract_delete.py
@@ -1,10 +1,14 @@
 """
-Example demonstrating contract creation on the network.
+Example demonstrating contract deletion on the network.
 
-This module shows how to create a smart contract by:
+This module shows how to delete a smart contract by:
 1. Setting up a client with operator credentials
 2. Creating a file containing contract bytecode
-3. Creating a contract using the file
+3. Creating 2 contracts using the file
+4. Deleting the first contract and transferring the hbars to the second contract
+5. Checking if the first contract is deleted and the second contract has the hbars
+6. Deleting the second contract and transferring the hbars to the operator account
+7. Checking if the second contract is deleted
 
 Usage:
     # Due to the way the script is structured, it must be run as a module

--- a/hiero/hedera_sdk_python/documentation/sdk_users/running_examples.md
+++ b/hiero/hedera_sdk_python/documentation/sdk_users/running_examples.md
@@ -61,6 +61,7 @@ You can choose either syntax or even mix both styles in your projects.
   - [Querying Contract Bytecode](#querying-contract-bytecode)
   - [Updating a Contract](#updating-a-contract)
   - [Executing a Contract](#executing-a-contract)
+  - [Deleting a Contract](#deleting-a-contract)
 - [Miscellaneous Queries](#miscellaneous-queries)
   - [Querying Transaction Record](#querying-transaction-record)
 
@@ -1415,6 +1416,53 @@ transaction.sign(operator_key)
 transaction.execute(client)
 ```
 
+### Deleting a Contract
+
+#### Pythonic Syntax:
+```python
+# Option 1: Transfer contract balance to an account
+transaction = ContractDeleteTransaction(
+    contract_id=contract_id,
+    transfer_account_id=recipient_account_id
+).freeze_with(client)
+
+transaction.sign(admin_key)  # Admin key must have been set during contract creation
+transaction.execute(client)
+
+# Option 2: Transfer contract balance to another contract
+transaction = ContractDeleteTransaction(
+    contract_id=contract_id,
+    transfer_contract_id=transfer_contract_id
+).freeze_with(client)
+
+transaction.sign(admin_key)  # Admin key must have been set during contract creation
+transaction.execute(client)
+```
+
+#### Method Chaining:
+```python
+# Option 1: Transfer contract balance to an account
+transaction = (
+    ContractDeleteTransaction()
+    .set_contract_id(contract_id)
+    .set_transfer_account_id(recipient_account_id)
+    .freeze_with(client)
+)
+
+transaction.sign(admin_key)  # Admin key must have been set during contract creation
+transaction.execute(client)
+
+# Option 2: Transfer contract balance to another contract
+transaction = (
+    ContractDeleteTransaction()
+    .set_contract_id(contract_id)
+    .set_transfer_contract_id(recipient_contract_id)
+    .freeze_with(client)
+)
+
+transaction.sign(admin_key)  # Admin key must have been set during contract creation
+transaction.execute(client)
+```
 
 ## Miscellaneous Queries
 

--- a/src/hiero_sdk_python/__init__.py
+++ b/src/hiero_sdk_python/__init__.py
@@ -99,6 +99,7 @@ from .contract.contract_call_query import ContractCallQuery
 from .contract.contract_info_query import ContractInfoQuery
 from .contract.contract_bytecode_query import ContractBytecodeQuery
 from .contract.contract_execute_transaction import ContractExecuteTransaction
+from .contract.contract_delete_transaction import ContractDeleteTransaction
 from .contract.contract_function_parameters import ContractFunctionParameters
 from .contract.contract_function_result import ContractFunctionResult
 from .contract.contract_info import ContractInfo
@@ -202,6 +203,7 @@ __all__ = [
     "ContractInfoQuery",
     "ContractBytecodeQuery",
     "ContractExecuteTransaction",
+    "ContractDeleteTransaction",
     "ContractFunctionParameters",
     "ContractFunctionResult",
     "ContractInfo",

--- a/src/hiero_sdk_python/contract/contract_delete_transaction.py
+++ b/src/hiero_sdk_python/contract/contract_delete_transaction.py
@@ -1,0 +1,187 @@
+"""
+ContractDeleteTransaction class.
+"""
+
+from typing import Optional
+
+from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.channels import _Channel
+from hiero_sdk_python.contract.contract_id import ContractId
+from hiero_sdk_python.executable import _Method
+from hiero_sdk_python.hapi.services.contract_delete_pb2 import (
+    ContractDeleteTransactionBody,
+)
+from hiero_sdk_python.hbar import Hbar
+from hiero_sdk_python.transaction.transaction import Transaction
+
+
+class ContractDeleteTransaction(Transaction):
+    """
+    A transaction that deletes a smart contract.
+
+    This transaction can be used to delete an existing smart contract from the network.
+    When a contract is deleted, its remaining balance can be transferred to either
+    another contract or an account. The contract can also be permanently removed
+    from the network state.
+
+    Args:
+        contract_id (Optional[ContractId]): The ID of the contract to delete.
+        transfer_contract_id (Optional[ContractId]): The contract ID to transfer
+            remaining balance to.
+        transfer_account_id (Optional[AccountId]): The account ID to transfer
+            remaining balance to.
+        permanent_removal (Optional[bool]): Whether to permanently remove the
+            contract from network state.
+    """
+
+    def __init__(
+        self,
+        contract_id: Optional[ContractId] = None,
+        transfer_contract_id: Optional[ContractId] = None,
+        transfer_account_id: Optional[AccountId] = None,
+        permanent_removal: Optional[bool] = None,
+    ):
+        """
+        Initializes a new ContractDeleteTransaction instance.
+
+        Args:
+            contract_id (Optional[ContractId]): The ID of the contract to delete.
+            transfer_contract_id (Optional[ContractId]): The contract ID to transfer
+                remaining balance to.
+            transfer_account_id (Optional[AccountId]): The account ID to transfer
+                remaining balance to.
+            permanent_removal (Optional[bool]): Whether to permanently remove the
+                contract from network state.
+        """
+        super().__init__()
+        self.contract_id: Optional[ContractId] = contract_id
+        self.transfer_contract_id: Optional[ContractId] = transfer_contract_id
+        self.transfer_account_id: Optional[AccountId] = transfer_account_id
+        self.permanent_removal: Optional[bool] = permanent_removal
+        self._default_transaction_fee = Hbar(2).to_tinybars()
+
+    def set_contract_id(
+        self, contract_id: Optional[ContractId]
+    ) -> "ContractDeleteTransaction":
+        """
+        Sets the ID of the contract to delete.
+
+        Args:
+            contract_id (Optional[ContractId]): The ID of the contract to delete.
+
+        Returns:
+            ContractDeleteTransaction: This transaction instance.
+        """
+        self._require_not_frozen()
+        self.contract_id = contract_id
+        return self
+
+    def set_transfer_contract_id(
+        self, transfer_contract_id: Optional[ContractId]
+    ) -> "ContractDeleteTransaction":
+        """
+        Sets the contract ID to transfer the remaining balance to.
+
+        When a contract is deleted, its remaining balance must be transferred
+        to either another contract or an account. This method sets the target
+        contract for the balance transfer.
+
+        Args:
+            transfer_contract_id (Optional[ContractId]): The contract ID to transfer
+                remaining balance to.
+
+        Returns:
+            ContractDeleteTransaction: This transaction instance.
+        """
+        self._require_not_frozen()
+        self.transfer_contract_id = transfer_contract_id
+        return self
+
+    def set_transfer_account_id(
+        self, transfer_account_id: Optional[AccountId]
+    ) -> "ContractDeleteTransaction":
+        """
+        Sets the account ID to transfer the remaining balance to.
+
+        When a contract is deleted, its remaining balance must be transferred
+        to either another contract or an account. This method sets the target
+        account for the balance transfer.
+
+        Args:
+            transfer_account_id (Optional[AccountId]): The account ID to transfer
+                remaining balance to.
+
+        Returns:
+            ContractDeleteTransaction: This transaction instance.
+        """
+        self._require_not_frozen()
+        self.transfer_account_id = transfer_account_id
+        return self
+
+    def set_permanent_removal(
+        self, permanent_removal: Optional[bool]
+    ) -> "ContractDeleteTransaction":
+        """
+        Sets whether to permanently remove the contract from network state.
+
+        When set to True, the contract will be permanently removed from the
+        network state and cannot be recovered. When False, the contract may
+        be recoverable depending on network configuration.
+
+        Args:
+            permanent_removal (Optional[bool]): Whether to permanently remove the
+                contract from network state.
+
+        Returns:
+            ContractDeleteTransaction: This transaction instance.
+        """
+        self._require_not_frozen()
+        self.permanent_removal = permanent_removal
+        return self
+
+    def build_transaction_body(self):
+        """
+        Builds the transaction body for this contract delete transaction.
+
+        Returns:
+            TransactionBody: The built transaction body.
+
+        Raises:
+            ValueError: If contract_id is not set.
+        """
+        if self.contract_id is None:
+            raise ValueError("Missing required ContractID")
+
+        contract_delete_body = ContractDeleteTransactionBody(
+            contractID=self.contract_id._to_proto(),
+            transferContractID=(
+                self.transfer_contract_id._to_proto()
+                if self.transfer_contract_id
+                else None
+            ),
+            transferAccountID=(
+                self.transfer_account_id._to_proto()
+                if self.transfer_account_id
+                else None
+            ),
+            permanent_removal=self.permanent_removal,
+        )
+
+        transaction_body = self.build_base_transaction_body()
+        transaction_body.contractDeleteInstance.CopyFrom(contract_delete_body)
+        return transaction_body
+
+    def _get_method(self, channel: _Channel) -> _Method:
+        """
+        Gets the method to execute the contract delete transaction.
+
+        Args:
+            channel (_Channel): The channel containing service stubs.
+
+        Returns:
+            _Method: An object containing the transaction function to
+                delete contracts.
+        """
+        return _Method(
+            transaction_func=channel.smart_contract.deleteContract, query_func=None
+        )

--- a/tests/integration/contract_delete_transaction_e2e_test.py
+++ b/tests/integration/contract_delete_transaction_e2e_test.py
@@ -1,0 +1,279 @@
+"""
+Integration tests for ContractDeleteTransaction.
+"""
+
+import pytest
+
+from examples.contracts import CONTRACT_DEPLOY_GAS, SIMPLE_CONTRACT_BYTECODE
+from hiero_sdk_python.contract.contract_create_transaction import (
+    ContractCreateTransaction,
+)
+from hiero_sdk_python.contract.contract_delete_transaction import (
+    ContractDeleteTransaction,
+)
+from hiero_sdk_python.contract.contract_id import ContractId
+from hiero_sdk_python.contract.contract_info_query import ContractInfoQuery
+from hiero_sdk_python.crypto.private_key import PrivateKey
+from hiero_sdk_python.exceptions import PrecheckError
+from hiero_sdk_python.hbar import Hbar
+from hiero_sdk_python.query.account_info_query import AccountInfoQuery
+from hiero_sdk_python.response_code import ResponseCode
+from tests.integration.utils_for_test import env
+
+
+@pytest.mark.integration
+def test_integration_contract_delete_transaction_can_transfer_balance_to_account(env):
+    """Test that the ContractDeleteTransaction can transfer the contract balance to account."""
+    receipt = (
+        ContractCreateTransaction()
+        .set_admin_key(env.operator_key.public_key())
+        .set_bytecode(bytes.fromhex(SIMPLE_CONTRACT_BYTECODE))
+        .set_initial_balance(Hbar(1).to_tinybars())
+        .set_gas(CONTRACT_DEPLOY_GAS)
+        .set_contract_memo("test contract delete transaction")
+        .execute(env.client)
+    )
+    assert (
+        receipt.status == ResponseCode.SUCCESS
+    ), f"Contract creation failed with status: {ResponseCode(receipt.status).name}"
+
+    contract_id = receipt.contract_id
+    assert contract_id is not None, "Contract ID should not be None"
+
+    # Create account with 1 HBAR initial balance
+    account = env.create_account()
+
+    receipt = (
+        ContractDeleteTransaction()
+        .set_contract_id(contract_id)
+        .set_transfer_account_id(account.id)
+        .execute(env.client)
+    )
+
+    assert (
+        receipt.status == ResponseCode.SUCCESS
+    ), f"Delete contract failed with status: {ResponseCode(receipt.status).name}"
+
+    contract_info = ContractInfoQuery(contract_id).execute(env.client)
+    assert contract_info.is_deleted is True, "Contract should be deleted"
+
+    account_info = AccountInfoQuery(account.id).execute(env.client)
+    assert account_info.account_id == account.id, "Account ID should match"
+    assert (
+        account_info.balance.to_tinybars() == Hbar(2).to_tinybars()
+    ), f"Account balance should be 2 HBAR but got {account_info.balance.to_tinybars()}"
+
+
+@pytest.mark.integration
+def test_integration_contract_delete_transaction_can_transfer_balance_to_contract(env):
+    """Test that the ContractDeleteTransaction can transfer the contract balance to contract."""
+    receipt = (
+        ContractCreateTransaction()
+        .set_bytecode(bytes.fromhex(SIMPLE_CONTRACT_BYTECODE))
+        .set_initial_balance(Hbar(1).to_tinybars())
+        .set_admin_key(env.operator_key.public_key())
+        .set_gas(CONTRACT_DEPLOY_GAS)
+        .set_contract_memo("test contract delete transaction")
+        .execute(env.client)
+    )
+    assert (
+        receipt.status == ResponseCode.SUCCESS
+    ), f"Contract creation failed with status: {ResponseCode(receipt.status).name}"
+
+    contract_id = receipt.contract_id
+    assert contract_id is not None, "Contract ID should not be None"
+
+    receipt = (
+        ContractCreateTransaction()
+        .set_bytecode(bytes.fromhex(SIMPLE_CONTRACT_BYTECODE))
+        .set_initial_balance(Hbar(1).to_tinybars())
+        .set_admin_key(env.operator_key.public_key())
+        .set_gas(CONTRACT_DEPLOY_GAS)
+        .set_contract_memo("contract to transfer balance to")
+        .execute(env.client)
+    )
+    assert (
+        receipt.status == ResponseCode.SUCCESS
+    ), f"Contract creation failed with status: {ResponseCode(receipt.status).name}"
+
+    transfer_contract_id = receipt.contract_id
+    assert transfer_contract_id is not None, "Contract ID should not be None"
+
+    receipt = (
+        ContractDeleteTransaction()
+        .set_contract_id(contract_id)
+        .set_transfer_contract_id(transfer_contract_id)
+        .execute(env.client)
+    )
+    assert (
+        receipt.status == ResponseCode.SUCCESS
+    ), f"Contract deletion failed with status: {ResponseCode(receipt.status).name}"
+
+    contract_info = ContractInfoQuery(contract_id).execute(env.client)
+    assert contract_info.is_deleted is True, "Contract should be deleted"
+
+    transfer_contract_info = ContractInfoQuery(transfer_contract_id).execute(env.client)
+    assert (
+        transfer_contract_info.contract_id == transfer_contract_id
+    ), "Contract ID should match"
+    assert (
+        transfer_contract_info.balance == Hbar(2).to_tinybars()
+    ), "Contract balance should be 2 HBAR"
+
+
+@pytest.mark.integration
+def test_integration_contract_delete_transaction_fails_when_deleted_twice(env):
+    """Test that deleting a contract twice fails."""
+    receipt = (
+        ContractCreateTransaction()
+        .set_admin_key(env.operator_key.public_key())
+        .set_gas(CONTRACT_DEPLOY_GAS)
+        .set_bytecode(bytes.fromhex(SIMPLE_CONTRACT_BYTECODE))
+        .set_contract_memo("some test contract create transaction memo")
+        .execute(env.client)
+    )
+
+    assert (
+        receipt.status == ResponseCode.SUCCESS
+    ), f"Contract creation failed with status: {ResponseCode(receipt.status).name}"
+
+    contract_id = receipt.contract_id
+    assert contract_id is not None, "Contract ID should not be None"
+
+    # Delete once
+    receipt = (
+        ContractDeleteTransaction()
+        .set_contract_id(contract_id)
+        .set_transfer_account_id(env.operator_id)
+        .execute(env.client)
+    )
+    assert (
+        receipt.status == ResponseCode.SUCCESS
+    ), f"Contract deletion failed with status: {ResponseCode(receipt.status).name}"
+
+    # Try to delete again
+    receipt = (
+        ContractDeleteTransaction()
+        .set_contract_id(contract_id)
+        .set_transfer_account_id(env.operator_id)
+        .execute(env.client)
+    )
+    assert receipt.status == ResponseCode.CONTRACT_DELETED, (
+        f"Contract deletion should have failed with CONTRACT_DELETED status but got: "
+        f"{ResponseCode(receipt.status).name}"
+    )
+
+
+@pytest.mark.integration
+def test_integration_contract_delete_transaction_fails_when_contract_does_not_exist(
+    env,
+):
+    """Test that deleting a non-existing contract fails."""
+    # Create a contract ID that doesn't exist on the network
+    contract_id = ContractId(0, 0, 999999999)
+
+    receipt = (
+        ContractDeleteTransaction()
+        .set_contract_id(contract_id)
+        .set_transfer_account_id(env.operator_id)
+        .execute(env.client)
+    )
+    assert receipt.status == ResponseCode.INVALID_CONTRACT_ID, (
+        f"Contract deletion should have failed with INVALID_CONTRACT_ID status but got: "
+        f"{ResponseCode(receipt.status).name}"
+    )
+
+
+@pytest.mark.integration
+def test_integration_contract_delete_transaction_fails_with_obtainer_required(env):
+    """Test that contract deletion fails if no transfer account or contract is set."""
+    receipt = (
+        ContractCreateTransaction()
+        .set_bytecode(bytes.fromhex(SIMPLE_CONTRACT_BYTECODE))
+        .set_gas(CONTRACT_DEPLOY_GAS)
+        .set_contract_memo("test contract delete transaction")
+        .set_initial_balance(Hbar(1).to_tinybars())
+        .execute(env.client)
+    )
+    assert (
+        receipt.status == ResponseCode.SUCCESS
+    ), f"Contract creation failed with status: {ResponseCode(receipt.status).name}"
+
+    contract_id = receipt.contract_id
+    assert contract_id is not None, "Contract ID should not be None"
+
+    # Attempt to delete without setting transfer_account_id or transfer_contract_id
+    with pytest.raises(
+        PrecheckError, match="failed precheck with status: OBTAINER_REQUIRED"
+    ):
+        ContractDeleteTransaction().set_contract_id(contract_id).execute(env.client)
+
+
+@pytest.mark.integration
+def test_integration_contract_delete_transaction_fails_with_immutable_contract(env):
+    """Test that contract deletion fails if the contract is immutable."""
+    # Create a contract without admin key to make it immutable
+    # This prevents the contract from being deleted later
+    receipt = (
+        ContractCreateTransaction()
+        .set_bytecode(bytes.fromhex(SIMPLE_CONTRACT_BYTECODE))
+        .set_gas(CONTRACT_DEPLOY_GAS)
+        .set_contract_memo("test contract delete transaction")
+        .set_initial_balance(Hbar(1).to_tinybars())
+        .execute(env.client)
+    )
+    assert (
+        receipt.status == ResponseCode.SUCCESS
+    ), f"Contract creation failed with status: {ResponseCode(receipt.status).name}"
+
+    contract_id = receipt.contract_id
+    assert contract_id is not None, "Contract ID should not be None"
+
+    receipt = (
+        ContractDeleteTransaction()
+        .set_contract_id(contract_id)
+        .set_transfer_account_id(env.operator_id)
+        .execute(env.client)
+    )
+
+    assert receipt.status == ResponseCode.MODIFYING_IMMUTABLE_CONTRACT, (
+        f"Contract deletion should have failed with MODIFYING_IMMUTABLE_CONTRACT status but got: "
+        f"{ResponseCode(receipt.status).name}"
+    )
+
+
+@pytest.mark.integration
+def test_integration_contract_delete_transaction_fails_with_invalid_signature(env):
+    """Test that contract deletion fails if the signature is invalid."""
+    admin_private_key = PrivateKey.generate_ed25519()
+
+    receipt = (
+        ContractCreateTransaction()
+        .set_admin_key(admin_private_key.public_key())
+        .set_bytecode(bytes.fromhex(SIMPLE_CONTRACT_BYTECODE))
+        .set_gas(CONTRACT_DEPLOY_GAS)
+        .set_contract_memo("test contract delete transaction")
+        .set_initial_balance(Hbar(1).to_tinybars())
+        .freeze_with(env.client)
+        .sign(admin_private_key)
+        .execute(env.client)
+    )
+    assert (
+        receipt.status == ResponseCode.SUCCESS
+    ), f"Contract creation failed with status: {ResponseCode(receipt.status).name}"
+
+    contract_id = receipt.contract_id
+    assert contract_id is not None, "Contract ID should not be None"
+
+    # Try to delete without signing with the admin key
+    receipt = (
+        ContractDeleteTransaction()
+        .set_contract_id(contract_id)
+        .set_transfer_account_id(env.operator_id)
+        .execute(env.client)
+    )
+
+    assert receipt.status == ResponseCode.INVALID_SIGNATURE, (
+        f"Contract deletion should have failed with INVALID_SIGNATURE status but got: "
+        f"{ResponseCode(receipt.status).name}"
+    )

--- a/tests/unit/test_contract_delete_transaction.py
+++ b/tests/unit/test_contract_delete_transaction.py
@@ -1,0 +1,446 @@
+"""
+Test cases for the ContractDeleteTransaction class.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.contract.contract_delete_transaction import (
+    ContractDeleteTransaction,
+)
+from hiero_sdk_python.contract.contract_id import ContractId
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def delete_params():
+    """Fixture for contract delete parameters."""
+    return {
+        "contract_id": ContractId(0, 0, 123),
+        "transfer_contract_id": ContractId(0, 0, 456),
+        "transfer_account_id": AccountId(0, 0, 789),
+        "permanent_removal": True,
+    }
+
+
+def test_constructor_with_parameters(delete_params):
+    """Test creating a contract delete transaction with constructor parameters."""
+    delete_tx = ContractDeleteTransaction(
+        contract_id=delete_params["contract_id"],
+        transfer_contract_id=delete_params["transfer_contract_id"],
+        transfer_account_id=delete_params["transfer_account_id"],
+        permanent_removal=delete_params["permanent_removal"],
+    )
+
+    assert delete_tx.contract_id == delete_params["contract_id"]
+    assert delete_tx.transfer_contract_id == delete_params["transfer_contract_id"]
+    assert delete_tx.transfer_account_id == delete_params["transfer_account_id"]
+    assert delete_tx.permanent_removal == delete_params["permanent_removal"]
+
+
+def test_constructor_with_contract_id_only(delete_params):
+    """Test creating a contract delete transaction with only contract_id."""
+    delete_tx = ContractDeleteTransaction(contract_id=delete_params["contract_id"])
+
+    assert delete_tx.contract_id == delete_params["contract_id"]
+    assert delete_tx.transfer_contract_id is None
+    assert delete_tx.transfer_account_id is None
+    assert delete_tx.permanent_removal is None
+
+
+def test_constructor_default_values():
+    """Test that constructor sets default values correctly."""
+    delete_tx = ContractDeleteTransaction()
+
+    assert delete_tx.contract_id is None
+    assert delete_tx.transfer_contract_id is None
+    assert delete_tx.transfer_account_id is None
+    assert delete_tx.permanent_removal is None
+
+
+def test_build_transaction_body_with_valid_parameters(mock_account_ids, delete_params):
+    """Test building a contract delete transaction body with valid parameters."""
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    delete_tx = ContractDeleteTransaction(
+        contract_id=delete_params["contract_id"],
+        transfer_contract_id=delete_params["transfer_contract_id"],
+        transfer_account_id=delete_params["transfer_account_id"],
+        permanent_removal=delete_params["permanent_removal"],
+    )
+
+    # Set operator and node account IDs needed for building transaction body
+    delete_tx.operator_account_id = operator_id
+    delete_tx.node_account_id = node_account_id
+
+    transaction_body = delete_tx.build_transaction_body()
+
+    # When both transfer_account_id and transfer_contract_id are set,
+    # the protobuf only will only set transferAccountID
+    assert (
+        transaction_body.contractDeleteInstance.contractID
+        == delete_params["contract_id"]._to_proto()
+    )
+    assert (
+        transaction_body.contractDeleteInstance.transferAccountID
+        == delete_params["transfer_account_id"]._to_proto()
+    )
+    assert (
+        transaction_body.contractDeleteInstance.permanent_removal
+        == delete_params["permanent_removal"]
+    )
+
+
+def test_build_transaction_body_with_required_params_only(
+    mock_account_ids, contract_id
+):
+    """Test building transaction body with only required parameters."""
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    delete_tx = ContractDeleteTransaction(contract_id=contract_id)
+
+    # Set operator and node account IDs needed for building transaction body
+    delete_tx.operator_account_id = operator_id
+    delete_tx.node_account_id = node_account_id
+
+    transaction_body = delete_tx.build_transaction_body()
+
+    assert transaction_body.contractDeleteInstance.contractID == contract_id._to_proto()
+    assert not transaction_body.contractDeleteInstance.HasField("transferContractID")
+    assert not transaction_body.contractDeleteInstance.HasField("transferAccountID")
+    assert transaction_body.contractDeleteInstance.permanent_removal is False
+
+
+def test_build_transaction_body_with_transfer_contract_id_only(
+    mock_account_ids, delete_params
+):
+    """Test building transaction body with transfer_contract_id only."""
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    delete_tx = ContractDeleteTransaction(
+        contract_id=delete_params["contract_id"],
+        transfer_contract_id=delete_params["transfer_contract_id"],
+    )
+
+    delete_tx.operator_account_id = operator_id
+    delete_tx.node_account_id = node_account_id
+
+    transaction_body = delete_tx.build_transaction_body()
+
+    assert (
+        transaction_body.contractDeleteInstance.contractID
+        == delete_params["contract_id"]._to_proto()
+    )
+    assert (
+        transaction_body.contractDeleteInstance.transferContractID
+        == delete_params["transfer_contract_id"]._to_proto()
+    )
+    assert not transaction_body.contractDeleteInstance.HasField("transferAccountID")
+    assert transaction_body.contractDeleteInstance.permanent_removal is False
+
+
+def test_build_transaction_body_with_transfer_account_id_only(
+    mock_account_ids, delete_params
+):
+    """Test building transaction body with transfer_account_id only."""
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    delete_tx = ContractDeleteTransaction(
+        contract_id=delete_params["contract_id"],
+        transfer_account_id=delete_params["transfer_account_id"],
+    )
+
+    delete_tx.operator_account_id = operator_id
+    delete_tx.node_account_id = node_account_id
+
+    transaction_body = delete_tx.build_transaction_body()
+
+    assert (
+        transaction_body.contractDeleteInstance.contractID
+        == delete_params["contract_id"]._to_proto()
+    )
+    assert not transaction_body.contractDeleteInstance.HasField("transferContractID")
+    assert (
+        transaction_body.contractDeleteInstance.transferAccountID
+        == delete_params["transfer_account_id"]._to_proto()
+    )
+    assert transaction_body.contractDeleteInstance.permanent_removal is False
+
+
+def test_build_transaction_body_with_permanent_removal_only(
+    mock_account_ids, delete_params
+):
+    """Test building transaction body with permanent_removal only."""
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    delete_tx = ContractDeleteTransaction(
+        contract_id=delete_params["contract_id"],
+        permanent_removal=delete_params["permanent_removal"],
+    )
+
+    delete_tx.operator_account_id = operator_id
+    delete_tx.node_account_id = node_account_id
+
+    transaction_body = delete_tx.build_transaction_body()
+
+    assert (
+        transaction_body.contractDeleteInstance.contractID
+        == delete_params["contract_id"]._to_proto()
+    )
+    assert not transaction_body.contractDeleteInstance.HasField("transferContractID")
+    assert not transaction_body.contractDeleteInstance.HasField("transferAccountID")
+    assert (
+        transaction_body.contractDeleteInstance.permanent_removal
+        == delete_params["permanent_removal"]
+    )
+
+
+def test_build_transaction_body_missing_contract_id():
+    """Test that build_transaction_body raises ValueError when contract_id is missing."""
+    delete_tx = ContractDeleteTransaction()
+
+    with pytest.raises(ValueError, match="Missing required ContractID"):
+        delete_tx.build_transaction_body()
+
+
+def test_set_contract_id(delete_params):
+    """Test setting contract_id using the setter method."""
+    delete_tx = ContractDeleteTransaction()
+
+    result = delete_tx.set_contract_id(delete_params["contract_id"])
+
+    assert delete_tx.contract_id == delete_params["contract_id"]
+    assert result is delete_tx  # Should return self for method chaining
+
+
+def test_set_transfer_contract_id(delete_params):
+    """Test setting transfer_contract_id using the setter method."""
+    delete_tx = ContractDeleteTransaction()
+
+    result = delete_tx.set_transfer_contract_id(delete_params["transfer_contract_id"])
+
+    assert delete_tx.transfer_contract_id == delete_params["transfer_contract_id"]
+    assert result is delete_tx  # Should return self for method chaining
+
+
+def test_set_transfer_account_id(delete_params):
+    """Test setting transfer_account_id using the setter method."""
+    delete_tx = ContractDeleteTransaction()
+
+    result = delete_tx.set_transfer_account_id(delete_params["transfer_account_id"])
+
+    assert delete_tx.transfer_account_id == delete_params["transfer_account_id"]
+    assert result is delete_tx  # Should return self for method chaining
+
+
+def test_set_permanent_removal(delete_params):
+    """Test setting permanent_removal using the setter method."""
+    delete_tx = ContractDeleteTransaction()
+
+    result = delete_tx.set_permanent_removal(delete_params["permanent_removal"])
+
+    assert delete_tx.permanent_removal == delete_params["permanent_removal"]
+    assert result is delete_tx  # Should return self for method chaining
+
+
+def test_set_permanent_removal_boolean_values():
+    """Test setting permanent_removal with both True and False values."""
+    delete_tx = ContractDeleteTransaction()
+
+    # Test setting to True
+    result = delete_tx.set_permanent_removal(True)
+    assert delete_tx.permanent_removal is True
+    assert result is delete_tx
+
+    # Test setting to False
+    result = delete_tx.set_permanent_removal(False)
+    assert delete_tx.permanent_removal is False
+    assert result is delete_tx
+
+    # Test setting to None
+    result = delete_tx.set_permanent_removal(None)
+    assert delete_tx.permanent_removal is None
+    assert result is delete_tx
+
+
+def test_method_chaining_with_all_setters(delete_params):
+    """Test that all setter methods support method chaining."""
+    delete_tx = ContractDeleteTransaction()
+
+    result = (
+        delete_tx.set_contract_id(delete_params["contract_id"])
+        .set_transfer_contract_id(delete_params["transfer_contract_id"])
+        .set_transfer_account_id(delete_params["transfer_account_id"])
+        .set_permanent_removal(delete_params["permanent_removal"])
+    )
+
+    assert result is delete_tx
+    assert delete_tx.contract_id == delete_params["contract_id"]
+    assert delete_tx.transfer_contract_id == delete_params["transfer_contract_id"]
+    assert delete_tx.transfer_account_id == delete_params["transfer_account_id"]
+    assert delete_tx.permanent_removal == delete_params["permanent_removal"]
+
+
+def test_method_chaining_partial_setters(delete_params):
+    """Test method chaining with only some setters."""
+    delete_tx = ContractDeleteTransaction()
+
+    result = delete_tx.set_contract_id(
+        delete_params["contract_id"]
+    ).set_permanent_removal(True)
+
+    assert result is delete_tx
+    assert delete_tx.contract_id == delete_params["contract_id"]
+    assert delete_tx.transfer_contract_id is None
+    assert delete_tx.transfer_account_id is None
+    assert delete_tx.permanent_removal is True
+
+
+def test_set_methods_require_not_frozen(mock_client, delete_params):
+    """Test that setter methods raise exception when transaction is frozen."""
+    delete_tx = ContractDeleteTransaction(contract_id=delete_params["contract_id"])
+    delete_tx.freeze_with(mock_client)
+
+    test_cases = [
+        ("set_contract_id", delete_params["contract_id"]),
+        ("set_transfer_contract_id", delete_params["transfer_contract_id"]),
+        ("set_transfer_account_id", delete_params["transfer_account_id"]),
+        ("set_permanent_removal", delete_params["permanent_removal"]),
+    ]
+
+    for method_name, value in test_cases:
+        with pytest.raises(
+            Exception, match="Transaction is immutable; it has been frozen"
+        ):
+            getattr(delete_tx, method_name)(value)
+
+
+def test_sign_transaction(mock_client, delete_params):
+    """Test signing the contract delete transaction with a private key."""
+    delete_tx = ContractDeleteTransaction(contract_id=delete_params["contract_id"])
+
+    private_key = MagicMock()
+    private_key.sign.return_value = b"signature"
+    private_key.public_key().to_bytes_raw.return_value = b"public_key"
+
+    delete_tx.freeze_with(mock_client)
+    delete_tx.sign(private_key)
+
+    node_id = mock_client.network.current_node._account_id
+    body_bytes = delete_tx._transaction_body_bytes[node_id]
+
+    assert len(delete_tx._signature_map[body_bytes].sigPair) == 1
+    sig_pair = delete_tx._signature_map[body_bytes].sigPair[0]
+    assert sig_pair.pubKeyPrefix == b"public_key"
+    assert sig_pair.ed25519 == b"signature"
+
+
+def test_to_proto(mock_client, delete_params):
+    """Test converting the contract delete transaction to protobuf format after signing."""
+    delete_tx = ContractDeleteTransaction(contract_id=delete_params["contract_id"])
+
+    private_key = MagicMock()
+    private_key.sign.return_value = b"signature"
+    private_key.public_key().to_bytes_raw.return_value = b"public_key"
+
+    delete_tx.freeze_with(mock_client)
+    delete_tx.sign(private_key)
+    proto = delete_tx._to_proto()
+
+    assert proto.signedTransactionBytes
+    assert len(proto.signedTransactionBytes) > 0
+
+
+def test_get_method():
+    """Test retrieving the gRPC method for the transaction."""
+    delete_tx = ContractDeleteTransaction()
+
+    mock_channel = MagicMock()
+    mock_smart_contract_stub = MagicMock()
+    mock_channel.smart_contract = mock_smart_contract_stub
+
+    method = delete_tx._get_method(mock_channel)
+
+    assert method.query is None
+    assert method.transaction == mock_smart_contract_stub.deleteContract
+
+
+def test_parameter_validation_types(delete_params):
+    """Test that parameters accept the correct types."""
+    delete_tx = ContractDeleteTransaction()
+
+    # Test with valid types
+    delete_tx.set_contract_id(delete_params["contract_id"])
+    assert isinstance(delete_tx.contract_id, ContractId)
+
+    delete_tx.set_transfer_contract_id(delete_params["transfer_contract_id"])
+    assert isinstance(delete_tx.transfer_contract_id, ContractId)
+
+    delete_tx.set_transfer_account_id(delete_params["transfer_account_id"])
+    assert isinstance(delete_tx.transfer_account_id, AccountId)
+
+    delete_tx.set_permanent_removal(delete_params["permanent_removal"])
+    assert isinstance(delete_tx.permanent_removal, bool)
+
+
+def test_parameter_validation_none_values():
+    """Test that parameters can be set to None."""
+    delete_tx = ContractDeleteTransaction(
+        contract_id=ContractId(0, 0, 123),
+        transfer_contract_id=ContractId(0, 0, 456),
+        transfer_account_id=AccountId(0, 0, 789),
+        permanent_removal=True,
+    )
+
+    # All parameters except contract_id can be set to None
+    delete_tx.set_transfer_contract_id(None)
+    assert delete_tx.transfer_contract_id is None
+
+    delete_tx.set_transfer_account_id(None)
+    assert delete_tx.transfer_account_id is None
+
+    delete_tx.set_permanent_removal(None)
+    assert delete_tx.permanent_removal is None
+
+    delete_tx.set_contract_id(None)
+    assert delete_tx.contract_id is None
+
+
+def test_constructor_parameter_combinations():
+    """Test various constructor parameter combinations."""
+    contract_id = ContractId(0, 0, 123)
+    transfer_contract_id = ContractId(0, 0, 456)
+    transfer_account_id = AccountId(0, 0, 789)
+
+    # Test with transfer_contract_id only
+    delete_tx = ContractDeleteTransaction(
+        contract_id=contract_id,
+        transfer_contract_id=transfer_contract_id,
+    )
+    assert delete_tx.contract_id == contract_id
+    assert delete_tx.transfer_contract_id == transfer_contract_id
+    assert delete_tx.transfer_account_id is None
+    assert delete_tx.permanent_removal is None
+
+    # Test with transfer_account_id only
+    delete_tx = ContractDeleteTransaction(
+        contract_id=contract_id,
+        transfer_account_id=transfer_account_id,
+    )
+    assert delete_tx.contract_id == contract_id
+    assert delete_tx.transfer_contract_id is None
+    assert delete_tx.transfer_account_id == transfer_account_id
+    assert delete_tx.permanent_removal is None
+
+    # Test with permanent_removal only
+    delete_tx = ContractDeleteTransaction(
+        contract_id=contract_id,
+        permanent_removal=True,
+    )
+    assert delete_tx.contract_id == contract_id
+    assert delete_tx.transfer_contract_id is None
+    assert delete_tx.transfer_account_id is None
+    assert delete_tx.permanent_removal is True


### PR DESCRIPTION
**Description**:
Implemented the `ContractDeleteTransaction` class that allows deleting smart contracts from the network.

* Add `ContractDeleteTransaction` class implementation
* Add integration tests for `ContractDeleteTransaction`
* Add unit tests for `ContractDeleteTransaction` class
* Add contract delete example
* Add `ContractDeleteTransaction` documentation in examples README
* Add `ContractDeleteTransaction` to `__init__.py` file in `__all__` list
* Update CHANGELOG with ContractDeleteTransaction addition

**Related issue(s)**:

Fixes #200 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
