### PR TITLE
feat: add ScheduleCreateTransaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Convert camelCase to snake_case in integration tests (#318)
 
 ### Added
+- ScheduleId() class
+- ScheduleCreateTransaction() class
+- build_scheduled_body() in every transaction
 - ContractDeleteTransaction class
 - ContractExecuteTransaction class
 - setMessageAndPay() function in StatefulContract
@@ -22,6 +25,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - consumeLargeData() function in StatefulContract
 
 ### Changed
+- Extract _build_proto_body() from build_transaction_body() in every transaction
 - StatefulContract's setMessage() function designed with no access restrictions, allowing calls from any address
 - bump solo version to `v0.12`
 - Extract Ed25519 byte loading logic into private helper method `_from_bytes_ed25519()`

--- a/docs/sdk_users/running_examples.md
+++ b/docs/sdk_users/running_examples.md
@@ -64,6 +64,8 @@ You can choose either syntax or even mix both styles in your projects.
   - [Executing a Contract](#executing-a-contract)
   - [Deleting a Contract](#deleting-a-contract)
   - [Executing Ethereum Transactions](#executing-ethereum-transactions)
+- [Schedule Transactions](#schedule-transactions)
+  - [Creating a Schedule](#creating-a-schedule)
 - [Miscellaneous Queries](#miscellaneous-queries)
   - [Querying Transaction Record](#querying-transaction-record)
 
@@ -1490,6 +1492,148 @@ transaction = (
 
 transaction.sign(admin_key)  # Admin key must have been set during contract creation
 transaction.execute(client)
+```
+
+## Schedule Transactions
+
+### Creating a Schedule
+
+#### Pythonic Syntax:
+```python
+# First, create a transaction to be scheduled (e.g., a transfer transaction)
+transfer_tx = TransferTransaction(
+    hbar_transfers={
+        sender_id: -amount,  # Negative amount = debit
+        recipient_id: amount  # Positive amount = credit
+    }
+)
+
+# There are two equivalent approaches to creating scheduled transactions:
+
+# Approach 1: Use transaction.schedule() to generate a pre-configured ScheduleCreateTransaction
+# This internally creates a ScheduleCreateTransaction and sets the scheduled transaction
+schedule_tx1 = transfer_tx.schedule()
+# Then you can use the setter methods to configure additional parameters
+# schedule_tx1.set_payer_account_id(...).set_admin_key(...).etc
+
+# Approach 2: Create a ScheduleCreateTransaction with params directly
+schedule_tx = ScheduleCreateTransaction(
+    schedule_params=ScheduleCreateParams(
+        payer_account_id=client.operator_account_id,
+        admin_key=admin_key.public_key(),
+        expiration_time=expiration_time,  # Timestamp when the schedule expires
+        wait_for_expiry=True  # If true, executes only when expired even if all signatures present
+    )
+)
+# Set the transaction to be scheduled
+schedule_tx.set_scheduled_transaction(transfer_tx)
+schedule_tx.freeze_with(client)
+
+# Sign with required keys (any account being debited must sign)
+schedule_tx.sign(sender_private_key)
+schedule_tx.sign(admin_key)
+schedule_tx.sign(payer_account_private_key) # Sign with the payer key
+```
+
+#### Method Chaining:
+```python
+# First, create a transaction to be scheduled (e.g., a transfer transaction)
+transfer_tx = (
+    TransferTransaction()
+    .add_hbar_transfer(sender_id, -amount)  # Negative amount = debit
+    .add_hbar_transfer(recipient_id, amount)  # Positive amount = credit
+)
+
+# Convert it to a scheduled transaction
+# Using schedule() is equivalent to:
+# schedule_tx = ScheduleCreateTransaction()
+# schedule_tx.set_scheduled_transaction(transfer_tx)
+schedule_tx = transfer_tx.schedule()
+
+# Configure the scheduled transaction
+receipt = (
+    schedule_tx
+    .set_payer_account_id(payer_account_id)
+    .set_admin_key(admin_key.public_key())
+    .set_expiration_time(expiration_time)  # Timestamp when the schedule expires
+    .set_wait_for_expiry(True)  # If true, executes only when expired even if all signatures present
+    .freeze_with(client)
+    .sign(sender_private_key)  # Sign with the account being debited
+    .sign(admin_key)  # Sign with the admin key
+    .sign(payer_account_private_key) # Sign with the payer key
+    .execute(client)
+)
+```
+
+## Schedule Transactions
+
+### Creating a Schedule
+
+#### Pythonic Syntax:
+```python
+# First, create a transaction to be scheduled (e.g., a transfer transaction)
+transfer_tx = TransferTransaction(
+    hbar_transfers={
+        sender_id: -amount,  # Negative amount = debit
+        recipient_id: amount  # Positive amount = credit
+    }
+)
+
+# There are two equivalent approaches to creating scheduled transactions:
+
+# Approach 1: Use transaction.schedule() to generate a pre-configured ScheduleCreateTransaction
+# This internally creates a ScheduleCreateTransaction and sets the scheduled transaction
+schedule_tx1 = transfer_tx.schedule()
+# Then you can use the setter methods to configure additional parameters
+# schedule_tx1.set_payer_account_id(...).set_admin_key(...).etc
+
+# Approach 2: Create a ScheduleCreateTransaction with params directly
+schedule_tx = ScheduleCreateTransaction(
+    schedule_params=ScheduleCreateParams(
+        payer_account_id=client.operator_account_id,
+        admin_key=admin_key.public_key(),
+        expiration_time=expiration_time,  # Timestamp when the schedule expires
+        wait_for_expiry=True  # If true, executes only when expired even if all signatures present
+    )
+)
+# Set the transaction to be scheduled
+schedule_tx.set_scheduled_transaction(transfer_tx)
+schedule_tx.freeze_with(client)
+
+# Sign with required keys (any account being debited must sign)
+schedule_tx.sign(sender_private_key)
+schedule_tx.sign(admin_key)
+schedule_tx.sign(payer_account_private_key) # Sign with the payer key
+```
+
+#### Method Chaining:
+```python
+# First, create a transaction to be scheduled (e.g., a transfer transaction)
+transfer_tx = (
+    TransferTransaction()
+    .add_hbar_transfer(sender_id, -amount)  # Negative amount = debit
+    .add_hbar_transfer(recipient_id, amount)  # Positive amount = credit
+)
+
+# Convert it to a scheduled transaction
+# Using schedule() is equivalent to:
+# schedule_tx = ScheduleCreateTransaction()
+# schedule_tx.set_scheduled_transaction(transfer_tx)
+schedule_tx = transfer_tx.schedule()
+
+# Configure the scheduled transaction
+receipt = (
+    schedule_tx
+    .set_payer_account_id(payer_account_id)
+    .set_admin_key(admin_key.public_key())
+    .set_expiration_time(expiration_time)  # Timestamp when the schedule expires
+    .set_wait_for_expiry(True)  # If true, executes only when expired even if all signatures present
+    .freeze_with(client)
+    .sign(sender_private_key)  # Sign with the account being debited
+    .sign(admin_key)  # Sign with the admin key
+    .sign(payer_account_private_key) # Sign with the payer key
+    .execute(client)
+)
 ```
 
 ### Executing Ethereum Transactions

--- a/examples/schedule_create.py
+++ b/examples/schedule_create.py
@@ -1,0 +1,111 @@
+"""
+Example demonstrating account schedule creation.
+"""
+
+import datetime
+import os
+import sys
+
+from dotenv import load_dotenv
+
+from hiero_sdk_python import AccountId, Client, Hbar, Network, PrivateKey
+from hiero_sdk_python.account.account_create_transaction import AccountCreateTransaction
+from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.timestamp import Timestamp
+from hiero_sdk_python.transaction.transfer_transaction import TransferTransaction
+
+load_dotenv()
+
+
+def setup_client():
+    """Initialize and set up the client with operator account"""
+    network = Network(network="testnet")
+    client = Client(network)
+
+    operator_id = AccountId.from_string(os.getenv("OPERATOR_ID"))
+    operator_key = PrivateKey.from_string(os.getenv("OPERATOR_KEY"))
+    client.set_operator(operator_id, operator_key)
+
+    return client
+
+
+def create_account(client):
+    """Create a test account"""
+    account_private_key = PrivateKey.generate_ed25519()
+    account_public_key = account_private_key.public_key()
+
+    receipt = (
+        AccountCreateTransaction()
+        .set_key(account_public_key)
+        .set_initial_balance(Hbar(2))
+        .set_account_memo("Test account for schedule")
+        .freeze_with(client)
+        .sign(account_private_key)
+        .execute(client)
+    )
+
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Account creation failed with status: {ResponseCode(receipt.status).name}")
+        sys.exit(1)
+
+    account_id = receipt.account_id
+    print(f"\nAccount created with ID: {account_id}")
+
+    return account_id, account_private_key
+
+
+def schedule_create():
+    """
+    Demonstrates account schedule functionality by:
+    1. Setting up client with operator account
+    2. Creating a test account
+    3. Scheduling a transfer transaction to move HBAR from the test account to the operator account
+    4. Signing and executing the scheduled transaction
+    """
+    client = setup_client()
+
+    # Create an account first
+    account_id, account_private_key = create_account(client)
+
+    # Amount to transfer in tinybars
+    amount = Hbar(1).to_tinybars()
+
+    # Create a transfer transaction
+    transfer_tx = (
+        TransferTransaction()
+        .add_hbar_transfer(account_id, -amount)
+        .add_hbar_transfer(client.operator_account_id, amount)
+    )
+
+    # Convert the transfer transaction into a scheduled transaction
+    schedule_tx = transfer_tx.schedule()
+
+    # Set expiration time for the scheduled transaction (90 seconds from now)
+    expiration_time = datetime.datetime.now() + datetime.timedelta(seconds=90)
+
+    receipt = (
+        schedule_tx.set_payer_account_id(
+            client.operator_account_id
+        )  # payer of the transaction fee
+        .set_admin_key(
+            client.operator_private_key.public_key()
+        )  # delete/modify the transaction
+        .set_expiration_time(Timestamp.from_date(expiration_time))
+        .set_wait_for_expiry(True)  # wait to expire to execute
+        .freeze_with(client)
+        .sign(
+            account_private_key
+        )  # sign with the account private key as it transfers money
+        .execute(client)
+    )
+
+    if receipt.status != ResponseCode.SUCCESS:
+        print(f"Account schedule failed with status: {ResponseCode(receipt.status).name}")
+        sys.exit(1)
+
+    print("Transaction scheduled successfully!")
+    print(f"Schedule ID: {receipt.schedule_id}")
+
+
+if __name__ == "__main__":
+    schedule_create()

--- a/src/hiero_sdk_python/__init__.py
+++ b/src/hiero_sdk_python/__init__.py
@@ -107,6 +107,10 @@ from .contract.contract_info import ContractInfo
 from .contract.contract_update_transaction import ContractUpdateTransaction
 from .contract.ethereum_transaction import EthereumTransaction
 
+# Schedule
+from .schedule.schedule_create_transaction import ScheduleCreateTransaction
+from .schedule.schedule_id import ScheduleId
+
 __all__ = [
     # Client
     "Client",
@@ -212,4 +216,8 @@ __all__ = [
     "ContractInfo",
     "ContractUpdateTransaction",
     "EthereumTransaction",
+
+    # Schedule
+    "ScheduleCreateTransaction",
+    "ScheduleId",
 ]

--- a/src/hiero_sdk_python/consensus/topic_delete_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_delete_transaction.py
@@ -13,6 +13,9 @@ from hiero_sdk_python.hapi.services import (
     transaction_pb2,
     basic_types_pb2
 )
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.executable import _Method
 
@@ -42,25 +45,46 @@ class TopicDeleteTransaction(Transaction):
         self.topic_id = topic_id
         return self
 
+    def _build_proto_body(self):
+        """
+        Returns the protobuf body for the topic delete transaction.
+        
+        Returns:
+            ConsensusDeleteTopicTransactionBody: The protobuf body for this transaction.
+            
+        Raises:
+            ValueError: If required fields are missing.
+        """
+        if self.topic_id is None:
+            raise ValueError("Missing required fields: topic_id")
+            
+        return consensus_delete_topic_pb2.ConsensusDeleteTopicTransactionBody(
+            topicID=self.topic_id._to_proto()
+        )
+        
     def build_transaction_body(self) -> transaction_pb2.TransactionBody:
         """
         Builds and returns the protobuf transaction body for topic delete.
 
         Returns:
             TransactionBody: The protobuf transaction body containing the topic delete details.
-
-        Raises:
-            ValueError: If required fields are missing.
         """
-        if self.topic_id is None:
-            raise ValueError("Missing required fields: topic_id")
-        transaction_body: transaction_pb2.TransactionBody = self.build_base_transaction_body()
-        transaction_body.consensusDeleteTopic.CopyFrom(
-            consensus_delete_topic_pb2.ConsensusDeleteTopicTransactionBody(
-            topicID=self.topic_id._to_proto()
-        ))
-
+        consensus_delete_body = self._build_proto_body()
+        transaction_body = self.build_base_transaction_body()
+        transaction_body.consensusDeleteTopic.CopyFrom(consensus_delete_body)
         return transaction_body
+        
+    def build_scheduled_body(self) -> SchedulableTransactionBody:
+        """
+        Builds the scheduled transaction body for this topic delete transaction.
+
+        Returns:
+            SchedulableTransactionBody: The built scheduled transaction body.
+        """
+        consensus_delete_body = self._build_proto_body()
+        schedulable_body = self.build_base_scheduled_body()
+        schedulable_body.consensusDeleteTopic.CopyFrom(consensus_delete_body)
+        return schedulable_body
 
     def _get_method(self, channel: _Channel) -> _Method:
         """

--- a/src/hiero_sdk_python/contract/ethereum_transaction.py
+++ b/src/hiero_sdk_python/contract/ethereum_transaction.py
@@ -10,6 +10,9 @@ from hiero_sdk_python.file.file_id import FileId
 from hiero_sdk_python.hapi.services.ethereum_transaction_pb2 import (
     EthereumTransactionBody,
 )
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 from hiero_sdk_python.transaction.transaction import Transaction
 
 
@@ -90,6 +93,19 @@ class EthereumTransaction(Transaction):
         self.max_gas_allowed = max_gas_allowed
         return self
 
+    def _build_proto_body(self):
+        """
+        Returns the protobuf body for the ethereum transaction.
+
+        Returns:
+            EthereumTransactionBody: The protobuf body for this transaction.
+        """
+        return EthereumTransactionBody(
+            ethereum_data=self.ethereum_data,
+            call_data=self.call_data._to_proto() if self.call_data else None,
+            max_gas_allowance=self.max_gas_allowed,
+        )
+
     def build_transaction_body(self):
         """
         Builds and returns the protobuf transaction body for ethereum transaction.
@@ -98,15 +114,19 @@ class EthereumTransaction(Transaction):
             TransactionBody: The protobuf transaction body containing the
                 ethereum transaction details.
         """
-        ethereum_transaction_body = EthereumTransactionBody(
-            ethereum_data=self.ethereum_data,
-            call_data=self.call_data._to_proto() if self.call_data else None,
-            max_gas_allowance=self.max_gas_allowed,
-        )
-
+        ethereum_transaction_body = self._build_proto_body()
         transaction_body = self.build_base_transaction_body()
         transaction_body.ethereumTransaction.CopyFrom(ethereum_transaction_body)
         return transaction_body
+
+    def build_scheduled_body(self) -> SchedulableTransactionBody:
+        """
+        Builds the scheduled transaction body for this ethereum transaction.
+
+        Raises:
+            ValueError: EthereumTransaction cannot be scheduled.
+        """
+        raise ValueError("Cannot schedule an EthereumTransaction")
 
     def _get_method(self, channel: _Channel) -> _Method:
         """

--- a/src/hiero_sdk_python/schedule/schedule_create_transaction.py
+++ b/src/hiero_sdk_python/schedule/schedule_create_transaction.py
@@ -1,0 +1,252 @@
+"""
+ScheduleCreateTransaction class.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.channels import _Channel
+from hiero_sdk_python.crypto.public_key import PublicKey
+from hiero_sdk_python.executable import _Method
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
+from hiero_sdk_python.hapi.services.schedule_create_pb2 import (
+    ScheduleCreateTransactionBody,
+)
+from hiero_sdk_python.hbar import Hbar
+from hiero_sdk_python.timestamp import Timestamp
+from hiero_sdk_python.transaction.transaction import Transaction
+
+
+@dataclass
+class ScheduleCreateParams:
+    """
+    Represents schedule attributes that can be set on creation.
+
+    Attributes:
+        payer_account_id (Optional[AccountId]): The account ID of the payer
+            for the scheduled transaction.
+        admin_key (Optional[PublicKey]): The key that can delete or sign the schedule.
+        schedulable_body (Optional[SchedulableTransactionBody]): The body of the transaction
+            to be scheduled.
+        schedule_memo (Optional[str]): A memo to include with the schedule.
+        expiration_time (Optional[Timestamp]): The time at which the schedule should expire.
+        wait_for_expiry (Optional[bool]): If True, the transaction will execute only at expiration time,
+            even if all required signatures are collected before then. If False or unset,
+            the transaction will execute as soon as all required signatures are received.
+    """
+
+    payer_account_id: Optional[AccountId] = None
+    admin_key: Optional[PublicKey] = None
+    schedulable_body: Optional[SchedulableTransactionBody] = None
+    schedule_memo: Optional[str] = None
+    expiration_time: Optional[Timestamp] = None
+    wait_for_expiry: Optional[bool] = None
+
+
+class ScheduleCreateTransaction(Transaction):
+    """
+    Represents a schedule create transaction on the network.
+
+    This transaction creates a new schedule on the network with the specified payer account ID,
+    admin key, schedulable body, schedule memo, expiration time and wait for expiry.
+
+    Inherits from the base Transaction class and implements the required methods
+    to build and execute a schedule create transaction.
+    """
+
+    def __init__(
+        self,
+        schedule_params: Optional[ScheduleCreateParams] = None,
+    ):
+        """
+        Initializes a new ScheduleCreateTransaction instance with the specified parameters.
+
+        Args:
+            schedule_params (Optional[ScheduleCreateParams]):
+                The parameters for the schedule create transaction.
+        """
+        super().__init__()
+        schedule_params = schedule_params or ScheduleCreateParams()
+        self.payer_account_id: Optional[AccountId] = schedule_params.payer_account_id
+        self.admin_key: Optional[PublicKey] = schedule_params.admin_key
+        self.schedulable_body: Optional[SchedulableTransactionBody] = (
+            schedule_params.schedulable_body
+        )
+        self.schedule_memo: Optional[str] = schedule_params.schedule_memo
+        self.expiration_time: Optional[Timestamp] = schedule_params.expiration_time
+        self.wait_for_expiry: Optional[bool] = schedule_params.wait_for_expiry
+        self._default_transaction_fee = Hbar(5).to_tinybars()
+
+    def _set_schedulable_body(
+        self, schedulable_body: Optional[SchedulableTransactionBody]
+    ) -> "ScheduleCreateTransaction":
+        """
+        Sets the schedulable body for this schedule create transaction.
+
+        Args:
+            schedulable_body (Optional[SchedulableTransactionBody]):
+                The body of the schedulable transaction.
+
+        Returns:
+            ScheduleCreateTransaction: This transaction instance.
+        """
+        self._require_not_frozen()
+        self.schedulable_body = schedulable_body
+        return self
+
+    def set_scheduled_transaction(
+        self, transaction: "Transaction"
+    ) -> "ScheduleCreateTransaction":
+        """
+        Sets the scheduled transaction for this schedule create transaction.
+
+        Args:
+            transaction (Transaction):
+                The transaction to schedule.
+
+        Returns:
+            ScheduleCreateTransaction: This transaction instance.
+        """
+        self._require_not_frozen()
+        self.schedulable_body = transaction.build_scheduled_body()
+
+        return self
+
+    def set_schedule_memo(
+        self, schedule_memo: Optional[str]
+    ) -> "ScheduleCreateTransaction":
+        """
+        Sets the schedule memo for this schedule create transaction.
+
+        Args:
+            schedule_memo (Optional[str]): The schedule memo for the schedule.
+
+        Returns:
+            ScheduleCreateTransaction: This transaction instance.
+        """
+        self._require_not_frozen()
+        self.schedule_memo = schedule_memo
+        return self
+
+    def set_payer_account_id(
+        self, payer_account_id: Optional[AccountId]
+    ) -> "ScheduleCreateTransaction":
+        """
+        Sets the payer account ID for this schedule create transaction.
+
+        Args:
+            payer_account_id (Optional[AccountId]): The payer account ID for the schedule.
+
+        Returns:
+            ScheduleCreateTransaction: This transaction instance.
+        """
+        self._require_not_frozen()
+        self.payer_account_id = payer_account_id
+        return self
+
+    def set_expiration_time(
+        self, expiration_time: Optional[Timestamp]
+    ) -> "ScheduleCreateTransaction":
+        """
+        Sets the expiration time for this schedule create transaction.
+
+        Args:
+            expiration_time (Optional[Timestamp]): The expiration time for the schedule.
+
+        Returns:
+            ScheduleCreateTransaction: This transaction instance.
+        """
+        self._require_not_frozen()
+        self.expiration_time = expiration_time
+        return self
+
+    def set_wait_for_expiry(
+        self, wait_for_expiry: Optional[bool]
+    ) -> "ScheduleCreateTransaction":
+        """
+        Sets the wait for expiry for this schedule create transaction.
+
+        Args:
+            wait_for_expiry (Optional[bool]): Whether to wait for the schedule to expire.
+
+        Returns:
+            ScheduleCreateTransaction: This transaction instance.
+        """
+        self._require_not_frozen()
+        self.wait_for_expiry = wait_for_expiry
+        return self
+
+    def set_admin_key(
+        self, admin_key: Optional[PublicKey]
+    ) -> "ScheduleCreateTransaction":
+        """
+        Sets the admin key for this schedule create transaction.
+
+        Args:
+            admin_key (Optional[PublicKey]): The admin key for the schedule.
+
+        Returns:
+            ScheduleCreateTransaction: This transaction instance.
+        """
+        self._require_not_frozen()
+        self.admin_key = admin_key
+        return self
+
+    def _build_proto_body(self):
+        """
+        Returns the protobuf body for the schedule create transaction.
+
+        Returns:
+            ScheduleCreateTransactionBody: The protobuf body for this transaction.
+        """
+        return ScheduleCreateTransactionBody(
+            wait_for_expiry=self.wait_for_expiry,
+            memo=self.schedule_memo,
+            adminKey=self.admin_key._to_proto() if self.admin_key else None,
+            scheduledTransactionBody=self.schedulable_body,
+            expiration_time=(
+                self.expiration_time._to_protobuf() if self.expiration_time else None
+            ),
+            payerAccountID=(
+                self.payer_account_id._to_proto() if self.payer_account_id else None
+            ),
+        )
+
+    def build_transaction_body(self):
+        """
+        Builds the transaction body for this schedule create transaction.
+
+        Returns:
+            TransactionBody: The built transaction body.
+        """
+        schedule_create_body = self._build_proto_body()
+        transaction_body = self.build_base_transaction_body()
+        transaction_body.scheduleCreate.CopyFrom(schedule_create_body)
+        return transaction_body
+
+    def build_scheduled_body(self) -> SchedulableTransactionBody:
+        """
+        Builds the scheduled transaction body for this schedule create transaction.
+
+        Raises:
+            ValueError: ScheduleCreateTransaction cannot be scheduled.
+        """
+        raise ValueError("Cannot schedule a ScheduleCreateTransaction")
+
+    def _get_method(self, channel: _Channel) -> _Method:
+        """
+        Gets the method to execute the schedule create transaction.
+
+        This internal method returns a _Method object containing the appropriate gRPC
+        function to call when executing this transaction on the Hedera network.
+
+        Args:
+            channel (_Channel): The channel containing service stubs
+
+        Returns:
+            _Method: An object containing the transaction function to create a schedule.
+        """
+        return _Method(transaction_func=channel.schedule.createSchedule, query_func=None)

--- a/src/hiero_sdk_python/schedule/schedule_id.py
+++ b/src/hiero_sdk_python/schedule/schedule_id.py
@@ -1,0 +1,135 @@
+"""
+ScheduleId class.
+"""
+
+from dataclasses import dataclass
+
+from hiero_sdk_python.hapi.services.basic_types_pb2 import ScheduleID as ProtoScheduleID
+
+
+@dataclass(frozen=True)
+class ScheduleId:
+    """
+    Represents the unique identifier for a schedule.
+
+    A schedule ID consists of three components: shard, realm, and schedule.
+    These components uniquely identify a schedule in the network.
+
+    Attributes:
+        shard (int): The shard number. Defaults to 0.
+        realm (int): The realm number. Defaults to 0.
+        schedule (int): The unique schedule number within the shard/realm. Defaults to 0.
+    """
+
+    shard: int = 0
+    realm: int = 0
+    schedule: int = 0
+
+    @classmethod
+    def from_string(cls, id_str: str) -> "ScheduleId":
+        """
+        Creates a ScheduleId instance from a string representation.
+
+        Parses a string in the format 'shard.realm.schedule' into a ScheduleId object.
+        All three components must be present and be valid non-negative integers.
+
+        Args:
+            id_str (str): The string representation of the schedule ID in the format
+                'shard.realm.schedule'. Leading/trailing whitespace is automatically stripped.
+
+        Returns:
+            ScheduleId: A new ScheduleId instance with the parsed components.
+
+        Raises:
+            ValueError: If the string is not in the correct format, doesn't contain
+                exactly 3 dot-separated components, or contains non-integer values.
+        """
+        try:
+            shard_str, realm_str, schedule_str = id_str.strip().split(".")
+            return cls(
+                shard=int(shard_str),
+                realm=int(realm_str),
+                schedule=int(schedule_str),
+            )
+        except Exception as e:
+            raise ValueError(
+                f"Invalid schedule ID string '{id_str}'. Expected format 'shard.realm.schedule'."
+            ) from e
+
+    def __str__(self) -> str:
+        """
+        Returns the string representation of the schedule ID.
+
+        Returns:
+            str: The formatted schedule ID string in 'shard.realm.schedule' format.
+        """
+        return f"{self.shard}.{self.realm}.{self.schedule}"
+
+    def __repr__(self) -> str:
+        """
+        Returns the detailed string representation of the schedule ID for debugging.
+
+        Returns a representation that shows the class name and all component values,
+        which is useful for debugging and development purposes.
+
+        Returns:
+            str: A detailed representation in the format
+                'ScheduleId(shard=X, realm=Y, schedule=Z)'.
+        """
+        return f"ScheduleId(shard={self.shard}, realm={self.realm}, schedule={self.schedule})"
+
+    def __eq__(self, other: object) -> bool:
+        """
+        Checks equality between two ScheduleId instances.
+
+        Args:
+            other (object): The object to compare with. Must be a ScheduleId instance
+                for equality to be possible.
+
+        Returns:
+            bool: True if both instances are ScheduleId objects with identical
+                shard, realm, and schedule values, False otherwise.
+        """
+        if not isinstance(other, ScheduleId):
+            return NotImplemented
+        return (
+            self.shard == other.shard
+            and self.realm == other.realm
+            and self.schedule == other.schedule
+        )
+
+    def _to_proto(self) -> ProtoScheduleID:
+        """
+        Converts the ScheduleId instance to a protobuf ScheduleID object.
+
+        Returns:
+            ProtoScheduleID: The protobuf ScheduleID object with the same
+                shard, realm, and schedule values.
+
+        Note:
+            This is an internal method and should not be used directly by client code.
+        """
+        return ProtoScheduleID(
+            shardNum=self.shard,
+            realmNum=self.realm,
+            scheduleNum=self.schedule,
+        )
+
+    @classmethod
+    def _from_proto(cls, proto: ProtoScheduleID) -> "ScheduleId":
+        """
+        Creates a ScheduleId instance from a protobuf ScheduleID object.
+
+        This is an internal method used for deserialization when receiving responses
+        from the Hedera network via gRPC. It handles the conversion from the protobuf
+        field names (shardNum, realmNum, scheduleNum) to the Python representation.
+
+        Args:
+            proto (ProtoScheduleID): The protobuf ScheduleID object to convert.
+
+        Returns:
+            ScheduleId: A new ScheduleId instance with the values from the protobuf object.
+        """
+        return cls(
+            shard=proto.shardNum, realm=proto.realmNum, schedule=proto.scheduleNum
+        )

--- a/src/hiero_sdk_python/tokens/token_freeze_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_freeze_transaction.py
@@ -7,6 +7,9 @@ for an account on the Hedera network using the Hedera Token Service (HTS) API.
 """
 from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.hapi.services import token_freeze_account_pb2
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.executable import _Method
 
@@ -61,33 +64,50 @@ class TokenFreezeTransaction(Transaction):
         self.account_id = account_id
         return self
 
-    def build_transaction_body(self):
+    def _build_proto_body(self):
         """
-        Builds and returns the protobuf transaction body for token freeze.
-
+        Returns the protobuf body for the token freeze transaction.
+        
         Returns:
-            TransactionBody: The protobuf transaction body containing the token freeze details.
-
+            TokenFreezeAccountTransactionBody: The protobuf body for this transaction.
+            
         Raises:
-            ValueError: If the token ID is missing.
-            ValueError: If the account ID is missing.
+            ValueError: If the token ID or account ID is missing.
         """
-
         if not self.token_id:
             raise ValueError("Missing required TokenID.")
 
         if not self.account_id:
             raise ValueError("Missing required AccountID.")
 
-        token_freeze_body = token_freeze_account_pb2.TokenFreezeAccountTransactionBody(
+        return token_freeze_account_pb2.TokenFreezeAccountTransactionBody(
             token=self.token_id._to_proto(),
             account=self.account_id._to_proto()
         )
+        
+    def build_transaction_body(self):
+        """
+        Builds and returns the protobuf transaction body for token freeze.
 
+        Returns:
+            TransactionBody: The protobuf transaction body containing the token freeze details.
+        """
+        token_freeze_body = self._build_proto_body()
         transaction_body = self.build_base_transaction_body()
         transaction_body.tokenFreeze.CopyFrom(token_freeze_body)
-
         return transaction_body
+        
+    def build_scheduled_body(self) -> SchedulableTransactionBody:
+        """
+        Builds the scheduled transaction body for this token freeze transaction.
+
+        Returns:
+            SchedulableTransactionBody: The built scheduled transaction body.
+        """
+        token_freeze_body = self._build_proto_body()
+        schedulable_body = self.build_base_scheduled_body()
+        schedulable_body.tokenFreeze.CopyFrom(token_freeze_body)
+        return schedulable_body
 
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/tokens/token_grant_kyc_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_grant_kyc_transaction.py
@@ -6,6 +6,9 @@ Provides TokenGrantKycTransaction, a subclass of Transaction for granting KYC st
 to accounts for specific tokens on the Hedera network via the Hedera Token Service (HTS) API.
 """
 from hiero_sdk_python.hapi.services.token_grant_kyc_pb2 import TokenGrantKycTransactionBody
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.executable import _Method
@@ -61,12 +64,12 @@ class TokenGrantKycTransaction(Transaction):
         self.account_id = account_id
         return self
 
-    def build_transaction_body(self):
+    def _build_proto_body(self):
         """
-        Builds the transaction body for this token grant KYC transaction.
-
+        Returns the protobuf body for the token grant KYC transaction.
+        
         Returns:
-            TransactionBody: The built transaction body.
+            TokenGrantKycTransactionBody: The protobuf body for this transaction.
             
         Raises:
             ValueError: If the token ID or account ID is not set.
@@ -77,13 +80,34 @@ class TokenGrantKycTransaction(Transaction):
         if self.account_id is None:
             raise ValueError("Missing account ID")
 
-        token_grant_kyc_body = TokenGrantKycTransactionBody(
+        return TokenGrantKycTransactionBody(
             token=self.token_id._to_proto(),
             account=self.account_id._to_proto()
         )
+        
+    def build_transaction_body(self):
+        """
+        Builds the transaction body for this token grant KYC transaction.
+
+        Returns:
+            TransactionBody: The built transaction body.
+        """
+        token_grant_kyc_body = self._build_proto_body()
         transaction_body = self.build_base_transaction_body()
         transaction_body.tokenGrantKyc.CopyFrom(token_grant_kyc_body)
         return transaction_body
+        
+    def build_scheduled_body(self) -> SchedulableTransactionBody:
+        """
+        Builds the scheduled transaction body for this token grant KYC transaction.
+
+        Returns:
+            SchedulableTransactionBody: The built scheduled transaction body.
+        """
+        token_grant_kyc_body = self._build_proto_body()
+        schedulable_body = self.build_base_scheduled_body()
+        schedulable_body.tokenGrantKyc.CopyFrom(token_grant_kyc_body)
+        return schedulable_body
 
     def _get_method(self, channel: _Channel) -> _Method:
         """

--- a/src/hiero_sdk_python/tokens/token_mint_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_mint_transaction.py
@@ -7,6 +7,9 @@ non-fungible tokens on the Hedera network via the Hedera Token Service (HTS) API
 """
 from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.hapi.services import token_mint_pb2
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.executable import _Method
 
@@ -60,13 +63,13 @@ class TokenMintTransaction(Transaction):
         self.metadata = metadata
         return self
 
-    def build_transaction_body(self):
+    def _build_proto_body(self):
         """
-        Builds and returns the protobuf transaction body for token minting.
+        Returns the protobuf body for the token mint transaction.
         
         Returns:
-            TransactionBody: The protobuf transaction body containing the token minting details.
-
+            TokenMintTransactionBody: The protobuf body for this transaction.
+            
         Raises:
             ValueError: If required fields are missing or conflicting.
         """
@@ -84,7 +87,7 @@ class TokenMintTransaction(Transaction):
             if self.amount <= 0:
                 raise ValueError("Amount to mint must be positive.")
 
-            token_mint_body = token_mint_pb2.TokenMintTransactionBody(
+            return token_mint_pb2.TokenMintTransactionBody(
                 token=self.token_id._to_proto(),
                 amount=self.amount,
                 metadata=[] # Must be empty for fungible tokens
@@ -98,7 +101,7 @@ class TokenMintTransaction(Transaction):
             if not self.metadata:
                 raise ValueError("Metadata list cannot be empty for NFTs.")
 
-            token_mint_body = token_mint_pb2.TokenMintTransactionBody(
+            return token_mint_pb2.TokenMintTransactionBody(
                 token=self.token_id._to_proto(),
                 amount=0,  # Must be zero for NFTs
                 metadata=self.metadata
@@ -106,11 +109,30 @@ class TokenMintTransaction(Transaction):
 
         else:
             raise ValueError("Either amount or metadata must be provided for token minting.")
-
+            
+    def build_transaction_body(self):
+        """
+        Builds and returns the protobuf transaction body for token minting.
+        
+        Returns:
+            TransactionBody: The protobuf transaction body containing the token minting details.
+        """
+        token_mint_body = self._build_proto_body()
         transaction_body = self.build_base_transaction_body()
         transaction_body.tokenMint.CopyFrom(token_mint_body)
-
         return transaction_body
+        
+    def build_scheduled_body(self) -> SchedulableTransactionBody:
+        """
+        Builds the scheduled transaction body for this token mint transaction.
+
+        Returns:
+            SchedulableTransactionBody: The built scheduled transaction body.
+        """
+        token_mint_body = self._build_proto_body()
+        schedulable_body = self.build_base_scheduled_body()
+        schedulable_body.tokenMint.CopyFrom(token_mint_body)
+        return schedulable_body
 
     def _get_method(self, channel: _Channel) -> _Method:
         return _Method(

--- a/src/hiero_sdk_python/tokens/token_mint_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_mint_transaction.py
@@ -63,6 +63,19 @@ class TokenMintTransaction(Transaction):
         self.metadata = metadata
         return self
 
+    def _validate_parameters(self):
+        """
+        Validates the parameters for the token mint transaction.
+        """
+        if self.token_id is None:
+            raise ValueError("Token ID is required for minting.")
+
+        if (self.amount is not None) and (self.metadata is not None):
+            raise ValueError(
+                "Specify either amount for fungible tokens or metadata "
+                "for NFTs, not both."
+            )
+
     def _build_proto_body(self):
         """
         Returns the protobuf body for the token mint transaction.
@@ -73,14 +86,7 @@ class TokenMintTransaction(Transaction):
         Raises:
             ValueError: If required fields are missing or conflicting.
         """
-        if not self.token_id:
-            raise ValueError("Token ID is required for minting.")
-
-        if (self.amount is not None) and (self.metadata is not None):
-            raise ValueError(
-                "Specify either amount for fungible tokens or metadata "
-                "for NFTs, not both."
-            )
+        self._validate_parameters()
 
         if self.amount is not None:
             # Minting fungible tokens

--- a/src/hiero_sdk_python/tokens/token_pause_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_pause_transaction.py
@@ -8,6 +8,9 @@ on the Hedera network via the Hedera Token Service (HTS) API.
 from hiero_sdk_python.tokens.token_id import TokenId
 from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.hapi.services.token_pause_pb2 import TokenPauseTransactionBody
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.executable import _Method
 
@@ -48,25 +51,46 @@ class TokenPauseTransaction(Transaction):
         self.token_id = token_id
         return self
 
+    def _build_proto_body(self):
+        """
+        Returns the protobuf body for the token pause transaction.
+        
+        Returns:
+            TokenPauseTransactionBody: The protobuf body for this transaction.
+            
+        Raises:
+            ValueError: If no token_id has been set.
+        """
+        if self.token_id is None or self.token_id.num == 0:
+            raise ValueError("token_id must be set before building the transaction body")
+
+        return TokenPauseTransactionBody(
+            token=self.token_id._to_proto()
+        )
+        
     def build_transaction_body(self):
         """
         Builds and returns the protobuf transaction body for token pause.
 
         Returns:
             TransactionBody: The protobuf transaction body containing the token pause details.
-        
-        Raises:
-        ValueError: If no token_id has been set.
         """
-        if self.token_id is None or self.token_id.num == 0:
-            raise ValueError("token_id must be set before building the transaction body")
-
-        token_pause_body = TokenPauseTransactionBody(
-            token=self.token_id._to_proto()
-        )
+        token_pause_body = self._build_proto_body()
         transaction_body = self.build_base_transaction_body()
         transaction_body.token_pause.CopyFrom(token_pause_body)
         return transaction_body
+        
+    def build_scheduled_body(self) -> SchedulableTransactionBody:
+        """
+        Builds the scheduled transaction body for this token pause transaction.
+
+        Returns:
+            SchedulableTransactionBody: The built scheduled transaction body.
+        """
+        token_pause_body = self._build_proto_body()
+        schedulable_body = self.build_base_scheduled_body()
+        schedulable_body.token_pause.CopyFrom(token_pause_body)
+        return schedulable_body
 
     def _get_method(self, channel: _Channel) -> _Method:
         return _Method(

--- a/src/hiero_sdk_python/tokens/token_revoke_kyc_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_revoke_kyc_transaction.py
@@ -7,6 +7,9 @@ Know-Your-Customer (KYC) status from an account for a specific token on the
 Hedera network via the Hedera Token Service (HTS) API.
 """
 from hiero_sdk_python.hapi.services.token_revoke_kyc_pb2 import TokenRevokeKycTransactionBody
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.executable import _Method
@@ -62,12 +65,12 @@ class TokenRevokeKycTransaction(Transaction):
         self.account_id = account_id
         return self
 
-    def build_transaction_body(self):
+    def _build_proto_body(self):
         """
-        Builds the transaction body for this token revoke KYC transaction.
-
+        Returns the protobuf body for the token revoke KYC transaction.
+        
         Returns:
-            TransactionBody: The built transaction body.
+            TokenRevokeKycTransactionBody: The protobuf body for this transaction.
             
         Raises:
             ValueError: If the token ID or account ID is not set.
@@ -78,13 +81,34 @@ class TokenRevokeKycTransaction(Transaction):
         if self.account_id is None:
             raise ValueError("Missing account ID")
 
-        token_revoke_kyc_body = TokenRevokeKycTransactionBody(
+        return TokenRevokeKycTransactionBody(
             token=self.token_id._to_proto(),
             account=self.account_id._to_proto()
         )
+        
+    def build_transaction_body(self):
+        """
+        Builds the transaction body for this token revoke KYC transaction.
+
+        Returns:
+            TransactionBody: The built transaction body.
+        """
+        token_revoke_kyc_body = self._build_proto_body()
         transaction_body = self.build_base_transaction_body()
         transaction_body.tokenRevokeKyc.CopyFrom(token_revoke_kyc_body)
         return transaction_body
+        
+    def build_scheduled_body(self) -> SchedulableTransactionBody:
+        """
+        Builds the scheduled transaction body for this token revoke KYC transaction.
+
+        Returns:
+            SchedulableTransactionBody: The built scheduled transaction body.
+        """
+        token_revoke_kyc_body = self._build_proto_body()
+        schedulable_body = self.build_base_scheduled_body()
+        schedulable_body.tokenRevokeKyc.CopyFrom(token_revoke_kyc_body)
+        return schedulable_body
 
     def _get_method(self, channel: _Channel) -> _Method:
         """

--- a/src/hiero_sdk_python/tokens/token_update_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_update_transaction.py
@@ -16,6 +16,9 @@ from hiero_sdk_python.tokens.token_key_validation import TokenKeyValidation
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services.token_update_pb2 import TokenUpdateTransactionBody
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 from google.protobuf.wrappers_pb2 import BytesValue, StringValue
 
 @dataclass
@@ -304,13 +307,13 @@ class TokenUpdateTransaction(Transaction):
         self.token_key_verification_mode = key_verification_mode
         return self
 
-    def build_transaction_body(self):
+    def _build_proto_body(self):
         """
-        Builds and returns the protobuf transaction body for token update.
-
+        Returns the protobuf body for the token update transaction.
+        
         Returns:
-            TransactionBody: The protobuf transaction body containing the token update details.
-
+            TokenUpdateTransactionBody: The protobuf body for this transaction.
+            
         Raises:
             ValueError: If token_id is not set.
         """
@@ -327,10 +330,31 @@ class TokenUpdateTransaction(Transaction):
             key_verification_mode=self.token_key_verification_mode._to_proto()
         )
         self._set_keys_to_proto(token_update_body)
+        return token_update_body
+        
+    def build_transaction_body(self):
+        """
+        Builds and returns the protobuf transaction body for token update.
+
+        Returns:
+            TransactionBody: The protobuf transaction body containing the token update details.
+        """
+        token_update_body = self._build_proto_body()
         transaction_body = self.build_base_transaction_body()
         transaction_body.tokenUpdate.CopyFrom(token_update_body)
-
         return transaction_body
+        
+    def build_scheduled_body(self) -> SchedulableTransactionBody:
+        """
+        Builds the scheduled transaction body for this token update transaction.
+
+        Returns:
+            SchedulableTransactionBody: The built scheduled transaction body.
+        """
+        token_update_body = self._build_proto_body()
+        schedulable_body = self.build_base_scheduled_body()
+        schedulable_body.tokenUpdate.CopyFrom(token_update_body)
+        return schedulable_body
 
     def _get_method(self, channel: _Channel) -> _Method:
         """

--- a/src/hiero_sdk_python/transaction/transaction.py
+++ b/src/hiero_sdk_python/transaction/transaction.py
@@ -27,7 +27,8 @@ class Transaction(_Executable):
 
     Required implementations for subclasses:
     1. build_transaction_body() - Build the transaction-specific protobuf body
-    2. _get_method(channel) - Return the appropriate gRPC method to call
+    2. build_scheduled_body() - Build the schedulable transaction-specific protobuf body
+    3. _get_method(channel) - Return the appropriate gRPC method to call
     """
 
     def __init__(self):
@@ -369,6 +370,8 @@ class Transaction(_Executable):
         transaction_body.generateRecord = self.generate_record
         transaction_body.memo = self.memo
 
+        # TODO: implement CUSTOM FEE LIMITS
+
         return transaction_body
 
     def build_base_scheduled_body(self) -> SchedulableTransactionBody:
@@ -384,6 +387,9 @@ class Transaction(_Executable):
             self.transaction_fee or self._default_transaction_fee
         )
         schedulable_body.memo = self.memo
+
+        # TODO: implement CUSTOM FEE LIMITS
+
         return schedulable_body
 
     def schedule(self) -> "ScheduleCreateTransaction":

--- a/src/hiero_sdk_python/transaction/transaction.py
+++ b/src/hiero_sdk_python/transaction/transaction.py
@@ -1,13 +1,21 @@
 import hashlib
+from typing import TYPE_CHECKING
 
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.exceptions import PrecheckError
 from hiero_sdk_python.executable import _Executable, _ExecutionState
 from hiero_sdk_python.hapi.services import (basic_types_pb2, transaction_pb2, transaction_contents_pb2, transaction_pb2)
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import SchedulableTransactionBody
 from hiero_sdk_python.hapi.services.transaction_response_pb2 import (TransactionResponse as TransactionResponseProto)
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 from hiero_sdk_python.transaction.transaction_response import TransactionResponse
+
+if TYPE_CHECKING:
+    from hiero_sdk_python.schedule.schedule_create_transaction import (
+        ScheduleCreateTransaction,
+    )
+
 
 class Transaction(_Executable):
     """
@@ -315,7 +323,22 @@ class Transaction(_Executable):
             NotImplementedError: Always, since subclasses must implement this method.
         """
         raise NotImplementedError("Subclasses must implement build_transaction_body()")
-    
+
+    def build_scheduled_body(self) -> SchedulableTransactionBody:
+        """
+        Abstract method to build the schedulable transaction body.
+
+        Subclasses must implement this method to construct the transaction-specific
+        body and include it in the overall SchedulableTransactionBody.
+
+        Returns:
+            SchedulableTransactionBody: The protobuf SchedulableTransactionBody message.
+
+        Raises:
+            NotImplementedError: Always, since subclasses must implement this method.
+        """
+        raise NotImplementedError("Subclasses must implement build_scheduled_body()")
+
     def build_base_transaction_body(self) -> transaction_pb2.TransactionBody:
         """
         Builds the base transaction body including common fields.
@@ -347,6 +370,47 @@ class Transaction(_Executable):
         transaction_body.memo = self.memo
 
         return transaction_body
+
+    def build_base_scheduled_body(self) -> SchedulableTransactionBody:
+        """
+        Builds the base scheduled transaction body including common fields.
+
+        Returns:
+            SchedulableTransactionBody:
+                The protobuf SchedulableTransactionBody message with common fields set.
+        """
+        schedulable_body = SchedulableTransactionBody()
+        schedulable_body.transactionFee = (
+            self.transaction_fee or self._default_transaction_fee
+        )
+        schedulable_body.memo = self.memo
+        return schedulable_body
+
+    def schedule(self) -> "ScheduleCreateTransaction":
+        """
+        Converts this transaction into a scheduled transaction.
+
+        This method prepares the current transaction to be scheduled for future execution
+        via the network's scheduling service. It returns a `ScheduleCreateTransaction`
+        instance with the transaction's details embedded as a schedulable transaction body.
+
+        Returns:
+            ScheduleCreateTransaction: A new instance representing the scheduled version
+                of this transaction, ready to be configured and submitted.
+
+        Raises:
+            Exception: If the transaction has already been frozen and cannot be scheduled.
+        """
+        self._require_not_frozen()
+
+        # The import is here to avoid circular dependency
+        # pylint: disable=import-outside-toplevel
+        from hiero_sdk_python.schedule.schedule_create_transaction import (
+            ScheduleCreateTransaction,
+        )
+
+        schedulable_body = self.build_scheduled_body()
+        return ScheduleCreateTransaction()._set_schedulable_body(schedulable_body)
 
     def _require_not_frozen(self):
         """

--- a/src/hiero_sdk_python/transaction/transaction_receipt.py
+++ b/src/hiero_sdk_python/transaction/transaction_receipt.py
@@ -7,6 +7,7 @@ from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.consensus.topic_id import TopicId
 from hiero_sdk_python.contract.contract_id import ContractId
 from hiero_sdk_python.file.file_id import FileId
+from hiero_sdk_python.schedule.schedule_id import ScheduleId
 from hiero_sdk_python.tokens.token_id import TokenId
 
 
@@ -128,6 +129,22 @@ class TransactionReceipt(_DeprecatedAliasesMixin):
             and self._receipt_proto.contractID.contractNum != 0
         ):
             return ContractId._from_proto(self._receipt_proto.contractID)
+
+        return None
+
+    @property
+    def schedule_id(self):
+        """
+        Returns the schedule ID associated with this receipt.
+
+        Returns:
+            ScheduleId or None: The ScheduleId if present; otherwise, None.
+        """
+        if (
+            self._receipt_proto.HasField("scheduleID")
+            and self._receipt_proto.scheduleID.scheduleNum != 0
+        ):
+            return ScheduleId._from_proto(self._receipt_proto.scheduleID)
 
         return None
 

--- a/src/hiero_sdk_python/transaction/transaction_receipt.py
+++ b/src/hiero_sdk_python/transaction/transaction_receipt.py
@@ -9,6 +9,7 @@ from hiero_sdk_python.contract.contract_id import ContractId
 from hiero_sdk_python.file.file_id import FileId
 from hiero_sdk_python.schedule.schedule_id import ScheduleId
 from hiero_sdk_python.tokens.token_id import TokenId
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 
 class TransactionReceipt(_DeprecatedAliasesMixin):
@@ -145,6 +146,19 @@ class TransactionReceipt(_DeprecatedAliasesMixin):
             and self._receipt_proto.scheduleID.scheduleNum != 0
         ):
             return ScheduleId._from_proto(self._receipt_proto.scheduleID)
+
+        return None
+
+    @property
+    def scheduled_transaction_id(self):
+        """
+        Returns the schedule transaction ID associated with this receipt.
+
+        Returns:
+            TransactionId or None: The TransactionId if present; otherwise, None.
+        """
+        if self._receipt_proto.HasField("scheduledTransactionID"):
+            return TransactionId._from_proto(self._receipt_proto.scheduledTransactionID)
 
         return None
 

--- a/src/hiero_sdk_python/transaction/transaction_receipt.py
+++ b/src/hiero_sdk_python/transaction/transaction_receipt.py
@@ -1,10 +1,14 @@
-import warnings 
+"""
+TransactionReceipt class
+"""
+
+from hiero_sdk_python._deprecated import _DeprecatedAliasesMixin
+from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.consensus.topic_id import TopicId
 from hiero_sdk_python.contract.contract_id import ContractId
 from hiero_sdk_python.file.file_id import FileId
 from hiero_sdk_python.tokens.token_id import TokenId
-from hiero_sdk_python.consensus.topic_id import TopicId
-from hiero_sdk_python.account.account_id import AccountId
-from hiero_sdk_python._deprecated import _DeprecatedAliasesMixin
+
 
 class TransactionReceipt(_DeprecatedAliasesMixin):
     """
@@ -38,10 +42,13 @@ class TransactionReceipt(_DeprecatedAliasesMixin):
         Returns:
             TokenId or None: The TokenId if present; otherwise, None.
         """
-        if self._receipt_proto.HasField('tokenID') and self._receipt_proto.tokenID.tokenNum != 0:
+        if (
+            self._receipt_proto.HasField("tokenID")
+            and self._receipt_proto.tokenID.tokenNum != 0
+        ):
             return TokenId._from_proto(self._receipt_proto.tokenID)
-        else:
-            return None
+
+        return None
 
     @property
     def topic_id(self):
@@ -51,10 +58,13 @@ class TransactionReceipt(_DeprecatedAliasesMixin):
         Returns:
             TopicId or None: The TopicId if present; otherwise, None.
         """
-        if self._receipt_proto.HasField('topicID') and self._receipt_proto.topicID.topicNum != 0:
+        if (
+            self._receipt_proto.HasField("topicID")
+            and self._receipt_proto.topicID.topicNum != 0
+        ):
             return TopicId._from_proto(self._receipt_proto.topicID)
-        else:
-            return None
+
+        return None
 
     @property
     def account_id(self):
@@ -64,16 +74,19 @@ class TransactionReceipt(_DeprecatedAliasesMixin):
         Returns:
             AccountId or None: The AccountId if present; otherwise, None.
         """
-        if self._receipt_proto.HasField('accountID') and self._receipt_proto.accountID.accountNum != 0:
+        if (
+            self._receipt_proto.HasField("accountID")
+            and self._receipt_proto.accountID.accountNum != 0
+        ):
             return AccountId._from_proto(self._receipt_proto.accountID)
-        else:
-            return None
+
+        return None
 
     @property
     def serial_numbers(self):
         """
         Retrieves the serial numbers associated with the transaction receipt, if available.
-        
+
         Returns:
             list of int: The serial numbers if present; otherwise, an empty list.
         """
@@ -84,11 +97,14 @@ class TransactionReceipt(_DeprecatedAliasesMixin):
         """
         Returns the file ID associated with this receipt.
         """
-        if self._receipt_proto.HasField('fileID') and self._receipt_proto.fileID.fileNum != 0:
+        if (
+            self._receipt_proto.HasField("fileID")
+            and self._receipt_proto.fileID.fileNum != 0
+        ):
             return FileId._from_proto(self._receipt_proto.fileID)
-        else:
-            return None
-          
+
+        return None
+
     @property
     def transaction_id(self):
         """
@@ -107,10 +123,13 @@ class TransactionReceipt(_DeprecatedAliasesMixin):
         Returns:
             ContractId or None: The ContractId if present; otherwise, None.
         """
-        if self._receipt_proto.HasField('contractID') and self._receipt_proto.contractID.contractNum != 0:
+        if (
+            self._receipt_proto.HasField("contractID")
+            and self._receipt_proto.contractID.contractNum != 0
+        ):
             return ContractId._from_proto(self._receipt_proto.contractID)
-        else:
-            return None
+
+        return None
 
     def _to_proto(self):
         """

--- a/tests/integration/schedule_create_transaction_e2e_test.py
+++ b/tests/integration/schedule_create_transaction_e2e_test.py
@@ -1,0 +1,220 @@
+"""
+Integration tests for ScheduleCreateTransaction.
+"""
+
+import datetime
+
+import pytest
+
+from hiero_sdk_python.consensus.topic_create_transaction import TopicCreateTransaction
+from hiero_sdk_python.consensus.topic_message_submit_transaction import (
+    TopicMessageSubmitTransaction,
+)
+from hiero_sdk_python.hbar import Hbar
+from hiero_sdk_python.query.account_info_query import AccountInfoQuery
+from hiero_sdk_python.query.token_info_query import TokenInfoQuery
+from hiero_sdk_python.query.topic_info_query import TopicInfoQuery
+from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.timestamp import Timestamp
+from hiero_sdk_python.tokens.token_burn_transaction import TokenBurnTransaction
+from hiero_sdk_python.tokens.token_mint_transaction import TokenMintTransaction
+from hiero_sdk_python.transaction.transfer_transaction import TransferTransaction
+from tests.integration.utils_for_test import create_fungible_token, env
+
+
+@pytest.mark.integration
+def test_integration_schedule_create_transaction_can_execute(env):
+    """Test that ScheduleCreateTransaction can execute."""
+    account = env.create_account()
+
+    schedule_create_tx = (
+        TransferTransaction()
+        .add_hbar_transfer(account.id, -1000)  # 1000 tinybars
+        .add_hbar_transfer(env.operator_id, 1000)
+        .schedule()
+    )
+
+    current_time = datetime.datetime.now()
+    future_expiration = Timestamp.from_date(current_time + datetime.timedelta(seconds=30))
+
+    receipt = (
+        schedule_create_tx.set_payer_account_id(account.id)
+        .set_schedule_memo("test schedule create transaction")
+        .set_expiration_time(future_expiration)
+        .set_wait_for_expiry(True)
+        .freeze_with(env.client)
+        .sign(account.key)  # Sign with the account key to pay for the transaction
+        .execute(env.client)
+    )
+
+    assert (
+        receipt.status == ResponseCode.SUCCESS
+    ), f"Transfer transaction failed with status: {ResponseCode(receipt.status).name}"
+    assert receipt.schedule_id is not None
+
+    # TODO: When ScheduleInfoQuery is implemented, assert that everything is fine.
+
+
+@pytest.mark.integration
+def test_integration_schedule_create_transaction_with_transfer_transaction(env):
+    """Test that ScheduleCreateTransaction can schedule a transfer transaction."""
+    account = env.create_account()
+
+    transfer_tx = (
+        TransferTransaction()
+        .add_hbar_transfer(account.id, -Hbar(1).to_tinybars())
+        .add_hbar_transfer(env.operator_id, Hbar(1).to_tinybars())
+        .schedule()
+    )
+
+    receipt = (
+        transfer_tx.freeze_with(env.client)
+        .sign(account.key)  # Sign with the sender's key as we send from the account id
+        .execute(env.client)
+    )
+
+    assert (
+        receipt.status == ResponseCode.SUCCESS
+    ), f"Transfer transaction failed with status: {ResponseCode(receipt.status).name}"
+    assert receipt.schedule_id is not None
+
+    account_info = AccountInfoQuery().set_account_id(account.id).execute(env.client)
+    assert account_info.balance.to_tinybars() == 0
+
+
+@pytest.mark.integration
+def test_integration_schedule_create_transaction_with_consensus_submit(env):
+    """Test that ScheduleCreateTransaction can schedule a ConsensusSubmitMessage transaction."""
+    topic_receipt = (
+        TopicCreateTransaction().set_memo("test topic for schedule").execute(env.client)
+    )
+    assert topic_receipt.status == ResponseCode.SUCCESS
+    topic_id = topic_receipt.topic_id
+
+    scheduled_tx = (
+        TopicMessageSubmitTransaction()
+        .set_topic_id(topic_id)
+        .set_message("scheduled message")
+        .schedule()
+    )
+
+    receipt = (
+        scheduled_tx.freeze_with(env.client).sign(env.operator_key).execute(env.client)
+    )
+    assert receipt.status == ResponseCode.SUCCESS
+    assert receipt.schedule_id is not None
+
+    # Confirm the message was submitted
+    topic_info = TopicInfoQuery().set_topic_id(topic_id).execute(env.client)
+    assert topic_info.sequence_number == 1
+
+
+@pytest.mark.integration
+def test_integration_schedule_create_transaction_with_token_burn(env):
+    """Test that ScheduleCreateTransaction can schedule a TokenBurnTransaction."""
+    initial_supply = 1000
+    amount_to_burn = 500
+
+    # Create a fungible token
+    token_id = create_fungible_token(
+        env, opts=[lambda tx: tx.set_initial_supply(initial_supply)]
+    )
+
+    scheduled_tx = (
+        TokenBurnTransaction()
+        .set_token_id(token_id)
+        .set_amount(amount_to_burn)
+        .schedule()
+    )
+
+    receipt = scheduled_tx.execute(env.client)
+    assert receipt.status == ResponseCode.SUCCESS
+    assert receipt.schedule_id is not None
+
+    # Confirm the supply was reduced
+    token_info = TokenInfoQuery().set_token_id(token_id).execute(env.client)
+    assert token_info.total_supply == initial_supply - amount_to_burn
+
+
+@pytest.mark.integration
+def test_integration_schedule_create_transaction_with_token_mint(env):
+    """Test that ScheduleCreateTransaction can schedule a TokenMintTransaction."""
+    initial_supply = 1000
+    amount_to_mint = 250
+
+    # Create a fungible token
+    token_id = create_fungible_token(
+        env, opts=[lambda tx: tx.set_initial_supply(initial_supply)]
+    )
+
+    scheduled_tx = (
+        TokenMintTransaction()
+        .set_token_id(token_id)
+        .set_amount(amount_to_mint)
+        .schedule()
+    )
+
+    receipt = scheduled_tx.execute(env.client)
+    assert receipt.status == ResponseCode.SUCCESS
+    assert receipt.schedule_id is not None
+
+    # Confirm the supply was increased
+    token_info = TokenInfoQuery().set_token_id(token_id).execute(env.client)
+    assert token_info.total_supply == initial_supply + amount_to_mint
+
+
+@pytest.mark.integration
+def test_integration_schedule_create_transaction_invalid_expiry(env):
+    """Test that ScheduleCreateTransaction fails when expiration_time is set far in the future."""
+    account = env.create_account()
+
+    # Create a simple transfer transaction
+    transfer_tx = (
+        TransferTransaction()
+        .add_hbar_transfer(account.id, -Hbar(1).to_tinybars())
+        .add_hbar_transfer(env.operator_id, Hbar(1).to_tinybars())
+    )
+
+    scheduled_tx = transfer_tx.schedule()
+
+    # Set expiration time far in the future
+    future_expiration = Timestamp.from_date(
+        datetime.datetime.now() + datetime.timedelta(days=366)
+    )
+
+    receipt = scheduled_tx.set_expiration_time(future_expiration).execute(env.client)
+    assert receipt.status == ResponseCode.SCHEDULE_EXPIRATION_TIME_TOO_FAR_IN_FUTURE, (
+        f"Schedule create should have failed with status "
+        f"SCHEDULE_EXPIRATION_TIME_TOO_FAR_IN_FUTURE, "
+        f"but got {ResponseCode(receipt.status).name}"
+    )
+
+
+@pytest.mark.integration
+def test_integration_schedule_create_transaction_invalid_expiry_in_the_past(env):
+    """Test that ScheduleCreateTransaction fails when expiration_time is set in the past."""
+    account = env.create_account()
+
+    # Create a simple transfer transaction
+    transfer_tx = (
+        TransferTransaction()
+        .add_hbar_transfer(account.id, -Hbar(1).to_tinybars())
+        .add_hbar_transfer(env.operator_id, Hbar(1).to_tinybars())
+    )
+
+    scheduled_tx = transfer_tx.schedule()
+
+    # Set expiration time in the past
+    past_time = Timestamp.from_date(
+        datetime.datetime.now() - datetime.timedelta(days=366)
+    )
+
+    receipt = scheduled_tx.set_expiration_time(past_time).execute(env.client)
+    assert (
+        receipt.status
+        == ResponseCode.SCHEDULE_EXPIRATION_TIME_MUST_BE_HIGHER_THAN_CONSENSUS_TIME
+    ), (
+        f"Schedule create should have failed with status "
+        f"SCHEDULE_EXPIRATION_TIME_MUST_BE_HIGHER_THAN_CONSENSUS_TIME, "
+        f"but got {ResponseCode(receipt.status).name}"
+    )

--- a/tests/integration/schedule_create_transaction_e2e_test.py
+++ b/tests/integration/schedule_create_transaction_e2e_test.py
@@ -51,6 +51,7 @@ def test_integration_schedule_create_transaction_can_execute(env):
         receipt.status == ResponseCode.SUCCESS
     ), f"Transfer transaction failed with status: {ResponseCode(receipt.status).name}"
     assert receipt.schedule_id is not None
+    assert receipt.scheduled_transaction_id is not None
 
     # TODO: When ScheduleInfoQuery is implemented, assert that everything is fine.
 
@@ -77,6 +78,7 @@ def test_integration_schedule_create_transaction_with_transfer_transaction(env):
         receipt.status == ResponseCode.SUCCESS
     ), f"Transfer transaction failed with status: {ResponseCode(receipt.status).name}"
     assert receipt.schedule_id is not None
+    assert receipt.scheduled_transaction_id is not None
 
     account_info = AccountInfoQuery().set_account_id(account.id).execute(env.client)
     assert account_info.balance.to_tinybars() == 0
@@ -103,6 +105,7 @@ def test_integration_schedule_create_transaction_with_consensus_submit(env):
     )
     assert receipt.status == ResponseCode.SUCCESS
     assert receipt.schedule_id is not None
+    assert receipt.scheduled_transaction_id is not None
 
     # Confirm the message was submitted
     topic_info = TopicInfoQuery().set_topic_id(topic_id).execute(env.client)
@@ -130,6 +133,7 @@ def test_integration_schedule_create_transaction_with_token_burn(env):
     receipt = scheduled_tx.execute(env.client)
     assert receipt.status == ResponseCode.SUCCESS
     assert receipt.schedule_id is not None
+    assert receipt.scheduled_transaction_id is not None
 
     # Confirm the supply was reduced
     token_info = TokenInfoQuery().set_token_id(token_id).execute(env.client)
@@ -157,6 +161,7 @@ def test_integration_schedule_create_transaction_with_token_mint(env):
     receipt = scheduled_tx.execute(env.client)
     assert receipt.status == ResponseCode.SUCCESS
     assert receipt.schedule_id is not None
+    assert receipt.scheduled_transaction_id is not None
 
     # Confirm the supply was increased
     token_info = TokenInfoQuery().set_token_id(token_id).execute(env.client)

--- a/tests/unit/test_account_delete_transaction.py
+++ b/tests/unit/test_account_delete_transaction.py
@@ -8,6 +8,9 @@ import pytest
 
 from hiero_sdk_python.account.account_delete_transaction import AccountDeleteTransaction
 from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -229,6 +232,32 @@ def test_parameter_validation_types(delete_params):
 
     delete_tx.set_transfer_account_id(delete_params["transfer_account_id"])
     assert isinstance(delete_tx.transfer_account_id, AccountId)
+
+
+def test_build_scheduled_body(delete_params):
+    """Test building a schedulable account delete transaction body."""
+    delete_tx = AccountDeleteTransaction(
+        account_id=delete_params["account_id"],
+        transfer_account_id=delete_params["transfer_account_id"],
+    )
+
+    schedulable_body = delete_tx.build_scheduled_body()
+
+    # Verify the correct type is returned
+    assert isinstance(schedulable_body, SchedulableTransactionBody)
+
+    # Verify the transaction was built with account delete type
+    assert schedulable_body.HasField("cryptoDelete")
+
+    # Verify fields in the schedulable body
+    assert (
+        schedulable_body.cryptoDelete.deleteAccountID
+        == delete_params["account_id"]._to_proto()
+    )
+    assert (
+        schedulable_body.cryptoDelete.transferAccountID
+        == delete_params["transfer_account_id"]._to_proto()
+    )
 
 
 def test_parameter_validation_none_values():

--- a/tests/unit/test_ethereum_transaction.py
+++ b/tests/unit/test_ethereum_transaction.py
@@ -206,6 +206,12 @@ def test_to_proto(mock_client, ethereum_params):
     assert proto.signedTransactionBytes
     assert len(proto.signedTransactionBytes) > 0
 
+def test_build_scheduled_body_raises_exception():
+    """Test that build_scheduled_body raises ValueError."""
+    schedule_tx = EthereumTransaction()
+
+    with pytest.raises(ValueError, match="Cannot schedule an EthereumTransaction"):
+        schedule_tx.build_scheduled_body()
 
 def test_ethereum_transaction_can_execute():
     """Test that an ethereum transaction can be executed successfully."""

--- a/tests/unit/test_file_append_transaction.py
+++ b/tests/unit/test_file_append_transaction.py
@@ -3,6 +3,9 @@ import pytest
 
 from hiero_sdk_python.file.file_append_transaction import FileAppendTransaction
 from hiero_sdk_python.file.file_id import FileId
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.timestamp import Timestamp
@@ -143,3 +146,27 @@ def test_build_transaction_body_missing_file_id():
 
     with pytest.raises(ValueError, match="Missing required FileID"):
         file_tx.build_transaction_body()
+
+def test_build_scheduled_body():
+    """Test building a schedulable file append transaction body."""
+    file_id = FileId(0, 0, 12345)
+    contents = b"Test schedulable content"
+
+    file_tx = FileAppendTransaction(
+        file_id=file_id,
+        contents=contents,
+        chunk_size=100
+    )
+
+    # Build the scheduled body
+    schedulable_body = file_tx.build_scheduled_body()
+
+    # Verify the correct type is returned
+    assert isinstance(schedulable_body, SchedulableTransactionBody)
+
+    # Verify the transaction was built with file append type
+    assert schedulable_body.HasField("fileAppend")
+
+    # Verify fields in the schedulable body
+    assert schedulable_body.fileAppend.fileID == file_id._to_proto()
+    assert schedulable_body.fileAppend.contents == contents[:100]  # First chunk

--- a/tests/unit/test_file_delete_transaction.py
+++ b/tests/unit/test_file_delete_transaction.py
@@ -7,6 +7,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from hiero_sdk_python.file.file_delete_transaction import FileDeleteTransaction
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -93,6 +96,25 @@ def test_to_proto(mock_client, file_id):
     assert proto.signedTransactionBytes
     assert len(proto.signedTransactionBytes) > 0
 
+
+def test_build_scheduled_body(mock_account_ids, file_id):
+    """Test building a schedulable file delete transaction body."""
+    account_id, _, node_account_id, _, _ = mock_account_ids
+    delete_tx = FileDeleteTransaction(file_id=file_id)
+    delete_tx.node_account_id = node_account_id
+    delete_tx.operator_account_id = account_id
+
+    # Build the scheduled body
+    schedulable_body = delete_tx.build_scheduled_body()
+
+    # Verify the correct type is returned
+    assert isinstance(schedulable_body, SchedulableTransactionBody)
+
+    # Verify the transaction was built with file delete type
+    assert schedulable_body.HasField("fileDelete")
+
+    # Verify fields in the schedulable body
+    assert schedulable_body.fileDelete.fileID == file_id._to_proto()
 
 def test_get_method():
     """Test retrieving the gRPC method for the transaction."""

--- a/tests/unit/test_schedule_create_transaction.py
+++ b/tests/unit/test_schedule_create_transaction.py
@@ -1,0 +1,271 @@
+"""
+Test cases for the ScheduleCreateTransaction class.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.crypto.private_key import PrivateKey
+from hiero_sdk_python.schedule.schedule_create_transaction import (
+    ScheduleCreateParams,
+    ScheduleCreateTransaction,
+)
+from hiero_sdk_python.timestamp import Timestamp
+from hiero_sdk_python.transaction.transfer_transaction import TransferTransaction
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def schedule_params():
+    """Fixture for schedule create parameters."""
+    return {
+        "payer_account_id": AccountId(0, 0, 123),
+        "admin_key": PrivateKey.generate_ed25519().public_key(),
+        "schedulable_body": TransferTransaction().build_scheduled_body(),
+        "schedule_memo": "test memo",
+        "expiration_time": Timestamp(seconds=1620000000, nanos=0),
+        "wait_for_expiry": True,
+    }
+
+
+def test_constructor_with_parameters(schedule_params):
+    """Test creating a schedule create transaction with constructor parameters."""
+    schedule_create_params = ScheduleCreateParams(
+        payer_account_id=schedule_params["payer_account_id"],
+        admin_key=schedule_params["admin_key"],
+        schedulable_body=schedule_params["schedulable_body"],
+        schedule_memo=schedule_params["schedule_memo"],
+        expiration_time=schedule_params["expiration_time"],
+        wait_for_expiry=schedule_params["wait_for_expiry"],
+    )
+
+    schedule_tx = ScheduleCreateTransaction(schedule_params=schedule_create_params)
+
+    assert schedule_tx.payer_account_id == schedule_params["payer_account_id"]
+    assert schedule_tx.admin_key == schedule_params["admin_key"]
+    assert schedule_tx.schedulable_body == schedule_params["schedulable_body"]
+    assert schedule_tx.schedule_memo == schedule_params["schedule_memo"]
+    assert schedule_tx.expiration_time == schedule_params["expiration_time"]
+    assert schedule_tx.wait_for_expiry == schedule_params["wait_for_expiry"]
+
+
+def test_constructor_default_values():
+    """Test that constructor sets default values correctly."""
+    schedule_tx = ScheduleCreateTransaction()
+
+    assert schedule_tx.payer_account_id is None
+    assert schedule_tx.admin_key is None
+    assert schedule_tx.schedulable_body is None
+    assert schedule_tx.schedule_memo is None
+    assert schedule_tx.expiration_time is None
+    assert schedule_tx.wait_for_expiry is None
+    assert schedule_tx._default_transaction_fee == 500000000  # 5 hbar in tinybars
+
+
+def test_build_transaction_body_with_valid_parameters(mock_account_ids, schedule_params):
+    """Test building a schedule create transaction body with valid parameters."""
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    schedule_create_params = ScheduleCreateParams(**schedule_params)
+    schedule_tx = ScheduleCreateTransaction(schedule_params=schedule_create_params)
+
+    # Set operator and node account IDs needed for building transaction body
+    schedule_tx.operator_account_id = operator_id
+    schedule_tx.node_account_id = node_account_id
+
+    transaction_body = schedule_tx.build_transaction_body()
+
+    # Verify the transaction body contains scheduleCreate field
+    assert transaction_body.HasField("scheduleCreate")
+
+    # Verify all fields are correctly set
+    schedule_create = transaction_body.scheduleCreate
+    assert (
+        schedule_create.payerAccountID == schedule_params["payer_account_id"]._to_proto()
+    )
+    assert schedule_create.adminKey == schedule_params["admin_key"]._to_proto()
+    assert schedule_create.scheduledTransactionBody == schedule_params["schedulable_body"]
+    assert schedule_create.memo == schedule_params["schedule_memo"]
+    assert (
+        schedule_create.expiration_time
+        == schedule_params["expiration_time"]._to_protobuf()
+    )
+    assert schedule_create.wait_for_expiry == schedule_params["wait_for_expiry"]
+
+
+def test_set_schedulable_body(schedule_params):
+    """Test setting schedulable_body using the setter method."""
+    schedule_tx = ScheduleCreateTransaction()
+
+    result = schedule_tx._set_schedulable_body(schedule_params["schedulable_body"])
+
+    assert schedule_tx.schedulable_body == schedule_params["schedulable_body"]
+    assert result is schedule_tx
+
+
+def test_set_scheduled_transaction():
+    """Test setting scheduled transaction using the setter method."""
+    schedule_tx = ScheduleCreateTransaction()
+    transfer_tx = TransferTransaction()
+
+    result = schedule_tx.set_scheduled_transaction(transfer_tx)
+
+    assert schedule_tx.schedulable_body == transfer_tx.build_scheduled_body()
+    assert result is schedule_tx  # Should return self for method chaining
+
+
+def test_set_schedule_memo(schedule_params):
+    """Test setting schedule_memo using the setter method."""
+    schedule_tx = ScheduleCreateTransaction()
+
+    result = schedule_tx.set_schedule_memo(schedule_params["schedule_memo"])
+
+    assert schedule_tx.schedule_memo == schedule_params["schedule_memo"]
+    assert result is schedule_tx  # Should return self for method chaining
+
+
+def test_set_payer_account_id(schedule_params):
+    """Test setting payer_account_id using the setter method."""
+    schedule_tx = ScheduleCreateTransaction()
+
+    result = schedule_tx.set_payer_account_id(schedule_params["payer_account_id"])
+
+    assert schedule_tx.payer_account_id == schedule_params["payer_account_id"]
+    assert result is schedule_tx  # Should return self for method chaining
+
+
+def test_set_expiration_time(schedule_params):
+    """Test setting expiration_time using the setter method."""
+    schedule_tx = ScheduleCreateTransaction()
+
+    result = schedule_tx.set_expiration_time(schedule_params["expiration_time"])
+
+    assert schedule_tx.expiration_time == schedule_params["expiration_time"]
+    assert result is schedule_tx  # Should return self for method chaining
+
+
+def test_set_wait_for_expiry(schedule_params):
+    """Test setting wait_for_expiry using the setter method."""
+    schedule_tx = ScheduleCreateTransaction()
+
+    result = schedule_tx.set_wait_for_expiry(schedule_params["wait_for_expiry"])
+
+    assert schedule_tx.wait_for_expiry == schedule_params["wait_for_expiry"]
+    assert result is schedule_tx  # Should return self for method chaining
+
+
+def test_set_admin_key(schedule_params):
+    """Test setting admin_key using the setter method."""
+    schedule_tx = ScheduleCreateTransaction()
+
+    result = schedule_tx.set_admin_key(schedule_params["admin_key"])
+
+    assert schedule_tx.admin_key == schedule_params["admin_key"]
+    assert result is schedule_tx  # Should return self for method chaining
+
+
+def test_method_chaining_with_all_setters(schedule_params):
+    """Test that all setter methods support method chaining."""
+    schedule_tx = ScheduleCreateTransaction()
+
+    result = (
+        schedule_tx.set_payer_account_id(schedule_params["payer_account_id"])
+        .set_admin_key(schedule_params["admin_key"])
+        ._set_schedulable_body(schedule_params["schedulable_body"])
+        .set_schedule_memo(schedule_params["schedule_memo"])
+        .set_expiration_time(schedule_params["expiration_time"])
+        .set_wait_for_expiry(schedule_params["wait_for_expiry"])
+    )
+
+    assert result is schedule_tx
+    assert schedule_tx.payer_account_id == schedule_params["payer_account_id"]
+    assert schedule_tx.admin_key == schedule_params["admin_key"]
+    assert schedule_tx.schedulable_body == schedule_params["schedulable_body"]
+    assert schedule_tx.schedule_memo == schedule_params["schedule_memo"]
+    assert schedule_tx.expiration_time == schedule_params["expiration_time"]
+    assert schedule_tx.wait_for_expiry == schedule_params["wait_for_expiry"]
+
+
+def test_set_methods_require_not_frozen(mock_client, schedule_params):
+    """Test that setter methods raise exception when transaction is frozen."""
+    schedule_tx = ScheduleCreateTransaction()
+    schedule_tx.freeze_with(mock_client)
+
+    test_cases = [
+        ("_set_schedulable_body", schedule_params["schedulable_body"]),
+        ("set_scheduled_transaction", TransferTransaction()),
+        ("set_schedule_memo", schedule_params["schedule_memo"]),
+        ("set_payer_account_id", schedule_params["payer_account_id"]),
+        ("set_expiration_time", schedule_params["expiration_time"]),
+        ("set_wait_for_expiry", schedule_params["wait_for_expiry"]),
+        ("set_admin_key", schedule_params["admin_key"]),
+    ]
+
+    for method_name, value in test_cases:
+        with pytest.raises(
+            Exception, match="Transaction is immutable; it has been frozen"
+        ):
+            getattr(schedule_tx, method_name)(value)
+
+
+def test_build_scheduled_body_raises_exception():
+    """Test that build_scheduled_body raises ValueError."""
+    schedule_tx = ScheduleCreateTransaction()
+
+    with pytest.raises(ValueError, match="Cannot schedule a ScheduleCreateTransaction"):
+        schedule_tx.build_scheduled_body()
+
+
+def test_get_method():
+    """Test retrieving the gRPC method for the transaction."""
+    schedule_tx = ScheduleCreateTransaction()
+
+    mock_channel = MagicMock()
+    mock_schedule_stub = MagicMock()
+    mock_channel.schedule = mock_schedule_stub
+
+    method = schedule_tx._get_method(mock_channel)
+
+    assert method.query is None
+    assert method.transaction == mock_schedule_stub.createSchedule
+
+
+def test_sign_transaction(mock_client):
+    """Test signing the schedule create transaction with a private key."""
+    schedule_tx = ScheduleCreateTransaction()
+    schedule_tx.set_scheduled_transaction(TransferTransaction())
+
+    private_key = MagicMock()
+    private_key.sign.return_value = b"signature"
+    private_key.public_key().to_bytes_raw.return_value = b"public_key"
+
+    schedule_tx.freeze_with(mock_client)
+    schedule_tx.sign(private_key)
+
+    node_id = mock_client.network.current_node._account_id
+    body_bytes = schedule_tx._transaction_body_bytes[node_id]
+
+    assert len(schedule_tx._signature_map[body_bytes].sigPair) == 1
+    sig_pair = schedule_tx._signature_map[body_bytes].sigPair[0]
+    assert sig_pair.pubKeyPrefix == b"public_key"
+    assert sig_pair.ed25519 == b"signature"
+
+
+def test_to_proto(mock_client):
+    """Test converting the schedule create transaction to protobuf format after signing."""
+    schedule_tx = ScheduleCreateTransaction()
+    schedule_tx.set_scheduled_transaction(TransferTransaction())
+
+    private_key = MagicMock()
+    private_key.sign.return_value = b"signature"
+    private_key.public_key().to_bytes_raw.return_value = b"public_key"
+
+    schedule_tx.freeze_with(mock_client)
+    schedule_tx.sign(private_key)
+    proto = schedule_tx._to_proto()
+
+    assert proto.signedTransactionBytes
+    assert len(proto.signedTransactionBytes) > 0

--- a/tests/unit/test_schedule_id.py
+++ b/tests/unit/test_schedule_id.py
@@ -1,0 +1,133 @@
+import pytest
+
+from hiero_sdk_python.hapi.services.basic_types_pb2 import ScheduleID
+from hiero_sdk_python.schedule.schedule_id import ScheduleId
+
+pytestmark = pytest.mark.unit
+
+
+def test_default_initialization():
+    """Test ScheduleId initialization with default values."""
+    schedule_id = ScheduleId()
+
+    assert schedule_id.shard == 0
+    assert schedule_id.realm == 0
+    assert schedule_id.schedule == 0
+
+
+def test_custom_initialization():
+    """Test ScheduleId initialization with custom values."""
+    schedule_id = ScheduleId(shard=1, realm=2, schedule=3)
+
+    assert schedule_id.shard == 1
+    assert schedule_id.realm == 2
+    assert schedule_id.schedule == 3
+
+
+def test_str_representation():
+    """Test string representation of ScheduleId."""
+    schedule_id = ScheduleId(shard=1, realm=2, schedule=3)
+
+    assert str(schedule_id) == "1.2.3"
+
+
+def test_str_representation_default():
+    """Test string representation of ScheduleId with default values."""
+    schedule_id = ScheduleId()
+
+    assert str(schedule_id) == "0.0.0"
+
+
+def test_from_string_valid():
+    """Test creating ScheduleId from valid string format."""
+    schedule_id = ScheduleId.from_string("1.2.3")
+
+    assert schedule_id.shard == 1
+    assert schedule_id.realm == 2
+    assert schedule_id.schedule == 3
+
+
+def test_from_string_with_spaces():
+    """Test creating ScheduleId from string with leading/trailing spaces."""
+    schedule_id = ScheduleId.from_string("  1.2.3  ")
+
+    assert schedule_id.shard == 1
+    assert schedule_id.realm == 2
+    assert schedule_id.schedule == 3
+
+
+def test_from_string_invalid_formats():
+    """Test creating ScheduleId from various invalid string formats."""
+    invalid_formats = [
+        "1.2",  # Too few parts
+        "1.2.3.4",  # Too many parts
+        "a.b.c",  # Non-numeric parts
+        "",  # Empty string
+        "1.a.3",  # Partial numeric
+    ]
+
+    for invalid_format in invalid_formats:
+        with pytest.raises(ValueError):
+            ScheduleId.from_string(invalid_format)
+
+
+def test_to_proto():
+    """Test converting ScheduleId to protobuf format."""
+    schedule_id = ScheduleId(shard=1, realm=2, schedule=3)
+    proto = schedule_id._to_proto()
+
+    assert isinstance(proto, ScheduleID)
+    assert proto.shardNum == 1
+    assert proto.realmNum == 2
+    assert proto.scheduleNum == 3
+
+
+def test_from_proto():
+    """Test creating ScheduleId from protobuf format."""
+    proto = ScheduleID(shardNum=1, realmNum=2, scheduleNum=3)
+
+    schedule_id = ScheduleId._from_proto(proto)
+
+    assert schedule_id.shard == 1
+    assert schedule_id.realm == 2
+    assert schedule_id.schedule == 3
+
+
+def test_roundtrip_proto_conversion():
+    """Test that converting to proto and back preserves values."""
+    original = ScheduleId(shard=5, realm=10, schedule=15)
+    proto = original._to_proto()
+    reconstructed = ScheduleId._from_proto(proto)
+
+    assert original.shard == reconstructed.shard
+    assert original.realm == reconstructed.realm
+    assert original.schedule == reconstructed.schedule
+
+
+def test_roundtrip_string_conversion():
+    """Test that converting to string and back preserves values."""
+    original = ScheduleId(shard=7, realm=14, schedule=21)
+    string_repr = str(original)
+    reconstructed = ScheduleId.from_string(string_repr)
+
+    assert original.shard == reconstructed.shard
+    assert original.realm == reconstructed.realm
+    assert original.schedule == reconstructed.schedule
+
+
+def test_equality():
+    """Test ScheduleId equality comparison."""
+    schedule_id1 = ScheduleId(shard=1, realm=2, schedule=3)
+    schedule_id2 = ScheduleId(shard=1, realm=2, schedule=3)
+    schedule_id3 = ScheduleId(shard=1, realm=2, schedule=4)
+
+    assert schedule_id1 == schedule_id2
+    assert schedule_id1 != schedule_id3
+
+
+def test_equality_different_type():
+    """Test ScheduleId equality comparison with different type."""
+    schedule_id = ScheduleId(shard=1, realm=2, schedule=3)
+
+    # Should not raise an exception and should return False
+    assert schedule_id != "1.2.3"

--- a/tests/unit/test_token_associate_transaction.py
+++ b/tests/unit/test_token_associate_transaction.py
@@ -2,6 +2,9 @@ import pytest
 from unittest.mock import MagicMock
 from hiero_sdk_python.tokens.token_associate_transaction import TokenAssociateTransaction
 from hiero_sdk_python.hapi.services import timestamp_pb2
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 pytestmark = pytest.mark.unit
@@ -101,3 +104,22 @@ def test_to_proto(mock_account_ids, mock_client):
 
     assert proto.signedTransactionBytes
     assert len(proto.signedTransactionBytes) > 0
+    
+def test_build_scheduled_body(mock_account_ids):
+    """Test building a scheduled transaction body for token associate transaction."""
+    account_id, _, _, token_id_1, token_id_2 = mock_account_ids
+    
+    associate_tx = TokenAssociateTransaction()
+    associate_tx.set_account_id(account_id)
+    associate_tx.add_token_id(token_id_1)
+    associate_tx.add_token_id(token_id_2)
+    
+    schedulable_body = associate_tx.build_scheduled_body()
+    
+    # Verify the schedulable body has the correct structure and fields
+    assert isinstance(schedulable_body, SchedulableTransactionBody)
+    assert schedulable_body.HasField("tokenAssociate")
+    assert schedulable_body.tokenAssociate.account == account_id._to_proto()
+    assert len(schedulable_body.tokenAssociate.tokens) == 2
+    assert schedulable_body.tokenAssociate.tokens[0] == token_id_1._to_proto()
+    assert schedulable_body.tokenAssociate.tokens[1] == token_id_2._to_proto()

--- a/tests/unit/test_token_burn_transaction.py
+++ b/tests/unit/test_token_burn_transaction.py
@@ -4,6 +4,9 @@ from hiero_sdk_python.tokens.token_id import TokenId
 from hiero_sdk_python.hapi.services.token_burn_pb2 import TokenBurnTransactionBody
 from hiero_sdk_python.hapi.services.transaction_receipt_pb2 import TransactionReceipt as TransactionReceiptProto
 from hiero_sdk_python.hapi.services.transaction_response_pb2 import TransactionResponse as TransactionResponseProto
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.token_burn_transaction import TokenBurnTransaction
 from hiero_sdk_python.hapi.services import response_header_pb2, response_pb2, transaction_get_receipt_pb2
@@ -154,3 +157,38 @@ def test_burn_transaction_from_proto(mock_account_ids):
     assert from_proto.token_id == TokenId(0,0,0)
     assert from_proto.amount == 0
     assert from_proto.serials == []
+    
+def test_build_scheduled_body_fungible(mock_account_ids):
+    """Test building a scheduled transaction body for fungible token burn transaction."""
+    _, _, _, token_id, _ = mock_account_ids
+    
+    burn_tx = TokenBurnTransaction()
+    burn_tx.set_token_id(token_id)
+    burn_tx.set_amount(100)
+    
+    schedulable_body = burn_tx.build_scheduled_body()
+    
+    # Verify the schedulable body has the correct structure and fields
+    assert isinstance(schedulable_body, SchedulableTransactionBody)
+    assert schedulable_body.HasField("tokenBurn")
+    assert schedulable_body.tokenBurn.token == token_id._to_proto()
+    assert schedulable_body.tokenBurn.amount == 100
+    assert len(schedulable_body.tokenBurn.serialNumbers) == 0
+    
+def test_build_scheduled_body_nft(mock_account_ids):
+    """Test building a scheduled transaction body for NFT burn transaction."""
+    _, _, _, token_id, _ = mock_account_ids
+    serials = [1, 2, 3]
+    
+    burn_tx = TokenBurnTransaction()
+    burn_tx.set_token_id(token_id)
+    burn_tx.set_serials(serials)
+    
+    schedulable_body = burn_tx.build_scheduled_body()
+    
+    # Verify the schedulable body has the correct structure and fields
+    assert isinstance(schedulable_body, SchedulableTransactionBody)
+    assert schedulable_body.HasField("tokenBurn")
+    assert schedulable_body.tokenBurn.token == token_id._to_proto()
+    assert schedulable_body.tokenBurn.amount == 0
+    assert schedulable_body.tokenBurn.serialNumbers == serials

--- a/tests/unit/test_token_create_transaction.py
+++ b/tests/unit/test_token_create_transaction.py
@@ -38,6 +38,9 @@ from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.exceptions import PrecheckError
 from hiero_sdk_python.crypto.private_key import PrivateKey
 from hiero_sdk_python.hapi.services import basic_types_pb2
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -833,3 +836,81 @@ def test_supply_type_and_max_supply_validation(
         assert body.tokenCreation.supplyType == supply_type.value
         assert body.tokenCreation.maxSupply == max_supply
         assert body.tokenCreation.initialSupply == initial_supply
+
+def test_build_scheduled_body_fungible_token(mock_account_ids, private_key):
+    """Test building a scheduled transaction body for fungible token creation."""
+    treasury_account, _, _, _, _ = mock_account_ids
+    
+    # Prepare token parameters for a fungible token
+    params = TokenParams(
+        token_name="TestToken",
+        token_symbol="TTK",
+        treasury_account_id=treasury_account,
+        decimals=2,
+        initial_supply=1000,
+        token_type=TokenType.FUNGIBLE_COMMON,
+        supply_type=SupplyType.INFINITE,
+    )
+    
+    # Prepare token keys
+    keys = TokenKeys(
+        admin_key=private_key,
+        supply_key=private_key
+    )
+    
+    # Create the transaction
+    token_tx = TokenCreateTransaction(params, keys)
+
+    schedulable_body = token_tx.build_scheduled_body()
+    
+    # Verify the schedulable body has the correct structure and fields
+    assert isinstance(schedulable_body, SchedulableTransactionBody)
+    assert schedulable_body.HasField("tokenCreation")
+    assert schedulable_body.tokenCreation.name == "TestToken"
+    assert schedulable_body.tokenCreation.symbol == "TTK"
+    assert schedulable_body.tokenCreation.treasury == treasury_account._to_proto()
+    assert schedulable_body.tokenCreation.decimals == 2
+    assert schedulable_body.tokenCreation.initialSupply == 1000
+    assert schedulable_body.tokenCreation.tokenType == TokenType.FUNGIBLE_COMMON.value
+    assert schedulable_body.tokenCreation.supplyType == SupplyType.INFINITE.value
+    assert schedulable_body.tokenCreation.adminKey.HasField("ed25519")
+    assert schedulable_body.tokenCreation.supplyKey.HasField("ed25519")
+    
+def test_build_scheduled_body_nft(mock_account_ids, private_key):
+    """Test building a scheduled transaction body for NFT token creation."""
+    treasury_account, _, _, _, _ = mock_account_ids
+    
+    # Prepare token parameters for an NFT
+    params = TokenParams(
+        token_name="TestNFT",
+        token_symbol="TNFT",
+        treasury_account_id=treasury_account,
+        token_type=TokenType.NON_FUNGIBLE_UNIQUE,
+        supply_type=SupplyType.FINITE,
+        max_supply=1000,
+    )
+    
+    # Prepare token keys
+    keys = TokenKeys(
+        admin_key=private_key,
+        supply_key=private_key,
+        wipe_key=private_key
+    )
+    
+    # Create the transaction
+    token_tx = TokenCreateTransaction(params, keys)
+    
+    schedulable_body = token_tx.build_scheduled_body()
+    
+    # Verify the schedulable body has the correct structure and fields
+    assert isinstance(schedulable_body, SchedulableTransactionBody)
+    assert schedulable_body.HasField("tokenCreation")
+    assert schedulable_body.tokenCreation.name == "TestNFT"
+    assert schedulable_body.tokenCreation.symbol == "TNFT"
+    assert schedulable_body.tokenCreation.treasury == treasury_account._to_proto()
+    assert schedulable_body.tokenCreation.tokenType == TokenType.NON_FUNGIBLE_UNIQUE.value
+    assert schedulable_body.tokenCreation.supplyType == SupplyType.FINITE.value
+    assert schedulable_body.tokenCreation.maxSupply == 1000
+    assert schedulable_body.tokenCreation.adminKey.HasField("ed25519")
+    assert schedulable_body.tokenCreation.supplyKey.HasField("ed25519")
+    assert schedulable_body.tokenCreation.wipeKey.HasField("ed25519")

--- a/tests/unit/test_token_delete_transaction.py
+++ b/tests/unit/test_token_delete_transaction.py
@@ -2,6 +2,9 @@ import pytest
 from unittest.mock import MagicMock
 from hiero_sdk_python.tokens.token_delete_transaction import TokenDeleteTransaction
 from hiero_sdk_python.hapi.services import basic_types_pb2, timestamp_pb2
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 pytestmark = pytest.mark.unit
@@ -88,3 +91,17 @@ def test_to_proto(mock_account_ids, mock_client):
 
     assert proto.signedTransactionBytes
     assert len(proto.signedTransactionBytes) > 0
+    
+def test_build_scheduled_body(mock_account_ids):
+    """Test building a scheduled transaction body for token delete transaction."""
+    _, _, _, token_id, _ = mock_account_ids
+    
+    delete_tx = TokenDeleteTransaction()
+    delete_tx.set_token_id(token_id)
+
+    schedulable_body = delete_tx.build_scheduled_body()
+    
+    # Verify the schedulable body has the correct structure and fields
+    assert isinstance(schedulable_body, SchedulableTransactionBody)
+    assert schedulable_body.HasField("tokenDeletion")
+    assert schedulable_body.tokenDeletion.token == token_id._to_proto()

--- a/tests/unit/test_token_freeze_transaction.py
+++ b/tests/unit/test_token_freeze_transaction.py
@@ -2,6 +2,9 @@ import pytest
 from unittest.mock import MagicMock
 from hiero_sdk_python.tokens.token_freeze_transaction import TokenFreezeTransaction
 from hiero_sdk_python.hapi.services import timestamp_pb2
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 pytestmark = pytest.mark.unit
@@ -108,3 +111,19 @@ def test_to_proto(mock_account_ids, mock_client):
 
     assert proto.signedTransactionBytes
     assert len(proto.signedTransactionBytes) > 0
+    
+def test_build_scheduled_body(mock_account_ids):
+    """Test building a scheduled transaction body for token freeze transaction."""
+    _, freeze_id, _, token_id, _ = mock_account_ids
+    
+    freeze_tx = TokenFreezeTransaction()
+    freeze_tx.set_token_id(token_id)
+    freeze_tx.set_account_id(freeze_id)
+
+    schedulable_body = freeze_tx.build_scheduled_body()
+    
+    # Verify the schedulable body has the correct structure and fields
+    assert isinstance(schedulable_body, SchedulableTransactionBody)
+    assert schedulable_body.HasField("tokenFreeze")
+    assert schedulable_body.tokenFreeze.token == token_id._to_proto()
+    assert schedulable_body.tokenFreeze.account == freeze_id._to_proto()

--- a/tests/unit/test_token_grant_kyc_transaction.py
+++ b/tests/unit/test_token_grant_kyc_transaction.py
@@ -6,6 +6,9 @@ from hiero_sdk_python.hapi.services.transaction_response_pb2 import TransactionR
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.token_grant_kyc_transaction import TokenGrantKycTransaction
 from hiero_sdk_python.hapi.services import response_header_pb2, response_pb2, transaction_get_receipt_pb2
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.tokens.token_id import TokenId
 
@@ -150,3 +153,19 @@ def test_grant_kyc_transaction_from_proto(mock_account_ids):
     # Verify empty protobuf deserializes to empty/default values
     assert from_proto.token_id == TokenId(0,0,0)
     assert from_proto.account_id == AccountId()
+    
+def test_build_scheduled_body(mock_account_ids):
+    """Test building a scheduled transaction body for token grant KYC transaction."""
+    account_id, _, _, token_id, _ = mock_account_ids
+    
+    grant_kyc_tx = TokenGrantKycTransaction()
+    grant_kyc_tx.set_token_id(token_id)
+    grant_kyc_tx.set_account_id(account_id)
+
+    schedulable_body = grant_kyc_tx.build_scheduled_body()
+    
+    # Verify the schedulable body has the correct structure and fields
+    assert isinstance(schedulable_body, SchedulableTransactionBody)
+    assert schedulable_body.HasField("tokenGrantKyc")
+    assert schedulable_body.tokenGrantKyc.token == token_id._to_proto()
+    assert schedulable_body.tokenGrantKyc.account == account_id._to_proto()

--- a/tests/unit/test_token_mint_transaction.py
+++ b/tests/unit/test_token_mint_transaction.py
@@ -1,28 +1,39 @@
-import pytest
 from unittest.mock import MagicMock
-from hiero_sdk_python.tokens.token_mint_transaction import TokenMintTransaction
-from hiero_sdk_python.hapi.services import basic_types_pb2, timestamp_pb2, transaction_pb2, transaction_pb2
-from hiero_sdk_python.transaction.transaction_id import TransactionId
+
+import pytest
 from cryptography.hazmat.primitives import serialization
+
+from hiero_sdk_python.hapi.services import (
+    basic_types_pb2,
+    timestamp_pb2,
+    token_mint_pb2,
+    transaction_pb2,
+)
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 from hiero_sdk_python.response_code import ResponseCode
-from hiero_sdk_python.hapi.services import token_mint_pb2
+from hiero_sdk_python.tokens.token_mint_transaction import TokenMintTransaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 pytestmark = pytest.mark.unit
+
 
 def generate_transaction_id(account_id_proto):
     """Generate a unique transaction ID based on the account ID and the current timestamp."""
     import time
+
     current_time = time.time()
     timestamp_seconds = int(current_time)
     timestamp_nanos = int((current_time - timestamp_seconds) * 1e9)
 
-    tx_timestamp = timestamp_pb2.Timestamp(seconds=timestamp_seconds, nanos=timestamp_nanos)
-
-    tx_id = TransactionId(
-        valid_start=tx_timestamp,
-        account_id=account_id_proto
+    tx_timestamp = timestamp_pb2.Timestamp(
+        seconds=timestamp_seconds, nanos=timestamp_nanos
     )
+
+    tx_id = TransactionId(valid_start=tx_timestamp, account_id=account_id_proto)
     return tx_id
+
 
 # This test uses fixture mock_account_ids as parameter
 def test_build_nft_transaction_body_single_bytes_metadata(mock_account_ids):
@@ -33,7 +44,7 @@ def test_build_nft_transaction_body_single_bytes_metadata(mock_account_ids):
 
     mint_tx = TokenMintTransaction()
     mint_tx.set_token_id(token_id)
-    mint_tx.set_metadata(single_metadata)  
+    mint_tx.set_metadata(single_metadata)
     mint_tx.transaction_id = generate_transaction_id(payer_account)
     mint_tx.node_account_id = node_account_id
 
@@ -43,11 +54,12 @@ def test_build_nft_transaction_body_single_bytes_metadata(mock_account_ids):
     assert transaction_body.tokenMint.metadata[0] == single_metadata
     assert transaction_body.tokenMint.amount == 0
 
+
 # This test uses fixtures (mock_account_ids, amount) as parameters
 def test_build_transaction_body_fungible(mock_account_ids, amount):
     """Test building a token mint transaction body for fungible tokens."""
     payer_account, _, node_account_id, token_id, _ = mock_account_ids
-   
+
     mint_tx = TokenMintTransaction()
     mint_tx.set_token_id(token_id)
     mint_tx.set_amount(amount)
@@ -60,7 +72,10 @@ def test_build_transaction_body_fungible(mock_account_ids, amount):
     assert transaction_body.tokenMint.token.realmNum == 1
     assert transaction_body.tokenMint.token.tokenNum == 1
     assert transaction_body.tokenMint.amount == amount
-    assert len(transaction_body.tokenMint.metadata) == 0  # No metadata for fungible tokens
+    assert (
+        len(transaction_body.tokenMint.metadata) == 0
+    )  # No metadata for fungible tokens
+
 
 # This test uses fixtures (mock_account_ids, metadata) as parameters
 def test_build_transaction_body_nft(mock_account_ids, metadata):
@@ -78,8 +93,9 @@ def test_build_transaction_body_nft(mock_account_ids, metadata):
     assert transaction_body.tokenMint.token.shardNum == 1
     assert transaction_body.tokenMint.token.realmNum == 1
     assert transaction_body.tokenMint.token.tokenNum == 1
-    assert transaction_body.tokenMint.amount == 0  
+    assert transaction_body.tokenMint.amount == 0
     assert transaction_body.tokenMint.metadata == metadata
+
 
 # This test uses fixtures (mock_account_ids, amount) as parameters
 @pytest.mark.parametrize("amount", [0, -1, -1000])
@@ -92,21 +108,24 @@ def test_build_fungible_transaction_body_invalid_amount(mock_account_ids, amount
     with pytest.raises(ValueError, match="Amount to mint must be positive."):
         mint_tx.build_transaction_body()
 
+
 # This test uses fixture amount as parameter
 def test_build_fungible_transaction_body_missing_token_id(amount):
     """Test that missing token_id raises a ValueError for fungible token mint."""
-    mint_tx = TokenMintTransaction()  
-    mint_tx.set_amount(amount)        
+    mint_tx = TokenMintTransaction()
+    mint_tx.set_amount(amount)
     with pytest.raises(ValueError, match="Token ID is required for minting."):
         mint_tx.build_transaction_body()
+
 
 # This test uses fixture metadata as parameter
 def test_build_nft_transaction_body_missing_token_id(metadata):
     """Test that missing token_id raises a ValueError for nft mint."""
-    mint_tx = TokenMintTransaction()  
-    mint_tx.set_metadata(metadata)        
+    mint_tx = TokenMintTransaction()
+    mint_tx.set_metadata(metadata)
     with pytest.raises(ValueError, match="Token ID is required for minting."):
-        mint_tx.build_transaction_body()  
+        mint_tx.build_transaction_body()
+
 
 # This test uses fixture mock_account_ids as parameter
 def test_build_nft_transaction_body_invalid_metadata_type(mock_account_ids):
@@ -117,14 +136,17 @@ def test_build_nft_transaction_body_invalid_metadata_type(mock_account_ids):
     mint_tx = TokenMintTransaction()
     mint_tx.set_token_id(token_id)
     mint_tx.set_metadata(metadata)
-    with pytest.raises(ValueError, match="Metadata must be a list of byte arrays for NFTs."):
+    with pytest.raises(
+        ValueError, match="Metadata must be a list of byte arrays for NFTs."
+    ):
         mint_tx.build_transaction_body()
+
 
 # This test uses fixture mock_account_ids as parameter
 def test_build_nft_transaction_body_empty_metadata(mock_account_ids):
     """Test that empty metadata list with no fungible mint amount raises a ValueError."""
     _, _, _, token_id, _ = mock_account_ids
-    metadata = [] # Should be a list of bytes
+    metadata = []  # Should be a list of bytes
 
     mint_tx = TokenMintTransaction()
     mint_tx.set_token_id(token_id)
@@ -132,8 +154,11 @@ def test_build_nft_transaction_body_empty_metadata(mock_account_ids):
     with pytest.raises(ValueError, match="Metadata list cannot be empty for NFTs."):
         mint_tx.build_transaction_body()
 
+
 # This test uses fixtures (mock_account_ids, amount, metadata) as parameters
-def test_build_transaction_body_both_amount_and_metadata(mock_account_ids, amount, metadata):
+def test_build_transaction_body_both_amount_and_metadata(
+    mock_account_ids, amount, metadata
+):
     """Test that setting both amount and metadata raises a ValueError."""
     payer_account, _, node_account_id, token_id, _ = mock_account_ids
 
@@ -141,27 +166,31 @@ def test_build_transaction_body_both_amount_and_metadata(mock_account_ids, amoun
     mint_tx.set_token_id(token_id)
     mint_tx.set_amount(amount)
     mint_tx.set_metadata(metadata)
-    
+
     mint_tx.transaction_id = generate_transaction_id(payer_account)
     mint_tx.node_account_id = node_account_id
-    with pytest.raises(ValueError, match="Specify either amount for fungible tokens or metadata for NFTs, not both."):
+    with pytest.raises(
+        ValueError,
+        match="Specify either amount for fungible tokens or metadata for NFTs, not both.",
+    ):
         mint_tx.build_transaction_body()
+
 
 # This test uses fixtures (mock_account_ids, amount, mock_client) as parameters
 def test_sign_transaction_fungible(mock_account_ids, amount, mock_client):
     """Test signing the fungible token mint transaction with a supply key."""
-    operator_id, _, _, token_id, _= mock_account_ids
-    
+    operator_id, _, _, token_id, _ = mock_account_ids
+
     mint_tx = TokenMintTransaction()
     mint_tx.set_token_id(token_id)
-    mint_tx.set_amount(amount)        
+    mint_tx.set_amount(amount)
     mint_tx.transaction_id = generate_transaction_id(operator_id)
 
-    #Mock a supply key
+    # Mock a supply key
     supply_key = MagicMock()
-    supply_key.sign.return_value = b'signature'
-    supply_key.public_key().to_bytes_raw.return_value = b'public_key'
-    
+    supply_key.sign.return_value = b"signature"
+    supply_key.public_key().to_bytes_raw.return_value = b"public_key"
+
     mint_tx.freeze_with(mock_client)
 
     mint_tx.sign(supply_key)
@@ -171,8 +200,9 @@ def test_sign_transaction_fungible(mock_account_ids, amount, mock_client):
 
     assert len(mint_tx._signature_map[body_bytes].sigPair) == 1
     sig_pair = mint_tx._signature_map[body_bytes].sigPair[0]
-    assert sig_pair.pubKeyPrefix == b'public_key'
-    assert sig_pair.ed25519 == b'signature'
+    assert sig_pair.pubKeyPrefix == b"public_key"
+    assert sig_pair.ed25519 == b"signature"
+
 
 # This test uses fixtures (mock_account_ids, metadata, mock_client) as parameters
 def test_sign_transaction_nft(mock_account_ids, metadata, mock_client):
@@ -188,8 +218,8 @@ def test_sign_transaction_nft(mock_account_ids, metadata, mock_client):
     mint_tx.freeze_with(mock_client)
 
     supply_key = MagicMock()
-    supply_key.sign.return_value = b'signature'
-    supply_key.public_key().to_bytes_raw.return_value = b'public_key'
+    supply_key.sign.return_value = b"signature"
+    supply_key.public_key().to_bytes_raw.return_value = b"public_key"
     mint_tx.sign(supply_key)
 
     node_id = mock_client.network.current_node._account_id
@@ -197,23 +227,24 @@ def test_sign_transaction_nft(mock_account_ids, metadata, mock_client):
 
     assert len(mint_tx._signature_map[body_bytes].sigPair) == 1
     sig_pair = mint_tx._signature_map[body_bytes].sigPair[0]
-    assert sig_pair.pubKeyPrefix == b'public_key'
-    assert sig_pair.ed25519 == b'signature'
+    assert sig_pair.pubKeyPrefix == b"public_key"
+    assert sig_pair.ed25519 == b"signature"
+
 
 # This test uses fixtures (mock_account_ids, amount, mock_client) as parameters
 def test_to_proto_fungible(mock_account_ids, amount, mock_client):
     """Test converting the fungible token mint transaction to protobuf format after signing."""
-    operator_id, _, _, token_id, _= mock_account_ids
+    operator_id, _, _, token_id, _ = mock_account_ids
 
     mint_tx = TokenMintTransaction()
     mint_tx.set_token_id(token_id)
-    mint_tx.set_amount(amount)        
+    mint_tx.set_amount(amount)
     mint_tx.transaction_id = generate_transaction_id(operator_id)
 
     supply_key = MagicMock()
-    supply_key.sign.return_value = b'signature'
-    supply_key.public_key().to_bytes_raw.return_value = b'public_key'
-    
+    supply_key.sign.return_value = b"signature"
+    supply_key.public_key().to_bytes_raw.return_value = b"public_key"
+
     mint_tx.freeze_with(mock_client)
 
     mint_tx.sign(supply_key)
@@ -222,21 +253,22 @@ def test_to_proto_fungible(mock_account_ids, amount, mock_client):
     assert proto.signedTransactionBytes
     assert len(proto.signedTransactionBytes) > 0
 
+
 # This test uses fixtures (mock_account_ids, metadata, mock_client) as parameters
 def test_to_proto_nft(mock_account_ids, metadata, mock_client):
     """Test converting the nft token mint transaction to protobuf format after signing."""
-    operator_id, _, _, token_id, _= mock_account_ids
+    operator_id, _, _, token_id, _ = mock_account_ids
 
     mint_tx = TokenMintTransaction()
     mint_tx.set_token_id(token_id)
     mint_tx.set_metadata(metadata)
     mint_tx.transaction_id = generate_transaction_id(operator_id)
-    
+
     mint_tx.freeze_with(mock_client)
 
     supply_key = MagicMock()
-    supply_key.sign.return_value = b'signature'
-    supply_key.public_key().to_bytes_raw.return_value = b'public_key'
+    supply_key.sign.return_value = b"signature"
+    supply_key.public_key().to_bytes_raw.return_value = b"public_key"
     mint_tx.sign(supply_key)
 
     proto = mint_tx._to_proto()
@@ -244,4 +276,37 @@ def test_to_proto_nft(mock_account_ids, metadata, mock_client):
     assert len(proto.signedTransactionBytes) > 0
 
 
+def test_build_scheduled_body_fungible(mock_account_ids, amount):
+    """Test building a scheduled transaction body for fungible token mint transaction."""
+    _, _, _, token_id, _ = mock_account_ids
 
+    mint_tx = TokenMintTransaction()
+    mint_tx.set_token_id(token_id)
+    mint_tx.set_amount(amount)
+
+    schedulable_body = mint_tx.build_scheduled_body()
+
+    # Verify the schedulable body has the correct structure and fields
+    assert isinstance(schedulable_body, SchedulableTransactionBody)
+    assert schedulable_body.HasField("tokenMint")
+    assert schedulable_body.tokenMint.token == token_id._to_proto()
+    assert schedulable_body.tokenMint.amount == amount
+    assert len(schedulable_body.tokenMint.metadata) == 0
+
+
+def test_build_scheduled_body_nft(mock_account_ids, metadata):
+    """Test building a scheduled transaction body for NFT token mint transaction."""
+    _, _, _, token_id, _ = mock_account_ids
+
+    mint_tx = TokenMintTransaction()
+    mint_tx.set_token_id(token_id)
+    mint_tx.set_metadata(metadata)
+
+    schedulable_body = mint_tx.build_scheduled_body()
+
+    # Verify the schedulable body has the correct structure and fields
+    assert isinstance(schedulable_body, SchedulableTransactionBody)
+    assert schedulable_body.HasField("tokenMint")
+    assert schedulable_body.tokenMint.token == token_id._to_proto()
+    assert schedulable_body.tokenMint.amount == 0
+    assert schedulable_body.tokenMint.metadata == metadata

--- a/tests/unit/test_token_pause_transaction.py
+++ b/tests/unit/test_token_pause_transaction.py
@@ -10,7 +10,9 @@ from hiero_sdk_python.hapi.services import (
 from hiero_sdk_python.hapi.services.transaction_receipt_pb2 import TransactionReceipt as TransactionReceiptProto
 from hiero_sdk_python.hapi.services.transaction_response_pb2 import TransactionResponse as TransactionResponseProto
 from hiero_sdk_python.hapi.services.token_pause_pb2 import TokenPauseTransactionBody
-
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 from hiero_sdk_python.tokens.token_pause_transaction import TokenPauseTransaction
 from hiero_sdk_python.tokens.token_id import TokenId
 from hiero_sdk_python.transaction.transaction_id import TransactionId
@@ -150,4 +152,15 @@ def test_pause_transaction_can_execute(token_id):
         
         receipt = transaction.execute(client)
         
-        assert receipt.status == ResponseCode.SUCCESS, "Transaction should have succeeded"        
+        assert receipt.status == ResponseCode.SUCCESS, "Transaction should have succeeded"
+
+def test_build_scheduled_body(token_id):
+    """Test building a scheduled transaction body for token pause transaction."""
+    pause_tx = TokenPauseTransaction().set_token_id(token_id)
+
+    schedulable_body = pause_tx.build_scheduled_body()
+    
+    # Verify the schedulable body has the correct structure and fields
+    assert isinstance(schedulable_body, SchedulableTransactionBody)
+    assert schedulable_body.HasField("token_pause")
+    assert schedulable_body.token_pause.token == token_id._to_proto()

--- a/tests/unit/test_token_revoke_kyc_transaction.py
+++ b/tests/unit/test_token_revoke_kyc_transaction.py
@@ -3,6 +3,9 @@ import pytest
 from hiero_sdk_python.hapi.services.token_revoke_kyc_pb2 import TokenRevokeKycTransactionBody
 from hiero_sdk_python.hapi.services.transaction_receipt_pb2 import TransactionReceipt as TransactionReceiptProto
 from hiero_sdk_python.hapi.services.transaction_response_pb2 import TransactionResponse as TransactionResponseProto
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.token_revoke_kyc_transaction import TokenRevokeKycTransaction
 from hiero_sdk_python.hapi.services import response_header_pb2, response_pb2, transaction_get_receipt_pb2
@@ -125,6 +128,24 @@ def test_revoke_kyc_transaction_can_execute(mock_account_ids):
         receipt = transaction.execute(client)
         
         assert receipt.status == ResponseCode.SUCCESS, "Transaction should have succeeded"
+
+def test_build_scheduled_body(mock_account_ids):
+    """Test building a scheduled transaction body for token revoke KYC transaction."""
+    account_id, _, _, token_id, _ = mock_account_ids
+    
+    revoke_kyc_tx = (
+        TokenRevokeKycTransaction()
+        .set_token_id(token_id)
+        .set_account_id(account_id)
+    )
+    
+    schedulable_body = revoke_kyc_tx.build_scheduled_body()
+    
+    # Verify the schedulable body has the correct structure and fields
+    assert isinstance(schedulable_body, SchedulableTransactionBody)
+    assert schedulable_body.HasField("tokenRevokeKyc")
+    assert schedulable_body.tokenRevokeKyc.token == token_id._to_proto()
+    assert schedulable_body.tokenRevokeKyc.account == account_id._to_proto()
 
 def test_revoke_kyc_transaction_from_proto(mock_account_ids):
     """Test that a revoke KYC transaction can be created from a protobuf object."""

--- a/tests/unit/test_token_unfreeze_transaction.py
+++ b/tests/unit/test_token_unfreeze_transaction.py
@@ -2,6 +2,9 @@ import pytest
 from unittest.mock import MagicMock
 from hiero_sdk_python.tokens.token_unfreeze_transaction import TokenUnfreezeTransaction
 from hiero_sdk_python.hapi.services import timestamp_pb2
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 pytestmark = pytest.mark.unit
@@ -87,6 +90,22 @@ def test_sign_transaction(mock_account_ids, mock_client):
 
     assert sig_pair.pubKeyPrefix == b'public_key'
     assert sig_pair.ed25519 == b'signature'
+
+def test_build_scheduled_body(mock_account_ids):
+    """Test building a scheduled transaction body for token unfreeze transaction."""
+    _, freeze_id, _, token_id, _ = mock_account_ids
+    
+    unfreeze_tx = TokenUnfreezeTransaction()
+    unfreeze_tx.set_token_id(token_id)
+    unfreeze_tx.set_account_id(freeze_id)
+    
+    schedulable_body = unfreeze_tx.build_scheduled_body()
+    
+    # Verify the schedulable body has the correct structure and fields
+    assert isinstance(schedulable_body, SchedulableTransactionBody)
+    assert schedulable_body.HasField("tokenUnfreeze")
+    assert schedulable_body.tokenUnfreeze.token == token_id._to_proto()
+    assert schedulable_body.tokenUnfreeze.account == freeze_id._to_proto()
 
 def test_to_proto(mock_account_ids, mock_client):
     """Test converting the token unfreeze transaction to protobuf format after signing."""

--- a/tests/unit/test_token_update_nfts_transaction.py
+++ b/tests/unit/test_token_update_nfts_transaction.py
@@ -1,5 +1,8 @@
 import pytest
 
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 from hiero_sdk_python.hapi.services.token_update_nfts_pb2 import TokenUpdateNftsTransactionBody
 from hiero_sdk_python.hapi.services.transaction_receipt_pb2 import TransactionReceipt as TransactionReceiptProto
 from hiero_sdk_python.hapi.services.transaction_response_pb2 import TransactionResponse as TransactionResponseProto
@@ -162,6 +165,28 @@ def test_update_nfts_transaction_can_execute(mock_account_ids):
         receipt = transaction.execute(client)
         
         assert receipt.status == ResponseCode.SUCCESS, "Transaction should have succeeded"
+
+def test_build_scheduled_body(mock_account_ids):
+    """Test building a scheduled transaction body for token update NFTs transaction."""
+    _, _, _, token_id, _ = mock_account_ids
+    serial_numbers = [1, 2, 3]
+    metadata = b'updated metadata'
+    
+    update_tx = (
+        TokenUpdateNftsTransaction()
+        .set_token_id(token_id)
+        .set_serial_numbers(serial_numbers)
+        .set_metadata(metadata)
+    )
+    
+    schedulable_body = update_tx.build_scheduled_body()
+    
+    # Verify the schedulable body has the correct structure and fields
+    assert isinstance(schedulable_body, SchedulableTransactionBody)
+    assert schedulable_body.HasField("token_update_nfts")
+    assert schedulable_body.token_update_nfts.token == token_id._to_proto()
+    assert schedulable_body.token_update_nfts.serial_numbers == serial_numbers
+    assert schedulable_body.token_update_nfts.metadata.value == metadata
 
 def test_update_nfts_transaction_from_proto(mock_account_ids):
     """Test that a token update NFTs transaction can be created from a protobuf object."""

--- a/tests/unit/test_token_wipe_transaction.py
+++ b/tests/unit/test_token_wipe_transaction.py
@@ -7,6 +7,9 @@ from hiero_sdk_python.hapi.services.transaction_response_pb2 import TransactionR
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.token_wipe_transaction import TokenWipeTransaction
 from hiero_sdk_python.hapi.services import response_header_pb2, response_pb2, timestamp_pb2, transaction_get_receipt_pb2
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 from tests.unit.mock_server import mock_hedera_servers
@@ -185,3 +188,45 @@ def test_wipe_transaction_can_execute(mock_account_ids):
         receipt = transaction.execute(client)
         
         assert receipt.status == ResponseCode.SUCCESS, "Transaction should have succeeded"
+
+def test_build_scheduled_body(mock_account_ids):
+    """Test building a scheduled transaction body for token wipe transaction."""
+    _, wipe_account_id, _, token_id, _ = mock_account_ids
+    amount = 1000
+    
+    wipe_tx = (
+        TokenWipeTransaction()
+        .set_token_id(token_id)
+        .set_account_id(wipe_account_id)
+        .set_amount(amount)
+    )
+    
+    schedulable_body = wipe_tx.build_scheduled_body()
+    
+    # Verify the schedulable body has the correct structure and fields
+    assert isinstance(schedulable_body, SchedulableTransactionBody)
+    assert schedulable_body.HasField("tokenWipe")
+    assert schedulable_body.tokenWipe.token == token_id._to_proto()
+    assert schedulable_body.tokenWipe.account == wipe_account_id._to_proto()
+    assert schedulable_body.tokenWipe.amount == amount
+    
+def test_build_scheduled_body_with_serial_numbers(mock_account_ids):
+    """Test building a scheduled transaction body for token wipe transaction with serial numbers."""
+    _, wipe_account_id, _, token_id, _ = mock_account_ids
+    serial_numbers = [1, 2, 3]
+    
+    wipe_tx = (
+        TokenWipeTransaction()
+        .set_token_id(token_id)
+        .set_account_id(wipe_account_id)
+        .set_serial(serial_numbers)
+    )
+    
+    schedulable_body = wipe_tx.build_scheduled_body()
+    
+    # Verify the schedulable body has the correct structure and fields
+    assert isinstance(schedulable_body, SchedulableTransactionBody)
+    assert schedulable_body.HasField("tokenWipe")
+    assert schedulable_body.tokenWipe.token == token_id._to_proto()
+    assert schedulable_body.tokenWipe.account == wipe_account_id._to_proto()
+    assert schedulable_body.tokenWipe.serialNumbers == serial_numbers

--- a/tests/unit/test_topic_delete_transaction.py
+++ b/tests/unit/test_topic_delete_transaction.py
@@ -11,6 +11,9 @@ from hiero_sdk_python.hapi.services import (
     transaction_receipt_pb2,
     transaction_response_pb2
 )
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 from hiero_sdk_python.response_code import ResponseCode
 
 from tests.unit.mock_server import mock_hedera_servers
@@ -28,6 +31,27 @@ def test_build_topic_delete_transaction_body(mock_account_ids, topic_id):
 
     transaction_body = tx.build_transaction_body()
     assert transaction_body.consensusDeleteTopic.topicID.topicNum == 1234
+    
+# This test uses fixtures (mock_account_ids, topic_id) as parameters
+def test_build_scheduled_body(mock_account_ids, topic_id):
+    """Test building a schedulable TopicDeleteTransaction body with a valid topic ID."""
+    _, _, node_account_id, _, _ = mock_account_ids
+    
+    # Create transaction and set required fields
+    tx = TopicDeleteTransaction()
+    tx.set_topic_id(topic_id)
+    
+    # Build the scheduled body
+    schedulable_body = tx.build_scheduled_body()
+    
+    # Verify the correct type is returned
+    assert isinstance(schedulable_body, SchedulableTransactionBody)
+    
+    # Verify the transaction was built with topic delete type
+    assert schedulable_body.HasField("consensusDeleteTopic")
+    
+    # Verify the topic ID was correctly set
+    assert schedulable_body.consensusDeleteTopic.topicID.topicNum == 1234
 
 # This test uses fixture mock_account_ids as parameter
 def test_missing_topic_id_in_delete(mock_account_ids):

--- a/tests/unit/test_topic_message_submit_transaction.py
+++ b/tests/unit/test_topic_message_submit_transaction.py
@@ -10,6 +10,9 @@ from hiero_sdk_python.hapi.services import (
     transaction_receipt_pb2,
     transaction_response_pb2
 )
+from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
+    SchedulableTransactionBody,
+)
 from hiero_sdk_python.response_code import ResponseCode
 
 from tests.unit.mock_server import mock_hedera_servers
@@ -20,6 +23,27 @@ pytestmark = pytest.mark.unit
 def message():
     """Fixture to provide a test message."""
     return "Hello from topic submit!"
+    
+# This test uses fixtures (topic_id, message) as parameters
+def test_build_scheduled_body(topic_id, message):
+    """Test building a schedulable TopicMessageSubmitTransaction body."""
+    # Create transaction with all required fields
+    tx = TopicMessageSubmitTransaction()
+    tx.set_topic_id(topic_id)
+    tx.set_message(message)
+    
+    # Build the scheduled body
+    schedulable_body = tx.build_scheduled_body()
+    
+    # Verify the correct type is returned
+    assert isinstance(schedulable_body, SchedulableTransactionBody)
+    
+    # Verify the transaction was built with topic message submit type
+    assert schedulable_body.HasField("consensusSubmitMessage")
+    
+    # Verify fields in the schedulable body
+    assert schedulable_body.consensusSubmitMessage.topicID.topicNum == 1234
+    assert schedulable_body.consensusSubmitMessage.message == bytes(message, 'utf-8')
 
 # This test uses fixtures (topic_id, message) as parameters
 def test_execute_topic_message_submit_transaction(topic_id, message):


### PR DESCRIPTION
**Description:**
Implemented the `ScheduleCreateTransaction` class that allows scheduling transactions for future execution on the network.

* Add `ScheduleId` class implementation
* Add `ScheduleCreateTransaction` class implementation
* Add `schedulable` property to base `Transaction` class
* Add `build_scheduled_body()` method to all transaction types (Account, Contract, File, Token, Topic) for schedule creation
* Add unit tests for `build_scheduled_body()` method across all transaction types
* Add `schedule_id` field to `TransactionReceipt` for tracking scheduled transactions
* Add `_build_proto_body()` method extraction and refactoring across transaction classes
* Add unit tests for `ScheduleCreateTransaction` class
* Add unit tests for `ScheduleId` class
* Add integration tests for `ScheduleCreateTransaction` class
* Add `schedule_create.py` example demonstrating schedule creation
* Add Schedule Create section to `running_examples.md` documentation
* Add `ScheduleCreateTransaction` and `ScheduleId` to `__init__.py` file in `__all__` list
* Update CHANGELOG with schedule transaction functionality additions

Fixes #257 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
