### PR TITLE
feat: Checksum support for TokenId.from_string()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 ### Fixed
 - Incompatible Types assignment in token_transfer_list.py
 
+### Added
+- Added checksum validation for TokenId
+
 ## [0.1.5] - 2025-09-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,10 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - add revenue generating topic tests/example
 - add fee_schedule_key, fee_exempt_keys, custom_fees fields in TopicCreateTransaction, TopicUpdateTransaction, TopicInfo classes
 - add CustomFeeLimit class
+- Added checksum validation for TokenId
 
 ### Fixed
 - Incompatible Types assignment in token_transfer_list.py
-
-### Added
-- Added checksum validation for TokenId
 
 ## [0.1.5] - 2025-09-25
 

--- a/src/hiero_sdk_python/client/network.py
+++ b/src/hiero_sdk_python/client/network.py
@@ -74,7 +74,7 @@ class Network:
         nodes: Optional[List[_Node]] = None,
         mirror_address: Optional[str] = None,
         ledger_id: bytes | None = None
-    ) -> None
+    ) -> None:
         """
         Initializes the Network with the specified network name or custom config.
 

--- a/src/hiero_sdk_python/client/network.py
+++ b/src/hiero_sdk_python/client/network.py
@@ -61,12 +61,20 @@ class Network:
         ],
     }
 
+    LEDGER_ID: Dict[str, bytes] = {
+        'mainnet': bytes.fromhex('00'),
+        'testnet': bytes.fromhex('01'),
+        'previewnet': bytes.fromhex('02'),
+        'solo': bytes.fromhex('03')
+    }
+
     def __init__(
         self,
         network: str = 'testnet',
         nodes: Optional[List[_Node]] = None,
         mirror_address: Optional[str] = None,
-    ) -> None:
+        ledger_id: bytes | None = None
+    ) -> None
         """
         Initializes the Network with the specified network name or custom config.
 
@@ -83,6 +91,8 @@ class Network:
         self.mirror_address: str = mirror_address or self.MIRROR_ADDRESS_DEFAULT.get(
             network, 'localhost:5600'
         )
+
+        self.ledger_id = ledger_id or self.LEDGER_ID.get(network, bytes.fromhex('03'))
 
         if nodes is not None:
             final_nodes = nodes

--- a/src/hiero_sdk_python/tokens/nft_id.py
+++ b/src/hiero_sdk_python/tokens/nft_id.py
@@ -120,10 +120,11 @@ class NftId(_DeprecatedAliasesMixin):
             token_id=TokenId.from_string(token_part),
             serial_number=int(serial_part),
         )
-    
+ 
     def to_string_with_checksum(self, client:Client) -> str:
         """
-        Returns the string representation of the NftId with checksum in the format 'shard.realm.num-checksum/serial'
+        Returns the string representation of the NftId with 
+        checksum in the format 'shard.realm.num-checksum/serial'
         """
         return f"{self.token_id.to_string_with_checksum(client)}/{self.serial_number}"
 

--- a/src/hiero_sdk_python/tokens/nft_id.py
+++ b/src/hiero_sdk_python/tokens/nft_id.py
@@ -11,6 +11,7 @@ import re
 import warnings
 from dataclasses import dataclass, field
 from typing import Optional
+from hiero_sdk_python.client.client import Client
 from hiero_sdk_python.hapi.services import basic_types_pb2
 from hiero_sdk_python.tokens.token_id import TokenId
 from hiero_sdk_python._deprecated import _DeprecatedAliasesMixin
@@ -119,6 +120,12 @@ class NftId(_DeprecatedAliasesMixin):
             token_id=TokenId.from_string(token_part),
             serial_number=int(serial_part),
         )
+    
+    def to_string_with_checksum(self, client:Client) -> str:
+        """
+        Returns the string representation of the NftId with checksum in the format 'shard.realm.num-checksum/serial'
+        """
+        return f"{self.token_id.to_string_with_checksum(client)}/{self.serial_number}"
 
     def __str__(self) -> str:
         """

--- a/src/hiero_sdk_python/tokens/token_id.py
+++ b/src/hiero_sdk_python/tokens/token_id.py
@@ -94,7 +94,7 @@ class TokenId:
         """
         Returns the string representation of the TokenId in the format 'shard.realm.num'.
         """
-        return format_to_string(self.shard, self.realm, self.realm)
+        return format_to_string(self.shard, self.realm, self.num)
 
     def __hash__(self) -> int:
         """ Returns a hash of the TokenId instance. """

--- a/src/hiero_sdk_python/tokens/token_id.py
+++ b/src/hiero_sdk_python/tokens/token_id.py
@@ -5,7 +5,7 @@ hiero_sdk_python.tokens.token_id.py
 Defines TokenId, a frozen dataclass for representing Hedera token identifiers
 (shard, realm, num) with validation and protobuf conversion utilities.
 """
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Optional
 
 from hiero_sdk_python.hapi.services import basic_types_pb2
@@ -23,7 +23,7 @@ class TokenId:
     shard: int
     realm: int
     num: int
-    checksum: str|None = None
+    checksum: str | None = field(default=None, init=False)
 
     def __post_init__(self) -> None:
         if self.shard < 0:
@@ -67,13 +67,18 @@ class TokenId:
         elif not isinstance(token_id_str, str):
             raise TypeError('TokenId must be a string')
         
-        return parse_from_string(cls, token_id_str)
+        shard, realm, num, checksum = parse_from_string(token_id_str)
+
+        token_id = cls(int(shard), int(realm), int(num))
+        object.__setattr__(token_id, 'checksum', checksum)
+
+        return token_id
     
     def validate_checksum(self, client: Client):
         """Validate the checksum for the TokenId instance"""
         validate_checksum(
             shard=self.shard, 
-            realm=self.realm,
+            realm=self.realm, 
             num=self.num, 
             checksum=self.checksum, 
             client=client

--- a/src/hiero_sdk_python/tokens/token_id.py
+++ b/src/hiero_sdk_python/tokens/token_id.py
@@ -62,11 +62,6 @@ class TokenId:
         """
         Parses a string in the format 'shard.realm.num' to create a TokenId instance.
         """
-        if token_id_str == "":
-            raise ValueError('TokenId cannot be empty')
-        elif not isinstance(token_id_str, str):
-            raise TypeError('TokenId must be a string')
-
         shard, realm, num, checksum = parse_from_string(token_id_str)
 
         token_id = cls(int(shard), int(realm), int(num))
@@ -74,7 +69,7 @@ class TokenId:
 
         return token_id
 
-    def validate_checksum(self, client: Client):
+    def validate_checksum(self, client: Client) -> None:
         """Validate the checksum for the TokenId instance"""
         validate_checksum(
             shard=self.shard,
@@ -84,7 +79,7 @@ class TokenId:
             client=client
         )
 
-    def to_string_with_checksum(self, client:Client):
+    def to_string_with_checksum(self, client:Client) -> str:
         """
         Returns the string representation of the TokenId with checksum 
         in the format 'shard.realm.num-checksum'

--- a/src/hiero_sdk_python/tokens/token_id.py
+++ b/src/hiero_sdk_python/tokens/token_id.py
@@ -66,32 +66,33 @@ class TokenId:
             raise ValueError('TokenId cannot be empty')
         elif not isinstance(token_id_str, str):
             raise TypeError('TokenId must be a string')
-        
+
         shard, realm, num, checksum = parse_from_string(token_id_str)
 
         token_id = cls(int(shard), int(realm), int(num))
         object.__setattr__(token_id, 'checksum', checksum)
 
         return token_id
-    
+
     def validate_checksum(self, client: Client):
         """Validate the checksum for the TokenId instance"""
         validate_checksum(
-            shard=self.shard, 
-            realm=self.realm, 
-            num=self.num, 
-            checksum=self.checksum, 
+            shard=self.shard,
+            realm=self.realm,
+            num=self.num,
+            checksum=self.checksum,
             client=client
         )
 
     def to_string_with_checksum(self, client:Client):
         """
-        Returns the string representation of the TokenId with checksum in the format 'shard.realm.num-checksum'
+        Returns the string representation of the TokenId with checksum 
+        in the format 'shard.realm.num-checksum'
         """
         return format_to_string_with_checksum(
-            shard=self.shard, 
-            realm=self.realm, 
-            num=self.num, 
+            shard=self.shard,
+            realm=self.realm,
+            num=self.num,
             client=client
         )
 

--- a/src/hiero_sdk_python/tokens/token_id.py
+++ b/src/hiero_sdk_python/tokens/token_id.py
@@ -13,6 +13,7 @@ from hiero_sdk_python.client.client import Client
 from hiero_sdk_python.utils.entity_id_helper import (
     parse_from_string,
     validate_checksum,
+    format_to_string,
     format_to_string_with_checksum
 )
 
@@ -79,7 +80,9 @@ class TokenId:
         )
 
     def to_string_with_checksum(self, client:Client):
-        """Get string representation of TokenId with checksum"""
+        """
+        Returns the string representation of the TokenId with checksum in the format 'shard.realm.num-checksum'
+        """
         return format_to_string_with_checksum(
             shard=self.shard, 
             realm=self.realm, 
@@ -91,7 +94,7 @@ class TokenId:
         """
         Returns the string representation of the TokenId in the format 'shard.realm.num'.
         """
-        return f"{self.shard}.{self.realm}.{self.num}"
+        return format_to_string(self.shard, self.realm, self.realm)
 
     def __hash__(self) -> int:
         """ Returns a hash of the TokenId instance. """

--- a/src/hiero_sdk_python/tokens/token_id.py
+++ b/src/hiero_sdk_python/tokens/token_id.py
@@ -6,7 +6,7 @@ Defines TokenId, a frozen dataclass for representing Hedera token identifiers
 (shard, realm, num) with validation and protobuf conversion utilities.
 """
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import Optional
 
 from hiero_sdk_python.hapi.services import basic_types_pb2
 from hiero_sdk_python.client.client import Client

--- a/src/hiero_sdk_python/utils/entity_id_helper.py
+++ b/src/hiero_sdk_python/utils/entity_id_helper.py
@@ -8,7 +8,7 @@ MULTIPLIER = 1000003
 P3 = 26**3
 P5 = 26**5
 
-def parse_from_string(cls, address: str):
+def parse_from_string(address: str):
     """
     Parse an address string of the form: <shard>.<realm>.<num>[-<checksum>]
     Examples:
@@ -23,12 +23,8 @@ def parse_from_string(cls, address: str):
         raise ValueError("Invalid address format")
     
     shard, realm, num, checksum = match.groups()
-    return cls(
-        shard=int(shard), 
-        realm=int(realm), 
-        num=int(num), 
-        checksum=checksum or None
-    )
+    
+    return shard, realm, num, checksum
 
 def generate_checksum(ledger_id: bytes, address: str) -> str:
     """

--- a/src/hiero_sdk_python/utils/entity_id_helper.py
+++ b/src/hiero_sdk_python/utils/entity_id_helper.py
@@ -76,7 +76,7 @@ def generate_checksum(ledger_id: bytes, address: str) -> str:
 
     return "".join(reversed(letter))
 
-def validate_checksum(shard: int, realm: int, num: int, checksum: str, client: Client) -> None:
+def validate_checksum(shard: int, realm: int, num: int, checksum: str | None, client: Client) -> None:
     """
     Validate a Hiero entity ID checksum against the current client's ledger.
 
@@ -90,6 +90,10 @@ def validate_checksum(shard: int, realm: int, num: int, checksum: str, client: C
     Raises:
         ValueError: If the ledger ID is missing or if the checksum is invalid.
     """
+    # If no checksum present then return.
+    if (checksum is None):
+        return
+
     ledger_id = client.network.ledger_id
     if not ledger_id:
         raise ValueError("Missing ledger ID in client")

--- a/src/hiero_sdk_python/utils/entity_id_helper.py
+++ b/src/hiero_sdk_python/utils/entity_id_helper.py
@@ -21,9 +21,9 @@ def parse_from_string(address: str):
     match = ID_REGEX.match(address)
     if not match:
         raise ValueError("Invalid address format")
-    
+
     shard, realm, num, checksum = match.groups()
-    
+
     return shard, realm, num, checksum
 
 def generate_checksum(ledger_id: bytes, address: str) -> str:
@@ -64,7 +64,7 @@ def generate_checksum(ledger_id: bytes, address: str) -> str:
 
     for i in range(len(h)):
         sh = (sh * 31 + h[i]) % P5
-    
+
     cp = ((((len(address) % 5) * 11 + sd0) * 11 + sd1) * P3 + sd + sh) % P5
     cp = (cp * MULTIPLIER) % P5
 
@@ -75,7 +75,7 @@ def generate_checksum(ledger_id: bytes, address: str) -> str:
         cp //= 26
 
     return "".join(reversed(letter))
-        
+
 def validate_checksum(shard: int, realm: int, num: int, checksum: str, client: Client):
     """
     Validate a Hiero entity ID checksum against the current client's ledger.
@@ -93,10 +93,10 @@ def validate_checksum(shard: int, realm: int, num: int, checksum: str, client: C
     ledger_id = client.network.ledger_id
     if not ledger_id:
         raise ValueError("Missing ledger ID in client")
-    
+
     address = format_to_string(shard, realm, num)
     expected_checksum = generate_checksum(ledger_id, address)
-    
+
     if expected_checksum != checksum:
         raise ValueError(f"Checksum mismatch for {address}")
 
@@ -114,5 +114,5 @@ def format_to_string_with_checksum(shard: int, realm: int, num: int,client: Clie
     if not ledger_id:
         raise ValueError("Missing ledger ID in client")
 
-    base_str = format_to_string(shard, realm, num) 
-    return (f"{base_str}-{generate_checksum(ledger_id, format_to_string(shard, realm, num))}")
+    base_str = format_to_string(shard, realm, num)
+    return f"{base_str}-{generate_checksum(ledger_id, format_to_string(shard, realm, num))}"

--- a/src/hiero_sdk_python/utils/entity_id_helper.py
+++ b/src/hiero_sdk_python/utils/entity_id_helper.py
@@ -76,7 +76,7 @@ def generate_checksum(ledger_id: bytes, address: str) -> str:
 
     return "".join(reversed(letter))
 
-def validate_checksum(shard: int, realm: int, num: int, checksum: str, client: Client):
+def validate_checksum(shard: int, realm: int, num: int, checksum: str, client: Client) -> None:
     """
     Validate a Hiero entity ID checksum against the current client's ledger.
 

--- a/src/hiero_sdk_python/utils/entity_id_helper.py
+++ b/src/hiero_sdk_python/utils/entity_id_helper.py
@@ -1,0 +1,122 @@
+import re
+
+from hiero_sdk_python.client.client import Client
+
+ID_REGEX = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([a-z]{5}))?$")
+
+MULTIPLIER = 1000003
+P3 = 26**3
+P5 = 26**5
+
+def parse_from_string(cls, address: str):
+    """
+    Parse an address string of the form: <shard>.<realm>.<num>[-<checksum>]
+    Examples:
+        "0.0.123"
+        "0.0.123-abcde"
+
+    Returns:
+        An instance of cls with shard, realm, num, and optional checksum.
+    """
+    match = ID_REGEX.match(address)
+    if not match:
+        raise ValueError("Invalid address format")
+    
+    shard, realm, num, checksum = match.groups()
+    return cls(
+        shard=int(shard), 
+        realm=int(realm), 
+        num=int(num), 
+        checksum=checksum or None
+    )
+
+def generate_checksum(ledger_id: bytes, address: str) -> str:
+    """
+    Compute the 5-character checksum for a Hiero entity ID string (HIP-15).
+    
+    Args:
+        ledger_id: The ledger identifier as raw bytes (e.g., b"\x00" for mainnet).
+        address: A string of the form "shard.realm.num" (e.g., "0.0.123").
+    
+    Returns:
+        A 5-letter checksum string (e.g., "kfmza").
+    """
+    # Convert "0.0.123" into a digit list with '.' as 10
+    d = []
+    for ch in address:
+        if ch == '.':
+            d.append(10)
+        else:
+            d.append(int(ch))
+
+    # Initialize running sums
+    sd0 = 0  # sum of digits at even indices mod 11
+    sd1 = 0  # sum of digits at odd indices mod 11
+    sd = 0   # weight sum of all position mod P3
+
+    for i in range(len(d)):
+        sd = (sd * 31 + d[i]) % P3
+        if i % 2 == 0:
+            sd0 = (sd0 + d[i]) % 11
+        else:
+            sd1 = (sd1 + d[i]) % 11
+
+    # Compute hash of ledger ID bytes (padded with six zeros)
+    sh = 0
+    h = list(ledger_id or b"")
+    h += [0] * 6
+
+    for i in range(len(h)):
+        sh = (sh * 31 + h[i]) % P5
+    
+    cp = ((((len(address) % 5) * 11 + sd0) * 11 + sd1) * P3 + sd + sh) % P5
+    cp = (cp * MULTIPLIER) % P5
+
+    letter = []
+
+    for _ in range(5):
+        letter.append(chr(ord('a') + (cp % 26)))
+        cp //= 26
+
+    return "".join(reversed(letter))
+        
+def validate_checksum(shard: int, realm: int, num: int, checksum: str, client: Client):
+    """
+    Validate a Hiero entity ID checksum against the current client's ledger.
+
+    Args:
+        shard: Shard number of the entity ID.
+        realm: Realm number of the entity ID.
+        num: Entity number (account, token, topic, etc.).
+        checksum: The 5-letter checksum string to validate.
+        client: The Hiero client, which holds the target ledger_id.
+
+    Raises:
+        ValueError: If the ledger ID is missing or if the checksum is invalid.
+    """
+    ledger_id = client.network.ledger_id
+    if not ledger_id:
+        raise ValueError("Missing ledger ID in client")
+    
+    address = format_to_string(shard, realm, num)
+    expected_checksum = generate_checksum(ledger_id, address)
+    
+    if expected_checksum != checksum:
+        raise ValueError(f"Checksum mismatch for {address}")
+
+def format_to_string(shard: int, realm: int, num: int) -> str:
+    """
+    Convert an entity ID into its standard string representation.
+    """
+    return f"{shard}.{realm}.{num}"
+
+def format_to_string_with_checksum(shard: int, realm: int, num: int,client: Client) -> str:
+    """
+    Convert an entity ID into its string representation with checksum.
+    """
+    ledger_id = client.network.ledger_id
+    if not ledger_id:
+        raise ValueError("Missing ledger ID in client")
+
+    base_str = format_to_string(shard, realm, num) 
+    return (f"{base_str}-{generate_checksum(ledger_id, format_to_string(shard, realm, num))}")

--- a/tests/unit/nft_id_test.py
+++ b/tests/unit/nft_id_test.py
@@ -11,7 +11,7 @@ def test_nft_id():
     nftid_constructor_test = NftId(token_id=nftid_constructor_tokenid, serial_number=1234)
 
     assert str(nftid_constructor_test) == "0.1.2/1234"
-    assert repr(nftid_constructor_test) == "NftId(token_id=TokenId(shard=0, realm=1, num=2), serial_number=1234)"
+    assert repr(nftid_constructor_test) == "NftId(token_id=TokenId(shard=0, realm=1, num=2, checksum=None), serial_number=1234)"
     assert nftid_constructor_test._to_proto().__eq__(
         basic_types_pb2.NftID(
             token_ID=basic_types_pb2.TokenID(shardNum=0, realmNum=1, tokenNum=2),

--- a/tests/unit/nft_id_test.py
+++ b/tests/unit/nft_id_test.py
@@ -66,7 +66,7 @@ def test_nft_id():
     with pytest.raises(ValueError):
         NftId.from_string(fail_str)
 
-def test_get_nft_id_with_cehecksum(mock_client):
+def test_get_nft_id_with_checksum(mock_client):
     """Should return string with checksum when ledger id is provided."""
     client = mock_client
     client.network.ledger_id = bytes.fromhex("00")

--- a/tests/unit/nft_id_test.py
+++ b/tests/unit/nft_id_test.py
@@ -65,3 +65,13 @@ def test_nft_id():
     fail_str = "a.3.3/19"
     with pytest.raises(ValueError):
         NftId.from_string(fail_str)
+
+def test_get_nft_id_with_cehecksum(mock_client):
+    """Should return string with checksum when ledger id is provided."""
+    client = mock_client
+    client.network.ledger_id = bytes.fromhex("00")
+
+    token_id = TokenId.from_string("0.0.1")
+    nft_id = NftId(token_id, 1)
+
+    assert nft_id.to_string_with_checksum(client) == "0.0.1-dfkxr/1"

--- a/tests/unit/test_entity_id_helper.py
+++ b/tests/unit/test_entity_id_helper.py
@@ -55,9 +55,16 @@ def test_parse_from_string_for_invalid_addresses():
 def test_generate_checksum():
     """Checksum generation"""
     ledger_id = bytes.fromhex("00") # mainnet ledger_id
-    
     assert generate_checksum(ledger_id, '0.0.1') == 'dfkxr'
-    assert generate_checksum(ledger_id, '0.0.4') == 'cjcuq'
+
+    ledger_id = bytes.fromhex("01") # testnet ledger_id
+    assert generate_checksum(ledger_id, '0.0.1') == 'mswfa'
+
+    ledger_id = bytes.fromhex("02") # previewnet ledger_id
+    assert generate_checksum(ledger_id, '0.0.1') == 'wghmj'
+
+    ledger_id = bytes.fromhex("03") # solo/local ledger_id
+    assert generate_checksum(ledger_id, '0.0.1') == 'ftsts'
 
 def test_validate_checksum():
     """Valid checksum should pass without error"""

--- a/tests/unit/test_entity_id_helper.py
+++ b/tests/unit/test_entity_id_helper.py
@@ -1,8 +1,5 @@
-from hiero_sdk_python.client.client import Client
-from hiero_sdk_python.client.network import Network
 import pytest
 
-from hiero_sdk_python.tokens.token_id import TokenId
 from hiero_sdk_python.utils.entity_id_helper import (
     parse_from_string,
     generate_checksum,
@@ -17,40 +14,41 @@ def test_parse_parse_entity_id_from_string():
     """Entity ID can be parsed from string with or without checksum"""
     # Without checksum
     address = "0.0.123"
-    token_id = parse_from_string(TokenId, address)
+    shard, realm, num, checksum = parse_from_string(address)
 
-    assert token_id.shard == 0
-    assert token_id.realm == 0
-    assert token_id.num == 123
-    assert token_id.checksum is None
+    assert shard == '0'
+    assert realm == '0'
+    assert num == '123'
+    assert checksum is None
 
     # With checksum
     address = "0.0.123-vfmkw"
-    token_id = parse_from_string(TokenId, address)
+    shard, realm, num, checksum= parse_from_string(address)
     
-    assert token_id.shard == 0
-    assert token_id.realm == 0
-    assert token_id.num == 123
-    assert token_id.checksum == "vfmkw"
+    assert shard == '0'
+    assert realm == '0'
+    assert num == '123'
+    assert checksum == "vfmkw"
 
-def test_parse_from_string_for_invalid_addresses():
-    """Invalid entity ID strings should raise ValueError"""
-    invalid_addresses = [
+@pytest.mark.parametrize(
+    'invalid_address',
+    [
         "0.00.123",
         "0.0.123-VFMKW",
         "0.0.123#vfmkw",
-        "0.0.123-vFmKw"
-        "0.0.123vfmkw"
-        "0.0.123 - vfmkw"
-        "0.123"
-        "0.0.123."
-        "0.0.123-vf"
+        "0.0.123-vFmKw",
+        "0.0.123vfmkw",
+        "0.0.123 - vfmkw",
+        "0.123",
+        "0.0.123.",
+        "0.0.123-vf",
         "0.0.123-vfm-kw"
-    ]
-
-    for address in invalid_addresses:
-        with pytest.raises(ValueError, match="Invalid address format"):
-            parse_from_string(TokenId, address)
+    ],
+)
+def test_parse_from_string_for_invalid_addresses(invalid_address):
+    """Invalid entity ID strings should raise ValueError"""
+    with pytest.raises(ValueError, match="Invalid address format"):
+        parse_from_string(invalid_address)
 
 def test_generate_checksum():
     """Checksum generation"""
@@ -66,16 +64,18 @@ def test_generate_checksum():
     ledger_id = bytes.fromhex("03") # solo/local ledger_id
     assert generate_checksum(ledger_id, '0.0.1') == 'ftsts'
 
-def test_validate_checksum():
+def test_validate_checksum(mock_client):
     """Valid checksum should pass without error"""
-    client = Client(network=Network("mainnet"))
+    client = mock_client
+    client.network.ledger_id = bytes.fromhex("00")
 
     validate_checksum(0, 0, 1, 'dfkxr', client)
 
-def test_validate_checksum_for_invalid():
+def test_validate_checksum_for_invalid(mock_client):
     """Invalid checksum or missing ledger_id should raise ValueError"""
     # Mismatched checksum
-    client = Client(network=Network("mainnet"))
+    client = mock_client
+    client.network.ledger_id = bytes.fromhex("00")
 
     with pytest.raises(ValueError, match="Checksum mismatch for 0.0.4"):
         validate_checksum(0, 0, 4, "dfkxr", client)
@@ -90,27 +90,30 @@ def test_format_to_string():
     """Entity ID should format correctly without checksum"""
     assert format_to_string(0, 0, 4) == '0.0.4'
 
-def test_format_to_string_with_checksum():
+def test_format_to_string_with_checksum(mock_client):
     """Entity ID should format correctly with checksum"""
-    client = Client(network=Network("mainnet"))
+    client = mock_client
+    client.network.ledger_id = bytes.fromhex("00")
+
     checksum = 'dfkxr'
 
     assert format_to_string_with_checksum(0, 0, 1, client) == f'0.0.1-{checksum}'
 
-def test_parse_and_format_with_checksum():
+def test_parse_and_format_with_checksum(mock_client):
     """Parsing then formatting should preserve entity ID + checksum"""
-    client = Client(network=Network("mainnet"))
+    client = mock_client
+    client.network.ledger_id = bytes.fromhex("00")
 
     original = '0.0.1-dfkxr'
-    parsed = parse_from_string(TokenId, original)
-    formatted = format_to_string_with_checksum(parsed.shard, parsed.realm, parsed.num, client)
+    shard, realm, num, _ = parse_from_string(original)
+    formatted = format_to_string_with_checksum(shard, realm, num, client)
 
     assert formatted == original
 
 def test_parse_and_format_without_checksum():
     """Parsing then formatting should preserve entity ID without checksum"""
     original = '0.0.123'
-    parsed = parse_from_string(TokenId, original)
-    formatted = format_to_string(parsed.shard, parsed.realm, parsed.num)
+    shard, realm, num, _ = parse_from_string(original)
+    formatted = format_to_string(shard, realm, num)
 
     assert formatted == original

--- a/tests/unit/test_entity_id_helper.py
+++ b/tests/unit/test_entity_id_helper.py
@@ -24,7 +24,7 @@ def test_parse_parse_entity_id_from_string():
     # With checksum
     address = "0.0.123-vfmkw"
     shard, realm, num, checksum= parse_from_string(address)
-    
+ 
     assert shard == '0'
     assert realm == '0'
     assert num == '123'

--- a/tests/unit/test_entity_id_helper.py
+++ b/tests/unit/test_entity_id_helper.py
@@ -1,0 +1,109 @@
+from hiero_sdk_python.client.client import Client
+from hiero_sdk_python.client.network import Network
+import pytest
+
+from hiero_sdk_python.tokens.token_id import TokenId
+from hiero_sdk_python.utils.entity_id_helper import (
+    parse_from_string,
+    generate_checksum,
+    validate_checksum,
+    format_to_string,
+    format_to_string_with_checksum
+)
+
+pytestmark = pytest.mark.unit
+
+def test_parse_parse_entity_id_from_string():
+    """Entity ID can be parsed from string with or without checksum"""
+    # Without checksum
+    address = "0.0.123"
+    token_id = parse_from_string(TokenId, address)
+
+    assert token_id.shard == 0
+    assert token_id.realm == 0
+    assert token_id.num == 123
+    assert token_id.checksum is None
+
+    # With checksum
+    address = "0.0.123-vfmkw"
+    token_id = parse_from_string(TokenId, address)
+    
+    assert token_id.shard == 0
+    assert token_id.realm == 0
+    assert token_id.num == 123
+    assert token_id.checksum == "vfmkw"
+
+def test_parse_from_string_for_invalid_addresses():
+    """Invalid entity ID strings should raise ValueError"""
+    invalid_addresses = [
+        "0.00.123",
+        "0.0.123-VFMKW",
+        "0.0.123#vfmkw",
+        "0.0.123-vFmKw"
+        "0.0.123vfmkw"
+        "0.0.123 - vfmkw"
+        "0.123"
+        "0.0.123."
+        "0.0.123-vf"
+        "0.0.123-vfm-kw"
+    ]
+
+    for address in invalid_addresses:
+        with pytest.raises(ValueError, match="Invalid address format"):
+            parse_from_string(TokenId, address)
+
+def test_generate_checksum():
+    """Checksum generation"""
+    ledger_id = bytes.fromhex("00") # mainnet ledger_id
+    
+    assert generate_checksum(ledger_id, '0.0.1') == 'dfkxr'
+    assert generate_checksum(ledger_id, '0.0.4') == 'cjcuq'
+
+def test_validate_checksum():
+    """Valid checksum should pass without error"""
+    client = Client(network=Network("mainnet"))
+
+    validate_checksum(0, 0, 1, 'dfkxr', client)
+
+def test_validate_checksum_for_invalid():
+    """Invalid checksum or missing ledger_id should raise ValueError"""
+    # Mismatched checksum
+    client = Client(network=Network("mainnet"))
+
+    with pytest.raises(ValueError, match="Checksum mismatch for 0.0.4"):
+        validate_checksum(0, 0, 4, "dfkxr", client)
+
+    # Missing ledger_id
+    client.network.ledger_id = None
+
+    with pytest.raises(ValueError, match="Missing ledger ID in client"):
+        validate_checksum(0, 0, 1, "dfkxr", client)
+
+def test_format_to_string():
+    """Entity ID should format correctly without checksum"""
+    assert format_to_string(0, 0, 4) == '0.0.4'
+
+def test_format_to_string_with_checksum():
+    """Entity ID should format correctly with checksum"""
+    client = Client(network=Network("mainnet"))
+    checksum = 'dfkxr'
+
+    assert format_to_string_with_checksum(0, 0, 1, client) == f'0.0.1-{checksum}'
+
+def test_parse_and_format_with_checksum():
+    """Parsing then formatting should preserve entity ID + checksum"""
+    client = Client(network=Network("mainnet"))
+
+    original = '0.0.1-dfkxr'
+    parsed = parse_from_string(TokenId, original)
+    formatted = format_to_string_with_checksum(parsed.shard, parsed.realm, parsed.num, client)
+
+    assert formatted == original
+
+def test_parse_and_format_without_checksum():
+    """Parsing then formatting should preserve entity ID without checksum"""
+    original = '0.0.123'
+    parsed = parse_from_string(TokenId, original)
+    formatted = format_to_string(parsed.shard, parsed.realm, parsed.num)
+
+    assert formatted == original

--- a/tests/unit/test_token_id.py
+++ b/tests/unit/test_token_id.py
@@ -1,0 +1,63 @@
+from hiero_sdk_python.tokens.token_id import TokenId
+import pytest
+
+pytestmark = pytest.mark.unit
+
+def test_create_token_id_from_string():
+    """Should correctly create TokenId from string input, with and without checksum."""
+    # Without checksum
+    token_id = TokenId.from_string('0.0.1')
+
+    assert token_id.shard == 0
+    assert token_id.realm == 0
+    assert token_id.num == 1
+    assert token_id.checksum is None
+
+    # With checksum
+    token_id = TokenId.from_string('0.0.1-dfkxr')
+
+    assert token_id.shard == 0
+    assert token_id.realm == 0
+    assert token_id.num == 1
+    assert token_id.checksum == 'dfkxr'
+
+@pytest.mark.parametrize(
+    'invalid_id', 
+    [
+        '', 
+        123, 
+        None, 
+        '0.0.-1', 
+        'abc.def.ghi', 
+        '0.0.1-ad'
+    ]
+)
+def test_create_token_id_from_string_invalid_cases(invalid_id):
+    """Should raise error when creating TokenId from invalid string input."""
+    with pytest.raises((TypeError, ValueError)):
+        TokenId.from_string(invalid_id)
+
+def test_get_token_id_with_checksum(mock_client):
+    """Should return string with checksum when ledger id is provided."""
+    client = mock_client
+    client.network.ledger_id = bytes.fromhex("00")
+
+    token_id = TokenId.from_string("0.0.1")
+    assert token_id.to_string_with_checksum(client) == "0.0.1-dfkxr"
+
+def test_validate_checksum_success(mock_client):
+    """Should pass checksum validation when checksum is correct."""
+    client = mock_client
+    client.network.ledger_id = bytes.fromhex("00")
+    token_id = TokenId.from_string("0.0.1-dfkxr")
+
+    token_id.validate_checksum(client)
+
+def test_validate_checksum_failure(mock_client):
+    """Should raise ValueError if checksum validation fails."""
+    client = mock_client
+    client.network.ledger_id = bytes.fromhex("00")
+    token_id = TokenId.from_string("0.0.1-wronx")
+
+    with pytest.raises(ValueError):
+        token_id.validate_checksum(client)

--- a/tests/unit/test_token_id.py
+++ b/tests/unit/test_token_id.py
@@ -1,5 +1,6 @@
-from hiero_sdk_python.tokens.token_id import TokenId
 import pytest
+
+from hiero_sdk_python.tokens.token_id import TokenId
 
 pytestmark = pytest.mark.unit
 
@@ -24,11 +25,11 @@ def test_create_token_id_from_string():
 @pytest.mark.parametrize(
     'invalid_id', 
     [
-        '', 
-        123, 
-        None, 
-        '0.0.-1', 
-        'abc.def.ghi', 
+        '',
+        123,
+        None,
+        '0.0.-1',
+        'abc.def.ghi',
         '0.0.1-ad'
     ]
 )


### PR DESCRIPTION
**Description**:
This PR adds **checksum support** for Hiero entity ID.

**Changes introduces:**
- Added `entity_id_helper.py` which Implements checksum generation and validation logic
- Added unit tests for `entity_id_helper.py`
- Extended **TokenId**:
   - Added `checksum` field
   - Added `validate_checksum()` method
   - Added `to_string_with_checksum` method for string representation with checksum
- Updated `nft_id.py`  to include checksum support
- Updated/added unit tests for `TokenId` and `NftId`

**Related issue(s)**:
Closes #46 

**Notes for reviewer**:
- The checksum use in the tests are taken from the  implementation of  the [HIP-15](https://hips.hedera.com/hip/hip-15) specification.
- While this PR implements checksum support for `TokenId`, the same logic applies to other entity ID like (AccountId, FileId, and TopicId), which can also include checksums.

**Checklist**
- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
