### PR TITLE
chore: move README_upstream.md to docs as rebase.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Unit test compatibility issues when running with UV package manager
 - Type annotations in TokenRelationship class (kyc_status and freeze_status)
 - Test assertions in test_executable.py using pytest match parameter
+- Moved and renamed README_upstream.md to docs/sdk_developers/rebasing.md
 
 ### Removed
 - Removed the old `/documentation` folder.

--- a/docs/sdk_developers/rebasing.md
+++ b/docs/sdk_developers/rebasing.md
@@ -1,4 +1,4 @@
-# Keeping Your Branch Up to Date with Main (Hiero Python SDK)
+# Rebasing (Hiero Python SDK)
 
 If you have forked the Hiero Python SDK, created your own branch, and now need to sync it with the latest changes from main in the original repository, follow these steps.
 


### PR DESCRIPTION
Fixes https://github.com/hiero-ledger/hiero-sdk-python/issues/289