### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/hiero-ledger/hiero-sdk-python/security/code-scanning/4](https://github.com/hiero-ledger/hiero-sdk-python/security/code-scanning/4)

To fix this problem, an explicit `permissions` block should be added to the `.github/workflows/test.yml` workflow. The best location is at the root level of the workflow, before the `jobs:` block, so that it applies to all jobs unless overridden. Since the workflow does not use any actions or steps that require write access to repository `contents`, we should restrict the GITHUB_TOKEN's ability to read only, using `permissions: contents: read`. To implement, add:

```yaml
permissions:
  contents: read
```

between the existing `on:` and `jobs:` blocks in `.github/workflows/test.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
