### PR TITLE
fix: use secure Mirror Node endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Incorrect naming in README for generate_proto.py to generate_proto.sh
 - Changed README MIT license to Apache
 - Documentation structure updated: contents moved from `/documentation` to `/docs`.
+- Switched Mirror Node endpoints used by SDK to secure ones instead of deprecated insecure endpoints (shut down on Aug 20th, see [Hedera blogpost](https://hedera.com/blog/updated-deprecation-of-the-insecure-hedera-consensus-service-hcs-mirror-node-endpoints))
 
 ### Removed
 - Removed the old `/documentation` folder.

--- a/src/hiero_sdk_python/client/client.py
+++ b/src/hiero_sdk_python/client/client.py
@@ -51,7 +51,7 @@ class Client:
         We now use self.network.get_mirror_address() for a configurable mirror address.
         """
         mirror_address = self.network.get_mirror_address()
-        self.mirror_channel = grpc.insecure_channel(mirror_address)
+        self.mirror_channel = grpc.secure_channel(mirror_address, grpc.ssl_channel_credentials())
         self.mirror_stub = mirror_consensus_grpc.ConsensusServiceStub(self.mirror_channel)
 
     def set_operator(self, account_id: AccountId, private_key: PrivateKey) -> None:

--- a/src/hiero_sdk_python/client/network.py
+++ b/src/hiero_sdk_python/client/network.py
@@ -16,9 +16,9 @@ class Network:
     """
 
     MIRROR_ADDRESS_DEFAULT: Dict[str,str] = {
-        'mainnet': 'hcs.mainnet.mirrornode.hedera.com:5600',
-        'testnet': 'hcs.testnet.mirrornode.hedera.com:5600',
-        'previewnet': 'hcs.previewnet.mirrornode.hedera.com:5600',
+        'mainnet': 'mainnet.mirrornode.hedera.com:443',
+        'testnet': 'testnet.mirrornode.hedera.com:443',
+        'previewnet': 'previewnet.mirrornode.hedera.com:443',
         'solo': 'localhost:5600'
     }
 


### PR DESCRIPTION
**Description**:
Switches Mirror Node endpoints used by SDK to secure ones instead of deprecated insecure endpoints (shut down on Aug 20th).

**Related issue(s)**:

Fixes #316

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
  - Was tested only with Testnet at the moment
