### PR TITLE
fix: docs generate proto py to sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Changed
 - Extract Ed25519 byte loading logic into private helper method `_from_bytes_ed25519()`
+- Incorrect naming in README for generate_proto.py to generate_proto.sh
 
 ## [0.1.4] - 2025-08-19
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ uv sync
 sh generate_proto.sh
 ```
 
-To update to a newer version of the protobuf libraries, edit the `generate_proto.py` file and change the version number
+To update to a newer version of the protobuf libraries, edit the `generate_proto.sh` file and change the version number
 and then rerun it.
 
 


### PR DESCRIPTION
Fixed readme as we currently have .sh
Solves https://github.com/hiero-ledger/hiero-sdk-python/issues/268