### PR TITLE
fix: Value Error in examples/keys_private_ecdsa.py script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Type annotations in TokenRelationship class (kyc_status and freeze_status)
 - Test assertions in test_executable.py using pytest match parameter
 - Moved and renamed README_upstream.md to docs/sdk_developers/rebasing.md
+- Invalid DRE Hex representation in examples/keys_private_ecdsa.py
 
 ### Fixed
 - Windows malformed path using uv run generate_proto.py using as_posix()

--- a/examples/keys_private_ecdsa.py
+++ b/examples/keys_private_ecdsa.py
@@ -14,7 +14,7 @@ def example_generate_ecdsa() -> None:
     # 1) Generate ECDSA
     privkey = PrivateKey.generate("ecdsa")
     print("Generated ECDSA PrivateKey (hex) =", privkey)
-    
+
     # 2) Get the public key
     pubkey = privkey.public_key()
     print("Derived public key =", pubkey)
@@ -66,7 +66,7 @@ def example_load_ecdsa_from_hex() -> None:
     print("=== ECDSA: Load from Hex ===")
     # 32-byte scalar in hex. Must not be zero; example:
     ecdsa_hex = "abcdef0000000000000000000000000000000000000000000000000000000001"
-    
+
     # 1) Generate ECDSA
     privkey = PrivateKey.from_string_ecdsa(ecdsa_hex)
     print("Loaded ECDSA PrivateKey from hex =", privkey)
@@ -93,10 +93,10 @@ def example_load_ecdsa_der() -> None:
     # Example TraditionalOpenSSL DER-encoded key (for scalar=1).
     # (Truncated for demonstration)
     der_hex = (
-        "304e02010104"
-        "200100000000000000000000000000000000000000000000000000000000000000"
-        "a00706052b8104000aa1440342000479be667ef9dcbbac55a06295ce870b07029bfcdb"
-        "2dce28d959f2815b16f8179842a2f1423fc2440aeddc92f8cd3dfff65d61b2334fa1dafc519e6b9f3"
+        "30740201010"
+        "4200000000000000000000000000000000000000000000000000000000000000001"
+        "a00706052b8104000aa1440342000479be667ef9dcbbac55a06295ce870b07029bfc"
+        "db2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
     )
     
     # 1) Generate DER


### PR DESCRIPTION
**Description**:
Fix the invalid DER (hex) representation of an ECDSA secp256k1 private key by using the python program below to create new dre _hex representation and replace it with the existing one.
```python
from cryptography.hazmat.primitives.asymmetric import ec
from cryptography.hazmat.primitives import serialization

k = ec.derive_private_key(1, ec.SECP256K1())
der = k.private_bytes(
    encoding=serialization.Encoding.DER,
    format=serialization.PrivateFormat.TraditionalOpenSSL,
    encryption_algorithm=serialization.NoEncryption()
)
print(der.hex())
```

**Related issue(s)**:
Fixes #331

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
