### PR TITLE
feat: add type hints to examples/account_create.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- Type hints to examples/account_create.py functions (#418)
 - Comprehensive Google-style docstrings to examples/account_create.py (#417)
 - add revenue generating topic tests/example
 - add fee_schedule_key, fee_exempt_keys, custom_fees fields in TopicCreateTransaction, TopicUpdateTransaction, TopicInfo classes

--- a/examples/account_create.py
+++ b/examples/account_create.py
@@ -33,7 +33,7 @@ from hiero_sdk_python import (
 
 load_dotenv()
 
-def setup_client():
+def setup_client() -> tuple[Client, PrivateKey]:
     """
     Set up and configure a Hiero client for testnet operations.
 
@@ -67,7 +67,7 @@ def setup_client():
 
     return client, operator_key
 
-def create_new_account(client, operator_key):
+def create_new_account(client: Client, operator_key: PrivateKey) -> None:
     """
     Create a new account on the Hiero network.
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -18,5 +18,5 @@ allow_untyped_defs = True
 # Don’t follow into imported modules—treat them as no type to check
 follow_imports = silent
 
-# Turn off strict None‐checking—allows assigning X | None to X without error
+# Turn off strict None-checking—allows assigning X | None to X without error
 strict_optional = False


### PR DESCRIPTION
## Description
Fixes #418 

Added explicit type annotations to both functions in [examples/account_create.py](cci:7://file:///f:/HackContri/hiero-sdk-python/examples/account_create.py:0:0-0:0) to improve code readability, IDE autocompletion, and catch type-related bugs early.

## Changes Made
- ✅ Added return type annotation to [setup_client()](cci:1://file:///f:/HackContri/hiero-sdk-python/examples/account_create.py:35:0-67:31) function: `-> tuple[Client, PrivateKey]`
- ✅ Added parameter and return type annotations to [create_new_account()](cci:1://file:///f:/HackContri/hiero-sdk-python/examples/account_create.py:69:0-134:19) function: `(client: Client, operator_key: PrivateKey) -> None`
- ✅ Fixed encoding issue in [mypy.ini](cci:7://file:///f:/HackContri/hiero-sdk-python/mypy.ini:0:0-0:0) file (replaced en-dash with regular dash)
- ✅ Updated [CHANGELOG.md](cci:7://file:///f:/HackContri/hiero-sdk-python/CHANGELOG.md:0:0-0:0) with entry for type hints addition

## Acceptance Criteria Met
- ✅ [setup_client()](cci:1://file:///f:/HackContri/hiero-sdk-python/examples/account_create.py:35:0-67:31) has proper return type annotation
- ✅ [create_new_account(client, operator_key)](cci:1://file:///f:/HackContri/hiero-sdk-python/examples/account_create.py:69:0-134:19) has annotated parameter and return types
- ✅ Code passes type checking (`mypy examples/account_create.py` - Success: no issues found)
- ✅ Code compiles successfully using syntax validation
- ✅ Functionality remains the same (only type annotations added)

## Testing
- Type checking passes with mypy: `Success: no issues found in 1 source file`
- Python syntax validation passes
- No additional imports required - used built-in `tuple` type
- All existing functionality preserved

