### PR TITLE
docs: add comprehensive docstrings to examples/account_create.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- Comprehensive Google-style docstrings to examples/account_create.py (#417)
 - add revenue generating topic tests/example
 - add fee_schedule_key, fee_exempt_keys, custom_fees fields in TopicCreateTransaction, TopicUpdateTransaction, TopicInfo classes
 - add CustomFeeLimit class

--- a/examples/account_create.py
+++ b/examples/account_create.py
@@ -1,7 +1,22 @@
 """
-Run:
-uv run examples/account_create.py
-python examples/account_create.py
+Account Creation Example.
+
+This example demonstrates how to create a new account on the Hiero network.
+It shows the complete process of setting up a client, generating new keys,
+creating an account transaction, and handling the response.
+
+The example creates an account with:
+- A newly generated ED25519 key pair
+- An initial balance of 1 HBAR (100,000,000 tinybars)
+- A custom account memo
+
+Usage:
+    uv run examples/account_create.py
+    python examples/account_create.py
+
+Environment Variables Required:
+    OPERATOR_ID: The account ID of the operator (e.g., "0.0.123")
+    OPERATOR_KEY: The private key of the operator account
 """
 import os
 import sys
@@ -19,6 +34,30 @@ from hiero_sdk_python import (
 load_dotenv()
 
 def setup_client():
+    """
+    Set up and configure a Hiero client for testnet operations.
+
+    This function initializes a client connection to the Hiero testnet,
+    configures the operator account using environment variables, and
+    returns the configured client along with the operator's private key.
+
+    The operator account is used to pay for transaction fees and sign
+    transactions that require authorization.
+
+    Returns:
+        tuple[Client, PrivateKey]: A tuple containing:
+            - Client: Configured Hiero client connected to testnet
+            - PrivateKey: The operator account's private key for signing
+
+    Raises:
+        ValueError: If OPERATOR_ID or OPERATOR_KEY environment variables
+            are not set or are invalid.
+        Exception: If the client fails to connect to the network.
+
+    Environment Variables:
+        OPERATOR_ID (str): The account ID of the operator (e.g., "0.0.123")
+        OPERATOR_KEY (str): The private key of the operator account
+    """
     network = Network(network='testnet')
     client = Client(network)
 
@@ -29,6 +68,39 @@ def setup_client():
     return client, operator_key
 
 def create_new_account(client, operator_key):
+    """
+    Create a new account on the Hiero network.
+
+    This function generates a new ED25519 key pair, creates an account
+    creation transaction with an initial balance and memo, signs it with
+    the operator key, and executes it on the network.
+
+    The new account will be created with:
+    - A newly generated ED25519 key pair
+    - An initial balance of 1 HBAR (100,000,000 tinybars)
+    - A custom memo: "My new account"
+
+    Args:
+        client (Client): The configured Hiero client to execute the transaction.
+        operator_key (PrivateKey): The operator's private key used to sign
+            and authorize the account creation transaction.
+
+    Returns:
+        None: This function prints the results and exits on failure.
+
+    Raises:
+        Exception: If the transaction fails or returns a non-SUCCESS status.
+        Exception: If the account ID is not found in the transaction receipt.
+        SystemExit: Calls sys.exit(1) if account creation fails.
+
+    Example:
+        >>> client, operator_key = setup_client()
+        >>> create_new_account(client, operator_key)
+        Transaction status: ResponseCode.SUCCESS
+        Account creation successful. New Account ID: 0.0.12345
+        New Account Private Key: 302e...
+        New Account Public Key: 302a...
+    """
     new_account_private_key = PrivateKey.generate("ed25519")
     new_account_public_key = new_account_private_key.public_key()
 


### PR DESCRIPTION
## Description
Fixes #417 

Added comprehensive Google-style docstrings to [examples/account_create.py](cci:7://file:///f:/HackContri/hiero-sdk-python/examples/account_create.py:0:0-0:0) to help new developers understand the Hiero SDK.

## Changes Made
- ✅ Enhanced module docstring with detailed description, usage instructions, and environment variable requirements
- ✅ Added complete Google-style docstring to [setup_client()](cci:1://file:///f:/HackContri/hiero-sdk-python/examples/account_create.py:35:0-67:31) function with Returns, Raises, and Environment Variables sections
- ✅ Added complete Google-style docstring to [create_new_account()](cci:1://file:///f:/HackContri/hiero-sdk-python/examples/account_create.py:69:0-134:19) function with Args, Returns, Raises, and Example sections

## Acceptance Criteria Met
- ✅ [setup_client()](cci:1://file:///f:/HackContri/hiero-sdk-python/examples/account_create.py:35:0-67:31) has a complete, clear docstring
- ✅ [create_new_account()](cci:1://file:///f:/HackContri/hiero-sdk-python/examples/account_create.py:69:0-134:19) has a complete, clear docstring  
- ✅ Follows Google-style formatting (`"""Summary line.\n\nArgs:\n ...\nReturns:\n ..."""`)
- ✅ Describes parameters, return values, and exceptions accurately

## Testing
- Code follows the same docstring style as other SDK functions (referenced [account_id.py](cci:7://file:///f:/HackContri/hiero-sdk-python/src/hiero_sdk_python/account/account_id.py:0:0-0:0))
- All docstrings include proper sections: Summary, Args, Returns, Raises, Examples where applicable
- Documentation is clear and helpful for new developers

This is my first contribution to Hiero! 🎉