### PR TITLE
feat: add `AccountDeleteTransaction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - ContractDeleteTransaction class
 - ContractExecuteTransaction class
 - setMessageAndPay() function in StatefulContract
+- AccountDeleteTransaction Class
 
 ### Changed
 - Extract Ed25519 byte loading logic into private helper method `_from_bytes_ed25519()`

--- a/docs/sdk_users/running_examples.md
+++ b/docs/sdk_users/running_examples.md
@@ -15,6 +15,7 @@ You can choose either syntax or even mix both styles in your projects.
   - [Updating an Account](#updating-an-account)
   - [Querying Account Balance](#querying-account-balance)
   - [Querying Account Info](#querying-account-info)
+  - [Deleting an Account](#deleting-an-account)
   - [Creating a Token](#creating-a-token)
 - [Token Transactions](#token-transactions)
   - [Minting a Fungible Token](#minting-a-fungible-token)
@@ -170,6 +171,32 @@ print(f"Account Balance: {info.balance}")
 print(f"Account Memo: '{info.account_memo}'")
 print(f"Owned NFTs: {info.owned_nfts}")
 print(f"Token Relationships: {info.token_relationships}")
+```
+
+### Deleting an Account
+
+#### Pythonic Syntax:
+```
+transaction = AccountDeleteTransaction(
+    account_id=account_id,
+    transfer_account_id=transfer_account_id  # Account to receive remaining balance
+).freeze_with(client)
+
+transaction.sign(account_private_key)  # Account being deleted must sign
+transaction.execute(client)
+```
+
+#### Method Chaining:
+```
+transaction = (
+    AccountDeleteTransaction()
+    .set_account_id(account_id)
+    .set_transfer_account_id(transfer_account_id)  # Account to receive remaining balance
+    .freeze_with(client)
+)
+
+transaction.sign(account_private_key)  # Account being deleted must sign
+transaction.execute(client)
 ```
 
 ## Token Transactions

--- a/examples/account_delete.py
+++ b/examples/account_delete.py
@@ -1,0 +1,87 @@
+"""
+Example demonstrating account delete functionality.
+"""
+
+import os
+import sys
+
+from dotenv import load_dotenv
+
+from hiero_sdk_python import AccountId, Client, Hbar, Network, PrivateKey
+from hiero_sdk_python.account.account_create_transaction import AccountCreateTransaction
+from hiero_sdk_python.account.account_delete_transaction import AccountDeleteTransaction
+from hiero_sdk_python.response_code import ResponseCode
+
+load_dotenv()
+
+
+def setup_client():
+    """Initialize and set up the client with operator account"""
+    network = Network(network="testnet")
+    client = Client(network)
+
+    operator_id = AccountId.from_string(os.getenv("OPERATOR_ID"))
+    operator_key = PrivateKey.from_string(os.getenv("OPERATOR_KEY"))
+    client.set_operator(operator_id, operator_key)
+
+    return client
+
+
+def create_account(client):
+    """Create a test account"""
+    account_private_key = PrivateKey.generate_ed25519()
+    account_public_key = account_private_key.public_key()
+
+    receipt = (
+        AccountCreateTransaction()
+        .set_key(account_public_key)
+        .set_initial_balance(Hbar(1))
+        .set_account_memo("Test account for delete")
+        .freeze_with(client)
+        .sign(account_private_key)
+        .execute(client)
+    )
+
+    if receipt.status != ResponseCode.SUCCESS:
+        print(
+            f"Account creation failed with status: {ResponseCode(receipt.status).name}"
+        )
+        sys.exit(1)
+
+    account_id = receipt.account_id
+    print(f"\nAccount created with ID: {account_id}")
+
+    return account_id, account_private_key
+
+
+def account_delete():
+    """
+    Demonstrates account delete functionality by:
+    1. Setting up client with operator account
+    2. Creating an account
+    3. Deleting the account
+    """
+    client = setup_client()
+
+    # Create an account first
+    account_id, account_private_key = create_account(client)
+
+    # Delete the account
+    receipt = (
+        AccountDeleteTransaction()
+        .set_account_id(account_id)
+        .set_transfer_account_id(client.operator_account_id)
+        .freeze_with(client)
+        .sign(account_private_key)
+        .execute(client)
+    )
+
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Account delete failed with status: {ResponseCode(receipt.status).name}")
+        sys.exit(1)
+
+    print("Account deleted successfully!")
+
+
+if __name__ == "__main__":
+    account_delete()

--- a/src/hiero_sdk_python/__init__.py
+++ b/src/hiero_sdk_python/__init__.py
@@ -7,6 +7,7 @@ from .account.account_id import AccountId
 from .account.account_create_transaction import AccountCreateTransaction
 from .account.account_update_transaction import AccountUpdateTransaction
 from .account.account_info import AccountInfo
+from .account.account_delete_transaction import AccountDeleteTransaction
 
 # Crypto
 from .crypto.private_key import PrivateKey
@@ -115,6 +116,7 @@ __all__ = [
     "AccountCreateTransaction",
     "AccountUpdateTransaction",
     "AccountInfo",
+    "AccountDeleteTransaction",
 
     # Crypto
     "PrivateKey",

--- a/src/hiero_sdk_python/account/account_delete_transaction.py
+++ b/src/hiero_sdk_python/account/account_delete_transaction.py
@@ -88,10 +88,13 @@ class AccountDeleteTransaction(Transaction):
             TransactionBody: The built transaction body.
 
         Raises:
-            ValueError: If account_id is not set.
+            ValueError: If account_id or transfer_account_id is not set.
         """
         if self.account_id is None:
             raise ValueError("Missing required AccountID")
+
+        if self.transfer_account_id is None:
+            raise ValueError("Missing AccountID for transfer")
 
         account_delete_body = CryptoDeleteTransactionBody(
             deleteAccountID=self.account_id._to_proto(),

--- a/src/hiero_sdk_python/account/account_delete_transaction.py
+++ b/src/hiero_sdk_python/account/account_delete_transaction.py
@@ -1,0 +1,120 @@
+"""
+AccountDeleteTransaction class.
+"""
+
+from typing import Optional
+
+from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.channels import _Channel
+from hiero_sdk_python.executable import _Method
+from hiero_sdk_python.hapi.services.crypto_delete_pb2 import CryptoDeleteTransactionBody
+from hiero_sdk_python.hbar import Hbar
+from hiero_sdk_python.transaction.transaction import Transaction
+
+DEFAULT_TRANSACTION_FEE = Hbar(2).to_tinybars()
+
+
+class AccountDeleteTransaction(Transaction):
+    """
+    A transaction that deletes a account.
+
+    This transaction can be used to delete an existing account from the network.
+
+    Args:
+        account_id (Optional[AccountId]): The ID of the account to delete.
+        transfer_account_id (Optional[AccountId]): The account ID to transfer
+            remaining balance to.
+    """
+
+    def __init__(
+        self,
+        account_id: Optional[AccountId] = None,
+        transfer_account_id: Optional[AccountId] = None,
+    ):
+        """
+        Initializes a new AccountDeleteTransaction instance.
+
+        Args:
+            account_id (Optional[AccountId]): The ID of the account to delete.
+            transfer_account_id (Optional[AccountId]): The account ID to transfer
+                remaining balance to.
+        """
+        super().__init__()
+        self.account_id: Optional[AccountId] = account_id
+        self.transfer_account_id: Optional[AccountId] = transfer_account_id
+        self._default_transaction_fee = DEFAULT_TRANSACTION_FEE
+
+    def set_account_id(
+        self, account_id: Optional[AccountId]
+    ) -> "AccountDeleteTransaction":
+        """
+        Sets the ID of the account to delete.
+
+        Args:
+            account_id (Optional[AccountId]): The ID of the account to delete.
+
+        Returns:
+            AccountDeleteTransaction: This transaction instance.
+        """
+        self._require_not_frozen()
+        self.account_id = account_id
+        return self
+
+    def set_transfer_account_id(
+        self, transfer_account_id: Optional[AccountId]
+    ) -> "AccountDeleteTransaction":
+        """
+        Sets the account ID to transfer the remaining balance to.
+
+        When an account is deleted, its remaining balance must be transferred
+        to another account. This method sets the target account for the balance transfer.
+
+        Args:
+            transfer_account_id (Optional[AccountId]): The account ID to transfer
+                remaining balance to.
+
+        Returns:
+            AccountDeleteTransaction: This transaction instance.
+        """
+        self._require_not_frozen()
+        self.transfer_account_id = transfer_account_id
+        return self
+
+    def build_transaction_body(self):
+        """
+        Builds the transaction body for this account delete transaction.
+
+        Returns:
+            TransactionBody: The built transaction body.
+
+        Raises:
+            ValueError: If account_id is not set.
+        """
+        if self.account_id is None:
+            raise ValueError("Missing required AccountID")
+
+        account_delete_body = CryptoDeleteTransactionBody(
+            deleteAccountID=self.account_id._to_proto(),
+            transferAccountID=(
+                self.transfer_account_id._to_proto()
+                if self.transfer_account_id
+                else None
+            ),
+        )
+
+        transaction_body = self.build_base_transaction_body()
+        transaction_body.cryptoDelete.CopyFrom(account_delete_body)
+        return transaction_body
+
+    def _get_method(self, channel: _Channel) -> _Method:
+        """
+        Gets the method to execute the account delete transaction.
+
+        Args:
+            channel (_Channel): The channel containing service stubs.
+
+        Returns:
+            _Method: An object containing the transaction function to
+                delete accounts.
+        """
+        return _Method(transaction_func=channel.crypto.cryptoDelete, query_func=None)

--- a/tests/integration/account_delete_transaction_e2e_test.py
+++ b/tests/integration/account_delete_transaction_e2e_test.py
@@ -50,27 +50,6 @@ def test_integration_account_delete_transaction_can_execute(env):
 
 
 @pytest.mark.integration
-def test_integration_account_delete_transaction_no_transfer_account_id(env):
-    """
-    Test that AccountDeleteTransaction raises an error if transfer_account_id is not set.
-    """
-    account = env.create_account()
-
-    tx = (
-        AccountDeleteTransaction()
-        .set_account_id(account.id)
-        .freeze_with(env.client)
-        .sign(account.key)
-    )
-
-    # Attempt to execute without setting transfer_account_id, should raise PrecheckError
-    with pytest.raises(
-        PrecheckError, match="failed precheck with status: ACCOUNT_ID_DOES_NOT_EXIST"
-    ):
-        tx.execute(env.client)
-
-
-@pytest.mark.integration
 def test_integration_account_delete_transaction_fails_with_invalid_account_id(env):
     """Test that AccountDeleteTransaction fails if account_id is invalid."""
     account_id = AccountId(0, 0, 999999999)

--- a/tests/integration/account_delete_transaction_e2e_test.py
+++ b/tests/integration/account_delete_transaction_e2e_test.py
@@ -1,0 +1,192 @@
+"""
+Integration tests for AccountDeleteTransaction.
+"""
+
+import pytest
+
+from hiero_sdk_python.account.account_delete_transaction import AccountDeleteTransaction
+from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.exceptions import PrecheckError
+from hiero_sdk_python.hbar import Hbar
+from hiero_sdk_python.query.account_info_query import AccountInfoQuery
+from hiero_sdk_python.query.transaction_record_query import TransactionRecordQuery
+from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.tokens.nft_id import NftId
+from hiero_sdk_python.tokens.token_airdrop_transaction import TokenAirdropTransaction
+from hiero_sdk_python.tokens.token_mint_transaction import TokenMintTransaction
+from tests.integration.utils_for_test import (
+    create_fungible_token,
+    create_nft_token,
+    env,
+)
+
+
+@pytest.mark.integration
+def test_integration_account_delete_transaction_can_execute(env):
+    """Test that the AccountDeleteTransaction can execute."""
+    account = env.create_account()
+    transfer_account = env.create_account()
+
+    receipt = (
+        AccountDeleteTransaction()
+        .set_transfer_account_id(transfer_account.id)
+        .set_account_id(account.id)
+        .freeze_with(env.client)
+        .sign(account.key)
+        .execute(env.client)
+    )
+
+    assert (
+        receipt.status == ResponseCode.SUCCESS
+    ), f"Delete account failed with status: {ResponseCode(receipt.status).name}"
+
+    transfer_account_info = AccountInfoQuery(transfer_account.id).execute(env.client)
+    assert (
+        transfer_account_info.account_id == transfer_account.id
+    ), "Account ID should match"
+    assert (
+        transfer_account_info.balance.to_tinybars() == Hbar(2).to_tinybars()
+    ), f"Account balance should be 2 HBAR but got {transfer_account_info.balance.to_tinybars()}"
+
+
+@pytest.mark.integration
+def test_integration_account_delete_transaction_no_transfer_account_id(env):
+    """
+    Test that AccountDeleteTransaction raises an error if transfer_account_id is not set.
+    """
+    account = env.create_account()
+
+    tx = (
+        AccountDeleteTransaction()
+        .set_account_id(account.id)
+        .freeze_with(env.client)
+        .sign(account.key)
+    )
+
+    # Attempt to execute without setting transfer_account_id, should raise PrecheckError
+    with pytest.raises(
+        PrecheckError, match="failed precheck with status: ACCOUNT_ID_DOES_NOT_EXIST"
+    ):
+        tx.execute(env.client)
+
+
+@pytest.mark.integration
+def test_integration_account_delete_transaction_fails_with_invalid_account_id(env):
+    """Test that AccountDeleteTransaction fails if account_id is invalid."""
+    account_id = AccountId(0, 0, 999999999)
+
+    receipt = (
+        AccountDeleteTransaction()
+        .set_account_id(account_id)
+        .set_transfer_account_id(env.operator_id)
+        .execute(env.client)
+    )
+
+    assert receipt.status == ResponseCode.INVALID_ACCOUNT_ID, (
+        f"Delete account should have failed with INVALID_ACCOUNT_ID status"
+        f" but got: {ResponseCode(receipt.status).name}"
+    )
+
+
+@pytest.mark.integration
+def test_integration_account_delete_transaction_fails_with_no_signature(env):
+    """Test that AccountDeleteTransaction fails if not signed by the account's key."""
+    account = env.create_account()
+
+    receipt = (
+        AccountDeleteTransaction()
+        .set_account_id(account.id)
+        .set_transfer_account_id(env.operator_id)
+        .execute(env.client)
+    )
+
+    assert receipt.status == ResponseCode.INVALID_SIGNATURE, (
+        f"Delete account should have failed with INVALID_SIGNATURE"
+        f" but got: {ResponseCode(receipt.status).name}"
+    )
+
+
+@pytest.mark.integration
+def test_integration_account_delete_transaction_fails_with_pending_airdrops(env):
+    """Test that AccountDeleteTransaction fails if the account has pending airdrops."""
+    # Create fungible token and NFT
+    token_id = create_fungible_token(env)
+    nft_id = create_nft_token(env)
+
+    # Mint two NFTs
+    nft_metadata = [b"nft1", b"nft2"]
+    receipt = (
+        TokenMintTransaction()
+        .set_token_id(nft_id)
+        .set_metadata(nft_metadata)
+        .execute(env.client)
+    )
+    assert (
+        receipt.status == ResponseCode.SUCCESS
+    ), f"Token mint failed: {ResponseCode(receipt.status).name}"
+    nft_serials = receipt.serial_numbers
+    assert len(nft_serials) == 2, "Should have minted 2 NFTs"
+
+    # Create receiver account
+    receiver = env.create_account()
+
+    # Airdrop: transfer 2 NFTs and 100 FT to receiver, -100 FT from operator
+    receipt = (
+        TokenAirdropTransaction()
+        .add_nft_transfer(NftId(nft_id, nft_serials[0]), env.operator_id, receiver.id)
+        .add_nft_transfer(NftId(nft_id, nft_serials[1]), env.operator_id, receiver.id)
+        .add_token_transfer(token_id, receiver.id, 100)
+        .add_token_transfer(token_id, env.operator_id, -100)
+        .execute(env.client)
+    )
+    assert (
+        receipt.status == ResponseCode.SUCCESS
+    ), f"Token airdrop failed: {ResponseCode(receipt.status).name}"
+
+    record = TransactionRecordQuery(receipt.transaction_id).execute(env.client)
+    assert len(record.new_pending_airdrops) == 3, "Should have 3 pending airdrops"
+
+    # Attempt to delete the sender (operator) account
+    receipt = (
+        AccountDeleteTransaction()
+        .set_account_id(env.operator_id)
+        .set_transfer_account_id(receiver.id)
+        .execute(env.client)
+    )
+
+    assert receipt.status == ResponseCode.ACCOUNT_HAS_PENDING_AIRDROPS, (
+        f"Delete account should have failed with ACCOUNT_HAS_PENDING_AIRDROPS"
+        f"but got: {ResponseCode(receipt.status).name}"
+    )
+
+
+@pytest.mark.integration
+def test_integration_account_delete_transaction_fails_when_deleted_twice(env):
+    """Test that deleting an account twice fails."""
+    account = env.create_account()
+    transfer_account = env.create_account()
+
+    receipt = (
+        AccountDeleteTransaction()
+        .set_account_id(account.id)
+        .set_transfer_account_id(transfer_account.id)
+        .freeze_with(env.client)
+        .sign(account.key)
+        .execute(env.client)
+    )
+    assert (
+        receipt.status == ResponseCode.SUCCESS
+    ), f"First account deletion failed with status: {ResponseCode(receipt.status).name}"
+
+    receipt = (
+        AccountDeleteTransaction()
+        .set_account_id(account.id)
+        .set_transfer_account_id(transfer_account.id)
+        .freeze_with(env.client)
+        .sign(account.key)
+        .execute(env.client)
+    )
+    assert receipt.status == ResponseCode.ACCOUNT_DELETED, (
+        f"Second account deletion should have failed with ACCOUNT_DELETED status"
+        f" but got: {ResponseCode(receipt.status).name}"
+    )

--- a/tests/unit/test_account_delete_transaction.py
+++ b/tests/unit/test_account_delete_transaction.py
@@ -1,0 +1,305 @@
+"""
+Test cases for the AccountDeleteTransaction class.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from hiero_sdk_python.account.account_delete_transaction import AccountDeleteTransaction
+from hiero_sdk_python.account.account_id import AccountId
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def delete_params():
+    """Fixture for account delete parameters."""
+    return {
+        "account_id": AccountId(0, 0, 123),
+        "transfer_account_id": AccountId(0, 0, 456),
+    }
+
+
+def test_constructor_with_parameters(delete_params):
+    """Test creating an account delete transaction with constructor parameters."""
+    delete_tx = AccountDeleteTransaction(
+        account_id=delete_params["account_id"],
+        transfer_account_id=delete_params["transfer_account_id"],
+    )
+
+    assert delete_tx.account_id == delete_params["account_id"]
+    assert delete_tx.transfer_account_id == delete_params["transfer_account_id"]
+
+
+def test_constructor_with_account_id_only(delete_params):
+    """Test creating an account delete transaction with only account_id."""
+    delete_tx = AccountDeleteTransaction(account_id=delete_params["account_id"])
+
+    assert delete_tx.account_id == delete_params["account_id"]
+    assert delete_tx.transfer_account_id is None
+
+
+def test_constructor_with_transfer_account_id_only(delete_params):
+    """Test creating an account delete transaction with only transfer_account_id."""
+    delete_tx = AccountDeleteTransaction(
+        transfer_account_id=delete_params["transfer_account_id"]
+    )
+
+    assert delete_tx.account_id is None
+    assert delete_tx.transfer_account_id == delete_params["transfer_account_id"]
+
+
+def test_constructor_default_values():
+    """Test that constructor sets default values correctly."""
+    delete_tx = AccountDeleteTransaction()
+
+    assert delete_tx.account_id is None
+    assert delete_tx.transfer_account_id is None
+
+
+def test_build_transaction_body_with_valid_parameters(mock_account_ids, delete_params):
+    """Test building an account delete transaction body with valid parameters."""
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    delete_tx = AccountDeleteTransaction(
+        account_id=delete_params["account_id"],
+        transfer_account_id=delete_params["transfer_account_id"],
+    )
+
+    # Set operator and node account IDs needed for building transaction body
+    delete_tx.operator_account_id = operator_id
+    delete_tx.node_account_id = node_account_id
+
+    transaction_body = delete_tx.build_transaction_body()
+
+    assert (
+        transaction_body.cryptoDelete.deleteAccountID
+        == delete_params["account_id"]._to_proto()
+    )
+    assert (
+        transaction_body.cryptoDelete.transferAccountID
+        == delete_params["transfer_account_id"]._to_proto()
+    )
+
+
+def test_build_transaction_body_with_required_params_only(
+    mock_account_ids, delete_params
+):
+    """Test building transaction body with only required parameters."""
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    delete_tx = AccountDeleteTransaction(account_id=delete_params["account_id"])
+
+    # Set operator and node account IDs needed for building transaction body
+    delete_tx.operator_account_id = operator_id
+    delete_tx.node_account_id = node_account_id
+
+    transaction_body = delete_tx.build_transaction_body()
+
+    assert (
+        transaction_body.cryptoDelete.deleteAccountID
+        == delete_params["account_id"]._to_proto()
+    )
+    assert not transaction_body.cryptoDelete.HasField("transferAccountID")
+
+
+def test_build_transaction_body_missing_account_id():
+    """Test that build_transaction_body raises ValueError when account_id is missing."""
+    delete_tx = AccountDeleteTransaction()
+
+    with pytest.raises(ValueError, match="Missing required AccountID"):
+        delete_tx.build_transaction_body()
+
+
+def test_set_account_id(delete_params):
+    """Test setting account_id using the setter method."""
+    delete_tx = AccountDeleteTransaction()
+
+    result = delete_tx.set_account_id(delete_params["account_id"])
+
+    assert delete_tx.account_id == delete_params["account_id"]
+    assert result is delete_tx  # Should return self for method chaining
+
+
+def test_set_transfer_account_id(delete_params):
+    """Test setting transfer_account_id using the setter method."""
+    delete_tx = AccountDeleteTransaction()
+
+    result = delete_tx.set_transfer_account_id(delete_params["transfer_account_id"])
+
+    assert delete_tx.transfer_account_id == delete_params["transfer_account_id"]
+    assert result is delete_tx  # Should return self for method chaining
+
+
+def test_method_chaining_with_all_setters(delete_params):
+    """Test that all setter methods support method chaining."""
+    delete_tx = AccountDeleteTransaction()
+
+    result = delete_tx.set_account_id(
+        delete_params["account_id"]
+    ).set_transfer_account_id(delete_params["transfer_account_id"])
+
+    assert result is delete_tx
+    assert delete_tx.account_id == delete_params["account_id"]
+    assert delete_tx.transfer_account_id == delete_params["transfer_account_id"]
+
+
+def test_method_chaining_partial_setters(delete_params):
+    """Test method chaining with only some setters."""
+    delete_tx = AccountDeleteTransaction()
+
+    result = delete_tx.set_account_id(delete_params["account_id"])
+
+    assert result is delete_tx
+    assert delete_tx.account_id == delete_params["account_id"]
+    assert delete_tx.transfer_account_id is None
+
+
+def test_set_methods_require_not_frozen(mock_client, delete_params):
+    """Test that setter methods raise exception when transaction is frozen."""
+    delete_tx = AccountDeleteTransaction(account_id=delete_params["account_id"])
+    delete_tx.freeze_with(mock_client)
+
+    test_cases = [
+        ("set_account_id", delete_params["account_id"]),
+        ("set_transfer_account_id", delete_params["transfer_account_id"]),
+    ]
+
+    for method_name, value in test_cases:
+        with pytest.raises(
+            Exception, match="Transaction is immutable; it has been frozen"
+        ):
+            getattr(delete_tx, method_name)(value)
+
+
+def test_sign_transaction(mock_client, delete_params):
+    """Test signing the account delete transaction with a private key."""
+    delete_tx = AccountDeleteTransaction(account_id=delete_params["account_id"])
+
+    private_key = MagicMock()
+    private_key.sign.return_value = b"signature"
+    private_key.public_key().to_bytes_raw.return_value = b"public_key"
+
+    delete_tx.freeze_with(mock_client)
+    delete_tx.sign(private_key)
+
+    node_id = mock_client.network.current_node._account_id
+    body_bytes = delete_tx._transaction_body_bytes[node_id]
+
+    assert len(delete_tx._signature_map[body_bytes].sigPair) == 1
+    sig_pair = delete_tx._signature_map[body_bytes].sigPair[0]
+    assert sig_pair.pubKeyPrefix == b"public_key"
+    assert sig_pair.ed25519 == b"signature"
+
+
+def test_to_proto(mock_client, delete_params):
+    """Test converting the account delete transaction to protobuf format after signing."""
+    delete_tx = AccountDeleteTransaction(account_id=delete_params["account_id"])
+
+    private_key = MagicMock()
+    private_key.sign.return_value = b"signature"
+    private_key.public_key().to_bytes_raw.return_value = b"public_key"
+
+    delete_tx.freeze_with(mock_client)
+    delete_tx.sign(private_key)
+    proto = delete_tx._to_proto()
+
+    assert proto.signedTransactionBytes
+    assert len(proto.signedTransactionBytes) > 0
+
+
+def test_get_method():
+    """Test retrieving the gRPC method for the transaction."""
+    delete_tx = AccountDeleteTransaction()
+
+    mock_channel = MagicMock()
+    mock_crypto_stub = MagicMock()
+    mock_channel.crypto = mock_crypto_stub
+
+    method = delete_tx._get_method(mock_channel)
+
+    assert method.query is None
+    assert method.transaction == mock_crypto_stub.cryptoDelete
+
+
+def test_parameter_validation_types(delete_params):
+    """Test that parameters accept the correct types."""
+    delete_tx = AccountDeleteTransaction()
+
+    # Test with valid types
+    delete_tx.set_account_id(delete_params["account_id"])
+    assert isinstance(delete_tx.account_id, AccountId)
+
+    delete_tx.set_transfer_account_id(delete_params["transfer_account_id"])
+    assert isinstance(delete_tx.transfer_account_id, AccountId)
+
+
+def test_parameter_validation_none_values():
+    """Test that parameters can be set to None."""
+    delete_tx = AccountDeleteTransaction(
+        account_id=AccountId(0, 0, 123),
+        transfer_account_id=AccountId(0, 0, 456),
+    )
+
+    # All parameters can be set to None
+    delete_tx.set_account_id(None)
+    assert delete_tx.account_id is None
+
+    delete_tx.set_transfer_account_id(None)
+    assert delete_tx.transfer_account_id is None
+
+
+def test_constructor_parameter_combinations():
+    """Test various constructor parameter combinations."""
+    account_id = AccountId(0, 0, 123)
+    transfer_account_id = AccountId(0, 0, 456)
+
+    # Test with account_id only
+    delete_tx = AccountDeleteTransaction(account_id=account_id)
+    assert delete_tx.account_id == account_id
+    assert delete_tx.transfer_account_id is None
+
+    # Test with transfer_account_id only
+    delete_tx = AccountDeleteTransaction(transfer_account_id=transfer_account_id)
+    assert delete_tx.account_id is None
+    assert delete_tx.transfer_account_id == transfer_account_id
+
+    # Test with both parameters
+    delete_tx = AccountDeleteTransaction(
+        account_id=account_id,
+        transfer_account_id=transfer_account_id,
+    )
+    assert delete_tx.account_id == account_id
+    assert delete_tx.transfer_account_id == transfer_account_id
+
+    # Test with no parameters
+    delete_tx = AccountDeleteTransaction()
+    assert delete_tx.account_id is None
+    assert delete_tx.transfer_account_id is None
+
+
+def test_build_transaction_body_with_transfer_account_id_only(
+    mock_account_ids, delete_params
+):
+    """Test building transaction body with transfer_account_id set."""
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    delete_tx = AccountDeleteTransaction(
+        account_id=delete_params["account_id"],
+        transfer_account_id=delete_params["transfer_account_id"],
+    )
+
+    delete_tx.operator_account_id = operator_id
+    delete_tx.node_account_id = node_account_id
+
+    transaction_body = delete_tx.build_transaction_body()
+
+    assert (
+        transaction_body.cryptoDelete.deleteAccountID
+        == delete_params["account_id"]._to_proto()
+    )
+    assert (
+        transaction_body.cryptoDelete.transferAccountID
+        == delete_params["transfer_account_id"]._to_proto()
+    )


### PR DESCRIPTION
**Description**:
Implemented the `AccountDeleteTransaction` class that allows deleting accounts from the network.

* Add `AccountDeleteTransaction` class implementation
* Add integration tests for `AccountDeleteTransaction`
* Add unit tests for `AccountDeleteTransaction` class
* Add account delete example
* Add `AccountDeleteTransaction` documentation in examples README
* Add `AccountDeleteTransaction` to `__init__.py` file in `__all__` list
* Update CHANGELOG with AccountDeleteTransaction addition

**Related issue(s)**:

Fixes #255

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
