### PR TITLE
Make network configurable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,12 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -19,14 +25,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
       - name: Install uv
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
       - name: Install setuptools wheel
         run: pip install --upgrade pip setuptools wheel
-
-      - name: Setup Python
-        run: uv python install
 
       - name: Install dependencies
         run: uv sync --all-extras --dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Update grpcio dependency from 1.68.1 to 1.71.2
 - Updated `rebasing.md` with clarification on using `git reset --soft HEAD~<n>` where `<n>` specifies the number of commits to rewind.
 - Calls in examples for PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY')) to PrivateKey.from_string(os.getenv('OPERATOR_KEY')) to enable general key types
-- Add CI tests across Python 3.9–3.12
+- Add CI tests across Python 3.10–3.12.
 
 ### Fixed
 - Unit test compatibility issues when running with UV package manager

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Updated `rebasing.md` with clarification on using `git reset --soft HEAD~<n>` where `<n>` specifies the number of commits to rewind.
 - Calls in examples for PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY')) to PrivateKey.from_string(os.getenv('OPERATOR_KEY')) to enable general key types
 - Add CI tests across Python 3.10–3.12.
+- Network configuration now uses the NETWORK environment variable instead of a hardcoded "testnet" (defaults to "testnet" if not set).
+
 
 ### Fixed
 - Unit test compatibility issues when running with UV package manager

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Update grpcio dependency from 1.68.1 to 1.71.2
 - Updated `rebasing.md` with clarification on using `git reset --soft HEAD~<n>` where `<n>` specifies the number of commits to rewind.
 - Calls in examples for PrivateKey.from_string_ed25519(os.getenv('OPERATOR_KEY')) to PrivateKey.from_string(os.getenv('OPERATOR_KEY')) to enable general key types
+- Add CI tests across Python 3.9–3.12
 
 ### Fixed
 - Unit test compatibility issues when running with UV package manager

--- a/src/hiero_sdk_python/client/network.py
+++ b/src/hiero_sdk_python/client/network.py
@@ -1,5 +1,6 @@
 """Network module for managing Hedera SDK connections."""
 import secrets
+import os
 from typing import Dict, List, Optional, Any
 
 import requests
@@ -79,7 +80,8 @@ class Network:
                             If not provided,
                             we'll use a default from MIRROR_ADDRESS_DEFAULT[network].
         """
-        self.network: str = network or 'testnet'
+        env_network = os.getenv("NETWORK", "testnet")
+        self.network: str = (network or env_network).lower()
         self.mirror_address: str = mirror_address or self.MIRROR_ADDRESS_DEFAULT.get(
             network, 'localhost:5600'
         )


### PR DESCRIPTION
**Description**:
Make Hedera network selection configurable via the NETWORK environment variable instead of hardcoding "testnet".
This improves flexibility for developers running on mainnet, previewnet, or solo.
- Replace hardcoded "testnet" default with os.getenv("NETWORK", "testnet")
- Update Network class to prioritize: explicit constructor arg → NETWORK env var → "testnet" fallback
- 
**Related issue(s)**:
Fixes #253 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
