### PR TITLE
fix: Resolve value errors in example scripts cause due to optional values in `.env`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - ContractId.to_evm_address() method for EVM compatibility
 - consumeLargeData() function in StatefulContract
 - example script for Token Airdrop
+- added variables directly in the example script to reduce the need for users to supply extra environment variables.
 
 ### Changed
 - Extract _build_proto_body() from build_transaction_body() in every transaction
@@ -46,7 +47,6 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Invalid DRE Hex representation in examples/keys_private_ecdsa.py
 - Windows malformed path using uv run generate_proto.py using as_posix()
 - Changed README MIT license to Apache
-- adding variables directly in the example script to reduce the need for users to supply extra environment variables.
 
 ### Removed
 - Removed the old `/documentation` folder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,12 +46,14 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Invalid DRE Hex representation in examples/keys_private_ecdsa.py
 - Windows malformed path using uv run generate_proto.py using as_posix()
 - Changed README MIT license to Apache
+- adding variables directly in the example script to reduce the need for users to supply extra environment variables.
 
 ### Removed
 - Removed the old `/documentation` folder.
 - Rebase command in README_upstream changed to just -S
 - generate_proto.sh
 - pkg_resources dependency in generate_proto.py
+
 
 ### Breaking API changes
 - We have some changed imports and returns to maintain compatability in the proto bump 
@@ -86,7 +88,6 @@ contract_call_local_pb2.ContractLoginfo -> contract_types_pb2.ContractLoginfo
 - missing ECDSA support in query.py and contract_create_transaction.py (was only creating ED25519 keys)
 - Applied linting and code formatting across the consensus module
 - fixed pip install hiero_sdk_python -> pip install hiero-sdk-python in README.md
--  Errors in query_receipt, query_topic_message, query_topic_info, topic_delete, topic_message_submit, topic_update, transfer_hbar, and transfer_token cause by hardcoded value in .env
 
 ### Breaking API changes
 **We have several camelCase uses that will be deprecated → snake_case** Original aliases will continue to function, with a warning, until the following release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ contract_call_local_pb2.ContractLoginfo -> contract_types_pb2.ContractLoginfo
 - missing ECDSA support in query.py and contract_create_transaction.py (was only creating ED25519 keys)
 - Applied linting and code formatting across the consensus module
 - fixed pip install hiero_sdk_python -> pip install hiero-sdk-python in README.md
+-  Errors in query_receipt, query_topic_message, query_topic_info, topic_delete, topic_message_submit, topic_update, transfer_hbar, and transfer_token cause by hardcoded value in .env
 
 ### Breaking API changes
 **We have several camelCase uses that will be deprecated → snake_case** Original aliases will continue to function, with a warning, until the following release.

--- a/examples/query_receipt.py
+++ b/examples/query_receipt.py
@@ -11,21 +11,46 @@ from hiero_sdk_python import (
     Hbar,
     TransactionGetReceiptQuery,
     ResponseCode,
+    AccountCreateTransaction
 )
 
 load_dotenv()
 
 def query_receipt():
-    network = Network(network='testnet')
-    client = Client(network)
+    """
+    A full example that include account creation, Hbar transfer, and receipt querying
+    """
+    # Config Client
+    print("Connecting to Hedera testnet...")
+    client = Client(Network(network='testnet'))
 
-    operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
-    recipient_id = AccountId.from_string(os.getenv('RECIPIENT_ID'))
+    try:
+        operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
+        operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
+        client.set_operator(operator_id, operator_key)
+    except (TypeError, ValueError):
+        print("❌ Error: Creating client, Please check your .env file")
+        sys.exit(1)
+
+    # Create a new recipient account.
+    print("\nCreating a new recipient account...")
+    recipient_key = PrivateKey.generate()
+    try:
+        tx = (
+            AccountCreateTransaction()
+            .set_key(recipient_key.public_key())
+            .set_initial_balance(Hbar.from_tinybars(100_000_000))
+        )
+        receipt = tx.freeze_with(client).sign(operator_key).execute(client)
+        recipient_id = receipt.account_id
+        print(f"✅ Success! Created a new recipient account with ID: {recipient_id}")
+    except Exception as e:
+        print(f"Error creating new account: {e}")
+        sys.exit(1)
+
+    # Transfer Hbar to recipient account
+    print("\nTransferring Hbar...")
     amount = 10
-
-    client.set_operator(operator_id, operator_key)
-
     transaction = (
         TransferTransaction()
         .add_hbar_transfer(operator_id, -Hbar(amount).to_tinybars())
@@ -37,11 +62,13 @@ def query_receipt():
     receipt = transaction.execute(client)
     transaction_id = transaction.transaction_id
     print(f"Transaction ID: {transaction_id}")
-    print(f"Transfer transaction status: {ResponseCode(receipt.status).name}")
+    print(f"✅ Success! Transfer transaction status: {ResponseCode(receipt.status).name}")
 
+    # Query Transaction Receipt
+    print("\nQuerying transaction receipt...")
     receipt_query = TransactionGetReceiptQuery().set_transaction_id(transaction_id)
     queried_receipt = receipt_query.execute(client)
-    print(f"Queried transaction status: {ResponseCode(queried_receipt.status).name}")
+    print(f"✅ Success! Queried transaction status: {ResponseCode(queried_receipt.status).name}")
 
 if __name__ == "__main__":
     query_receipt()

--- a/examples/query_topic_info.py
+++ b/examples/query_topic_info.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from dotenv import load_dotenv
 
 from hiero_sdk_python import (
@@ -6,24 +7,52 @@ from hiero_sdk_python import (
     Client,
     AccountId,
     PrivateKey,
-    TopicId,
     TopicInfoQuery,
+    TopicCreateTransaction
 )
 
 load_dotenv()
 
 def query_topic_info():
-    operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
-    topic_id = TopicId.from_string(os.getenv('TOPIC_ID'))
-
+    """
+    A full example that create a topic and query topic info for that topic.
+    """
+    # Config Client
+    print("Connecting to Hedera testnet...")
     network = Network(network='testnet')
     client = Client(network)
-    client.set_operator(operator_id, operator_key)
 
+    try:
+        operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
+        operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+        client.set_operator(operator_id, operator_key)
+    except (TypeError, ValueError):
+        print("❌ Error: Creating client, Please check your .env file")
+        sys.exit(1)
+
+    # Create a new Topic
+    print("\nCreating a Topic...")
+    try:
+        topic_tx = (
+            TopicCreateTransaction(
+                memo="Python SDK created topic",
+                admin_key=operator_key.public_key()
+            )
+            .freeze_with(client)
+            .sign(operator_key)
+        )
+        topic_receipt = topic_tx.execute(client)
+        topic_id = topic_receipt.topic_id
+        print(f"✅ Success! Created topic: {topic_id}")
+    except Exception as e:
+        print(f"❌ Error: Creating topic: {e}")
+        sys.exit(1)
+
+    # Query Topic Info
+    print("\nQuerying Topic Info...")
     query = TopicInfoQuery().set_topic_id(topic_id)
     topic_info = query.execute(client)
-    print("Topic Info:", topic_info)
+    print("✅ Success! Topic Info:", topic_info)
 
 if __name__ == "__main__":
     query_topic_info()

--- a/examples/query_topic_info.py
+++ b/examples/query_topic_info.py
@@ -13,25 +13,24 @@ from hiero_sdk_python import (
 
 load_dotenv()
 
-def query_topic_info():
-    """
-    A full example that create a topic and query topic info for that topic.
-    """
-    # Config Client
+def setup_client():
+    """Initialize and set up the client with operator account"""
     print("Connecting to Hedera testnet...")
-    network = Network(network='testnet')
-    client = Client(network)
+    client = Client(Network(network='testnet'))
 
     try:
         operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
         operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
         client.set_operator(operator_id, operator_key)
+
+        return client, operator_id, operator_key
     except (TypeError, ValueError):
         print("❌ Error: Creating client, Please check your .env file")
         sys.exit(1)
 
-    # Create a new Topic
-    print("\nCreating a Topic...")
+def create_topic(client, operator_key):
+    """Create a new topic"""
+    print("\nSTEP 1: Creating a Topic...")
     try:
         topic_tx = (
             TopicCreateTransaction(
@@ -44,12 +43,24 @@ def query_topic_info():
         topic_receipt = topic_tx.execute(client)
         topic_id = topic_receipt.topic_id
         print(f"✅ Success! Created topic: {topic_id}")
+
+        return topic_id
     except Exception as e:
         print(f"❌ Error: Creating topic: {e}")
         sys.exit(1)
 
+def query_topic_info():
+    """
+    A full example that create a topic and query topic info for that topic.
+    """
+    # Config Client
+    client, _, operator_key = setup_client()
+   
+    # Create a new Topic
+    topic_id = create_topic(client, operator_key)
+
     # Query Topic Info
-    print("\nQuerying Topic Info...")
+    print("\nSTEP 2: Querying Topic Info...")
     query = TopicInfoQuery().set_topic_id(topic_id)
     topic_info = query.execute(client)
     print("✅ Success! Topic Info:", topic_info)

--- a/examples/query_topic_message.py
+++ b/examples/query_topic_message.py
@@ -1,16 +1,57 @@
 import os
 import time
+import sys
 from datetime import datetime, timezone
 from dotenv import load_dotenv
 
-from hiero_sdk_python import Network, Client, TopicMessageQuery
+from hiero_sdk_python import (
+    Network,
+    Client,
+    AccountId,
+    PrivateKey,
+    TopicCreateTransaction,
+    TopicMessageQuery
+)
 
 load_dotenv()
 
 def query_topic_messages():
+    """
+    A full example that creates a topic and perform query topic messages.
+    """
+    # Config Client
+    print("Connecting to Hedera testnet...")
     network = Network(network='testnet')
     client = Client(network)
 
+    try:
+        operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
+        operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+        client.set_operator(operator_id, operator_key)
+    except (TypeError, ValueError):
+        print("❌ Error: Creating client, Please check your .env file")
+        sys.exit(1)
+
+    # Create Topic
+    print("\nCreating a Topic...")
+    try:
+        topic_tx = (
+            TopicCreateTransaction(
+                memo="Python SDK created topic",
+                admin_key=operator_key.public_key()
+            )
+            .freeze_with(client)
+            .sign(operator_key)
+        )
+        topic_receipt = topic_tx.execute(client)
+        topic_id = topic_receipt.topic_id
+        print(f"✅ Success! Created topic: {topic_id}")
+    except Exception as e:
+        print(f"❌ Error: Creating topic: {e}")
+        sys.exit(1)
+
+    # Query Topic Messages
+    print("\nQuery Topic Messages...")
     def on_message_handler(topic_message):
         print(f"Received topic message: {topic_message}")
 
@@ -18,7 +59,7 @@ def query_topic_messages():
         print(f"Subscription error: {e}")
 
     query = TopicMessageQuery(
-        topic_id=os.getenv('TOPIC_ID'),
+        topic_id=topic_id,
         start_time=datetime.now(timezone.utc),
         limit=0,
         chunking_enabled=True
@@ -36,8 +77,8 @@ def query_topic_messages():
             time.sleep(10)
     except KeyboardInterrupt:
         print("Cancelling subscription...")
-        handle.cancel() 
-        handle.join()    
+        handle.cancel()
+        handle.join()
         print("Subscription cancelled. Exiting.")
 
 if __name__ == "__main__":

--- a/examples/query_topic_message.py
+++ b/examples/query_topic_message.py
@@ -15,25 +15,24 @@ from hiero_sdk_python import (
 
 load_dotenv()
 
-def query_topic_messages():
-    """
-    A full example that creates a topic and perform query topic messages.
-    """
-    # Config Client
+def setup_client():
+    """Initialize and set up the client with operator account"""
     print("Connecting to Hedera testnet...")
-    network = Network(network='testnet')
-    client = Client(network)
+    client = Client(Network(network='testnet'))
 
     try:
         operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
         operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
         client.set_operator(operator_id, operator_key)
+
+        return client, operator_id, operator_key
     except (TypeError, ValueError):
         print("❌ Error: Creating client, Please check your .env file")
         sys.exit(1)
 
-    # Create Topic
-    print("\nCreating a Topic...")
+def create_topic(client, operator_key):
+    """Create a new topic"""
+    print("\nSTEP 1: Creating a Topic...")
     try:
         topic_tx = (
             TopicCreateTransaction(
@@ -46,12 +45,24 @@ def query_topic_messages():
         topic_receipt = topic_tx.execute(client)
         topic_id = topic_receipt.topic_id
         print(f"✅ Success! Created topic: {topic_id}")
+
+        return topic_id
     except Exception as e:
         print(f"❌ Error: Creating topic: {e}")
         sys.exit(1)
 
+def query_topic_messages():
+    """
+    A full example that creates a topic and perform query topic messages.
+    """
+    # Config Client
+    client, _, operator_key = setup_client()
+    
+    # Create Topic
+    topic_id = create_topic(client, operator_key)
+
     # Query Topic Messages
-    print("\nQuery Topic Messages...")
+    print("\nSTEP 2: Query Topic Messages...")
     def on_message_handler(topic_message):
         print(f"Received topic message: {topic_message}")
 

--- a/examples/topic_delete.py
+++ b/examples/topic_delete.py
@@ -14,25 +14,24 @@ from hiero_sdk_python import (
 
 load_dotenv()
 
-def delete_topic():
-    """
-    A example to create a topic and then delete it.
-    """
-    # Config Client
+def setup_client():
+    """Initialize and set up the client with operator account"""
     print("Connecting to Hedera testnet...")
-    network = Network(network='testnet')
-    client = Client(network)
+    client = Client(Network(network='testnet'))
 
     try:
         operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
         operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
         client.set_operator(operator_id, operator_key)
+
+        return client, operator_id, operator_key
     except (TypeError, ValueError):
         print("❌ Error: Creating client, Please check your .env file")
         sys.exit(1)
 
-    # Create a new Topic
-    print("\nCreating a Topic...")
+def create_topic(client, operator_key):
+    """Create a new topic"""
+    print("\nSTEP 1: Creating a Topic...")
     try:
         topic_tx = (
             TopicCreateTransaction(
@@ -45,12 +44,23 @@ def delete_topic():
         topic_receipt = topic_tx.execute(client)
         topic_id = topic_receipt.topic_id
         print(f"✅ Success! Created topic: {topic_id}")
+
+        return topic_id
     except Exception as e:
         print(f"❌ Error: Creating topic: {e}")
         sys.exit(1)
 
+
+def delete_topic():
+    """A example to create a topic and then delete it"""
+    # Config Client
+    client, _, operator_key = setup_client()
+
+    # Create a new Topic
+    topic_id = create_topic(client, operator_key)
+
     # Delete the topic
-    print("\nDeleting Topic...")
+    print("\nSTEP 2: Deleting Topic...")
     transaction = (
         TopicDeleteTransaction(topic_id=topic_id)
         .freeze_with(client)

--- a/examples/topic_delete.py
+++ b/examples/topic_delete.py
@@ -6,23 +6,51 @@ from hiero_sdk_python import (
     Client,
     AccountId,
     PrivateKey,
-    TopicId,
     TopicDeleteTransaction,
     Network,
+    TopicCreateTransaction,
+    ResponseCode
 )
 
 load_dotenv()
 
 def delete_topic():
+    """
+    A example to create a topic and then delete it.
+    """
+    # Config Client
+    print("Connecting to Hedera testnet...")
     network = Network(network='testnet')
     client = Client(network)
 
-    operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
-    topic_id = TopicId.from_string(os.getenv('TOPIC_ID'))
+    try:
+        operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
+        operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+        client.set_operator(operator_id, operator_key)
+    except (TypeError, ValueError):
+        print("❌ Error: Creating client, Please check your .env file")
+        sys.exit(1)
 
-    client.set_operator(operator_id, operator_key)
+    # Create a new Topic
+    print("\nCreating a Topic...")
+    try:
+        topic_tx = (
+            TopicCreateTransaction(
+                memo="Python SDK created topic",
+                admin_key=operator_key.public_key()
+            )
+            .freeze_with(client)
+            .sign(operator_key)
+        )
+        topic_receipt = topic_tx.execute(client)
+        topic_id = topic_receipt.topic_id
+        print(f"✅ Success! Created topic: {topic_id}")
+    except Exception as e:
+        print(f"❌ Error: Creating topic: {e}")
+        sys.exit(1)
 
+    # Delete the topic
+    print("\nDeleting Topic...")
     transaction = (
         TopicDeleteTransaction(topic_id=topic_id)
         .freeze_with(client)
@@ -31,9 +59,12 @@ def delete_topic():
 
     try:
         receipt = transaction.execute(client)
-        print(f"Topic {topic_id} deleted successfully.")
+        print(f"Topic Delete Transaction completed: "
+              f"(status: {ResponseCode(receipt.status).name}, "
+              f"transaction_id: {receipt.transaction_id})")
+        print(f"✅ Success! Topic {topic_id} deleted successfully.")
     except Exception as e:
-        print(f"Topic deletion failed: {str(e)}")
+        print(f"❌ Error: Topic deletion failed: {str(e)}")
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/examples/topic_update.py
+++ b/examples/topic_update.py
@@ -6,23 +6,51 @@ from hiero_sdk_python import (
     Client,
     AccountId,
     PrivateKey,
-    TopicId,
     TopicUpdateTransaction,
     Network,
+    TopicCreateTransaction,
+    ResponseCode
 )
 
 load_dotenv()
 
 def update_topic(new_memo):
+    """
+    A example to create a topic and then update it.
+    """
+    # Config Client
+    print("Connecting to Hedera testnet...")
     network = Network(network='testnet')
     client = Client(network)
 
-    operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
-    topic_id = TopicId.from_string(os.getenv('TOPIC_ID'))
+    try:
+        operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
+        operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
+        client.set_operator(operator_id, operator_key)
+    except (TypeError, ValueError):
+        print("❌ Error: Creating client, Please check your .env file")
+        sys.exit(1)
 
-    client.set_operator(operator_id, operator_key)
+    # Create a new Topic
+    print("\nCreating a Topic...")
+    try:
+        topic_tx = (
+            TopicCreateTransaction(
+                memo="Python SDK created topic",
+                admin_key=operator_key.public_key()
+            )
+            .freeze_with(client)
+            .sign(operator_key)
+        )
+        topic_receipt = topic_tx.execute(client)
+        topic_id = topic_receipt.topic_id
+        print(f"✅ Success! Created topic: {topic_id}")
+    except Exception as e:
+        print(f"❌ Error: Creating topic: {e}")
+        sys.exit(1)
 
+    # Update the Topic
+    print("\nUpdating Topic...")
     transaction = (
         TopicUpdateTransaction(topic_id=topic_id, memo=new_memo)
         .freeze_with(client)
@@ -31,9 +59,12 @@ def update_topic(new_memo):
 
     try:
         receipt = transaction.execute(client)
-        print(f"Topic {topic_id} updated with new memo: {new_memo}")
+        print(f"Topic Update Transaction completed: "
+              f"(status: {ResponseCode(receipt.status).name}, "
+              f"transaction_id: {receipt.transaction_id})")
+        print(f"✅ Success! Topic {topic_id} updated with new memo: {new_memo}")
     except Exception as e:
-        print(f"Topic update failed: {str(e)}")
+        print(f"❌ Error: Topic update failed: {str(e)}")
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/examples/transfer_hbar.py
+++ b/examples/transfer_hbar.py
@@ -8,19 +8,53 @@ from hiero_sdk_python import (
     PrivateKey,
     Network,
     TransferTransaction,
+    AccountCreateTransaction,
+    Hbar,
+    CryptoGetAccountBalanceQuery
 )
 
 load_dotenv()
 
 def transfer_hbar():
-    network = Network(network='testnet')
-    client = Client(network)
+    """
+    A full example to create a new recipent account and transfer hbar to that account
+    """
+    # Config Client
+    print("Connecting to Hedera testnet...")
+    client = Client(Network(network='testnet'))
 
-    operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
-    recipient_id = AccountId.from_string(os.getenv('RECIPIENT_ID'))
-    client.set_operator(operator_id, operator_key)
+    try:
+        operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
+        operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
+        client.set_operator(operator_id, operator_key)
+    except (TypeError, ValueError):
+        print("❌ Error: Creating client, Please check your .env file")
+        sys.exit(1)
 
+    # Create a new recipient account.
+    print("\nCreating a new account...")
+    recipient_key = PrivateKey.generate("ed25519")
+    try:
+        tx = (
+            AccountCreateTransaction()
+            .set_key(recipient_key.public_key())
+            .set_initial_balance(Hbar.from_tinybars(100_000_000))
+        )
+        receipt = tx.freeze_with(client).sign(operator_key).execute(client)
+        recipient_id = receipt.account_id
+        print(f"✅ Success! Created a new recipient account with ID: {recipient_id}")
+    except Exception as e:
+        print(f"❌ Error creating new recipient account: {e}")
+        sys.exit(1)
+
+    # Check balance before HBAR transfer
+    before_balance_query = CryptoGetAccountBalanceQuery().set_account_id(recipient_id)
+    before_balance = before_balance_query.execute(client)
+
+    print(f"Recipient account balance before transfer: {before_balance.hbars} hbars")
+
+    # Transfer HBAR
+    print("\nTransfering HBAR...")
     transaction = (
         TransferTransaction()
         .add_hbar_transfer(operator_id, -100000000)  # send 1 HBAR in tinybars
@@ -32,9 +66,16 @@ def transfer_hbar():
 
     try:
         receipt = transaction.execute(client)
-        print("HBAR transfer successful.")
+
+        # Check balance after HBAR transfer
+        after_balance_query = CryptoGetAccountBalanceQuery().set_account_id(recipient_id)
+        after_balance = after_balance_query.execute(client)
+
+        print(f"Recipient account balance after transfer: {after_balance.hbars} hbars")
+
+        print("✅ Success! HBAR transfer successful.")
     except Exception as e:
-        print(f"HBAR transfer failed: {str(e)}")
+        print(f"❌ HBAR transfer failed: {str(e)}")
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/examples/transfer_hbar.py
+++ b/examples/transfer_hbar.py
@@ -15,25 +15,26 @@ from hiero_sdk_python import (
 
 load_dotenv()
 
-def transfer_hbar():
-    """
-    A full example to create a new recipent account and transfer hbar to that account
-    """
-    # Config Client
+def setup_client():
+    """Initialize and set up the client with operator account"""
     print("Connecting to Hedera testnet...")
     client = Client(Network(network='testnet'))
 
     try:
         operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-        operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
+        operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
         client.set_operator(operator_id, operator_key)
+
+        return client, operator_id, operator_key
     except (TypeError, ValueError):
         print("❌ Error: Creating client, Please check your .env file")
         sys.exit(1)
 
-    # Create a new recipient account.
-    print("\nCreating a new account...")
-    recipient_key = PrivateKey.generate("ed25519")
+
+def create_account(client, operator_key):
+    """Create a new recipient account"""
+    print("\nSTEP 1: Creating a new recipient account...")
+    recipient_key = PrivateKey.generate()
     try:
         tx = (
             AccountCreateTransaction()
@@ -43,37 +44,51 @@ def transfer_hbar():
         receipt = tx.freeze_with(client).sign(operator_key).execute(client)
         recipient_id = receipt.account_id
         print(f"✅ Success! Created a new recipient account with ID: {recipient_id}")
+        return recipient_id, recipient_key
+    
     except Exception as e:
-        print(f"❌ Error creating new recipient account: {e}")
+        print(f"Error creating new account: {e}")
         sys.exit(1)
 
-    # Check balance before HBAR transfer
-    before_balance_query = CryptoGetAccountBalanceQuery().set_account_id(recipient_id)
-    before_balance = before_balance_query.execute(client)
+def transfer_hbar():
+    """
+    A full example to create a new recipent account and transfer hbar to that account
+    """
+    # Config Client
+    client, operator_id, operator_key = setup_client()
 
-    print(f"Recipient account balance before transfer: {before_balance.hbars} hbars")
+    # Create a new recipient account.
+    recipient_id, _ = create_account(client, operator_key)
 
     # Transfer HBAR
-    print("\nTransfering HBAR...")
-    transaction = (
-        TransferTransaction()
-        .add_hbar_transfer(operator_id, -100000000)  # send 1 HBAR in tinybars
-        .add_hbar_transfer(recipient_id, 100000000)
-        .freeze_with(client)
-    )
-
-    transaction.sign(operator_key)
+    print("\nSTEP 2: Transfering HBAR...")
 
     try:
-        receipt = transaction.execute(client)
+        # Check balance before HBAR transfer
+        balance_before = (
+            CryptoGetAccountBalanceQuery(account_id=recipient_id)
+            .execute(client)
+            .hbars
+        )
+        print(f"Recipient account balance before transfer: {balance_before} hbars")
+
+        transfer_tx = (
+            TransferTransaction()
+            .add_hbar_transfer(operator_id, -100000000)  # send 1 HBAR in tinybars
+            .add_hbar_transfer(recipient_id, 100000000)
+            .freeze_with(client)
+        )
+        transfer_tx.execute(client)
+        
+        print("\n✅ Success! HBAR transfer successful.\n")
 
         # Check balance after HBAR transfer
-        after_balance_query = CryptoGetAccountBalanceQuery().set_account_id(recipient_id)
-        after_balance = after_balance_query.execute(client)
-
-        print(f"Recipient account balance after transfer: {after_balance.hbars} hbars")
-
-        print("✅ Success! HBAR transfer successful.")
+        balance_after = (
+            CryptoGetAccountBalanceQuery(account_id=recipient_id)
+            .execute(client)
+            .hbars
+        )
+        print(f"Recipient account balance after transfer: {balance_after} hbars")
     except Exception as e:
         print(f"❌ HBAR transfer failed: {str(e)}")
         sys.exit(1)

--- a/examples/transfer_token.py
+++ b/examples/transfer_token.py
@@ -7,37 +7,117 @@ from hiero_sdk_python import (
     AccountId,
     PrivateKey,
     Network,
-    TokenId,
     TransferTransaction,
+    AccountCreateTransaction,
+    Hbar,
+    TokenCreateTransaction,
+    CryptoGetAccountBalanceQuery,
+    TokenAssociateTransaction
 )
 
 load_dotenv()
 
 def transfer_tokens():
-    network = Network(network='testnet')
-    client = Client(network)
-
-    operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
-    operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
-    recipient_id = AccountId.from_string(os.getenv('RECIPIENT_ID'))
-    token_id = TokenId.from_string(os.getenv('TOKEN_ID'))
-    amount = 1
-
-    client.set_operator(operator_id, operator_key)
-
-    transaction = (
-        TransferTransaction()
-        .add_token_transfer(token_id, operator_id, -amount)
-        .add_token_transfer(token_id, recipient_id, amount)
-        .freeze_with(client)
-        .sign(operator_key)
-    )
+    """
+    A full example to create a new recipent account, a fungible token, and
+    transfer the token to that account
+    """
+    # Config Client
+    print("Connecting to Hedera testnet...")
+    client = Client(Network(network='testnet'))
 
     try:
-        receipt = transaction.execute(client)
-        print("Token transfer successful.")
+        operator_id = AccountId.from_string(os.getenv('OPERATOR_ID'))
+        operator_key = PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY'))
+        client.set_operator(operator_id, operator_key)
+    except (TypeError, ValueError):
+        print("❌ Error: Creating client, Please check your .env file")
+        sys.exit(1)
+
+    # Create a new recipient account.
+    print("\nCreating a new recipient account...")
+    recipient_key = PrivateKey.generate()
+    try:
+        account_receipt = (
+            AccountCreateTransaction()
+            .set_key(recipient_key.public_key())
+            .set_initial_balance(Hbar.from_tinybars(100_000_000))
+            .freeze_with(client)
+            .sign(operator_key)
+            .execute(client)
+        )
+        recipient_id = account_receipt.account_id
+        print(f"✅ Success! Created a new recipient account with ID: {recipient_id}")
     except Exception as e:
-        print(f"Token transfer failed: {str(e)}")
+        print(f"❌ Error creating new recipient account: {e}")
+        sys.exit(1)
+
+    # Create two new tokens.
+    print("\nCreating a new tokens...")
+    try:
+        token_tx = (
+            TokenCreateTransaction()
+            .set_token_name("First Token")
+            .set_token_symbol("TKA")
+            .set_initial_supply(1)
+            .set_treasury_account_id(operator_id)
+            .freeze_with(client)
+            .sign(operator_key)
+        )
+        token_receipt = token_tx.execute(client)
+        token_id = token_receipt.token_id
+
+        print(f"✅ Success! Created a token with Token ID: {token_id}")
+    except Exception as e:
+        print(f"❌ Error creating token: {e}")
+        sys.exit(1)
+
+    # Associate Token
+    print("\nAssociating Token...")
+    try:
+        association_tx = (
+            TokenAssociateTransaction(account_id=recipient_id, token_ids=[token_id])
+            .freeze_with(client)
+            .sign(recipient_key)
+        )
+        association_tx.execute(client)
+
+        print("✅ Success! Token association complete.")
+    except Exception as e:
+        print(f"❌ Error associating token: {e}")
+        sys.exit(1)
+
+    # Transfer Token
+    print("\nTransfering Token...")
+    try:
+        balance_before = (
+            CryptoGetAccountBalanceQuery(account_id=recipient_id)
+            .execute(client)
+            .token_balances
+        )
+        print("Token balance before token transfer:")
+        print(f"{token_id}: {balance_before.get(token_id)}")
+
+        transfer_tx = (
+            TransferTransaction()
+            .add_token_transfer(token_id, operator_id, -1)
+            .add_token_transfer(token_id, recipient_id, 1)
+            .freeze_with(client)
+            .sign(operator_key)
+        )
+        transfer_tx.execute(client)
+
+        balance_after = (
+            CryptoGetAccountBalanceQuery(account_id=recipient_id)
+            .execute(client)
+            .token_balances
+        )
+        print("Token balance after token transfer:")
+        print(f"{token_id}: {balance_after.get(token_id)}")
+
+        print("✅ Success! Token transfer complete.")
+    except Exception as e:
+        print(f"❌ Error transferring token: {str(e)}")
         sys.exit(1)
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Description**:
This PR  fixes errors in multiple example scripts occurring due to hardcoded values being used from `.env` file.

**Updated Files:**
- examples/transfer_token.py
- examples/transfer_hbar.py
- examples/topic_update.py
- examples/topic_message_submit.py
- examples/topic_delete.py
- examples/query_topic_message.py
- examples/query_topic_info.py
- examples/query_receipt.py

**Related issue(s)**:

Fixes #336  and #338

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
