### PR TITLE
docs(signing): add table of contents and expand verified commits section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Docs
+
+- docs(signing): add table of contents and expand verified commits section
+
 ### Added
 
 - add revenue generating topic tests/example

--- a/docs/sdk_developers/signing.md
+++ b/docs/sdk_developers/signing.md
@@ -6,10 +6,53 @@ This guide walks you through how to correctly configure and sign your commits.
 
 ---
 
-## 🛡️ Why Commit Signing?
+## Table of Contents
 
-- **DCO (`Signed-off-by`)** ensures you agree to the developer certificate of origin.
-- **GPG Signature** proves the commit was authored by a trusted and verified identity.
+- [Achieving Verified Commits](#-achieving-verified-commits)
+- [Step-by-Step Setup](#%EF%B8%8F-step-by-step-setup)
+  - [1. Generate a GPG Key](#1-generate-a-gpg-key)
+  - [2. Add Your GPG Key to GitHub](#2-add-your-gpg-key-to-github)
+  - [3. Tell Git to Use Your GPG Key](#3-tell-git-to-use-your-gpg-key)
+  - [4. Make a Signed Commit](#4-make-a-signed-commit)
+  - [Fixing an Unsigned Commit](#fixing-an-unsigned-commit)
+- [Final Checklist](#-final-checklist)
+- [Additional Resources](#-additional-resources)
+
+---
+
+## ✨ Achieving Verified Commits
+
+### Why Is This Important?
+
+To have your pull request (PR) merged into the Hiero Python SDK, **all commits MUST be verified**. This means your commits need to display a "Verified" badge on GitHub, which requires:
+
+1. **DCO Sign-off (`-s` flag)** - Ensures you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
+2. **GPG Signature (`-S` flag)** - Proves the commit was authored by a verified and trusted identity
+3. **GPG Key Connected to Your GitHub Account** - Your GPG public key must be added to your GitHub account
+
+### ⚠️ CRITICAL: BOTH Flags Are Required
+
+**Your commits MUST use BOTH `-s` and `-S` flags together:**
+
+```bash
+git commit -S -s -m "your commit message"
+```
+
+- `-S` = GPG sign the commit
+- `-s` = Add DCO sign-off
+
+**Without both flags, your commits will NOT appear as verified, and your PR cannot be merged.**
+
+### What You'll Need
+
+- A GPG key pair (we'll help you generate one)
+- Your GPG key added to your GitHub account
+- Git configured to use your GPG key
+- Your email on GitHub must match your GPG key email
+
+### Next Steps
+
+Follow the [Step-by-Step Setup](#%EF%B8%8F-step-by-step-setup) section below to configure everything correctly.
 
 ---
 
@@ -83,14 +126,26 @@ git push --force-with-lease
 
 ## ✅ Final Checklist
 
-- [ ] Signed your commit with `-S`
-- [ ] Added DCO with `-s`
-- [ ] GPG key is added to GitHub
-- [ ] Verified badge appears in PR
+- [ ] Signed your commit with `-S` (GPG signature)
+- [ ] Added DCO with `-s` (Developer Certificate of Origin)
+- [ ] Both flags used together: `git commit -S -s -m "message"`
+- [ ] GPG key is added to your GitHub account
+- [ ] Git is configured with your GPG key ID
+- [ ] Your GitHub email matches your GPG key email
+- [ ] Verified badge appears in your PR commits
 
+## 📚 Additional Resources
+
+Before submitting your PR, make sure to review these important guides:
+
+- [CONTRIBUTING.md](https://github.com/hiero-ledger/hiero-sdk-python/blob/main/CONTRIBUTING.md) - Complete contribution workflow guide
+- [rebasing.md](https://github.com/hiero-ledger/hiero-sdk-python/blob/main/docs/sdk_developers/rebasing.md) - Guide to keeping your branch updated
+- [merge_conflicts.md](https://github.com/hiero-ledger/hiero-sdk-python/blob/main/docs/sdk_developers/merge_conflicts.md) - How to resolve merge conflicts
 
 ### Still Need Help?
 
 If you run into issues:
 
-- Refer to [GitHub’s GPG Docs](https://docs.github.com/en/authentication/managing-commit-signature-verification)
+- Refer to [GitHub's GPG Docs](https://docs.github.com/en/authentication/managing-commit-signature-verification)
+- Visit the [Hiero Python SDK Discord](https://discord.com/channels/905194001349627914/1336494517544681563) for community support
+- Check the [Issues](https://github.com/hiero-ledger/hiero-sdk-python/issues) page for similar questions


### PR DESCRIPTION
Description:
Improve the commit signing guide in [signing.md] for better usability and clarity, especially for first-time contributors.

Add table of contents to [signing.md]
Replace "Why Commit Signing?" section with expanded "Achieving Verified Commits" section
Emphasize requirement for both -s and -S flags in commits
Add "Additional Resources" section linking to other documentation
Related issue(s):

Fixes #455 

Notes for reviewer:
This update enhances the documentation to make it easier for new contributors to understand and achieve verified commits, reducing barriers to PR submission.

Checklist

 Documented (Code comments, README, etc.)
 Tested (unit, integration, etc.)