### PR TITLE
docs(fees): Add Google-style docstrings to CustomFractionalFee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,12 @@
-This is a markdown file, click Ctrl+Shift+V to view or click open preview.
-
 # Changelog
 
-All notable changes to this project will be documented in this file.  
-This project adheres to [Semantic Versioning](https://semver.org).  
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](https://semver.org).
 This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 ### Added
+- Added Google-style docstrings to `CustomFractionalFee` class and its methods in `custom_fractional_fee.py`.
 
 ### Changed
 
@@ -16,7 +15,6 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 ## [0.1.6] - 2025-10-21
 
 ### Added
-
 - Add comprehensive Google-style docstrings to examples/account_create.py
 - add revenue generating topic tests/example
 - add fee_schedule_key, fee_exempt_keys, custom_fees fields in TopicCreateTransaction, TopicUpdateTransaction, TopicInfo classes
@@ -52,10 +50,10 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Incompatible Types assignment in token_transfer_list.py
 - Corrected references to _require_not_frozen() and removed the surplus _is_frozen
 - Removed duplicate static methods in `TokenInfo` class:
-  - `_copy_msg_to_proto`
-  - `_copy_key_if_present`
-  - `_parse_custom_fees`
-  Kept robust versions with proper docstrings and error handling.
+  - `_copy_msg_to_proto`
+  - `_copy_key_if_present`
+  - `_parse_custom_fees`
+  Kept robust versions with proper docstrings and error handling.
 - Add strict type hints to `TransactionGetReceiptQuery` (#420)
 - Fixed broken documentation links in CONTRIBUTING.md by converting absolute GitHub URLs to relative paths
 - Updated all documentation references to use local paths instead of pointing to hiero-sdk project hub
@@ -280,9 +278,9 @@ contract_call_local_pb2.ContractLoginfo -> contract_types_pb2.ContractLoginfo
 - SimpleContract and StatefulContract constructors to be payable
 - added new_pending_airdrops to TransactionRecord Class
 - Reorganized SDK developer documentation:
-  - Renamed and moved `README_linting.md` to `linting.md`
-  - Renamed and moved `README_types.md` to `types.md`
-  - Renamed and moved `Commit_Signing.md` to `signing.md`
+  - Renamed and moved `README_linting.md` to `linting.md`
+  - Renamed and moved `README_types.md` to `types.md`
+  - Renamed and moved `Commit_Signing.md` to `signing.md`
 - Created `sdk_users` docs folder and renamed `examples/README.md` to `running_examples.md`
 - Updated references and links accordingly
 

--- a/src/hiero_sdk_python/tokens/custom_fractional_fee.py
+++ b/src/hiero_sdk_python/tokens/custom_fractional_fee.py
@@ -1,3 +1,11 @@
+"""Module for defining and configuring custom fractional fees for tokens.
+
+This module provides functionality for creating and managing fractional
+fees that charge a percentage (numerator/denominator) of a transaction
+amount. It allows developers to specify minimum and maximum fee amounts
+and the method used to assess the fee (inclusive or exclusive).
+"""
+
 from __future__ import annotations
 import typing
 from hiero_sdk_python.tokens.custom_fee import CustomFee
@@ -9,8 +17,11 @@ if typing.TYPE_CHECKING:
 
 
 class CustomFractionalFee(CustomFee):
-    """
-    Represents a custom fractional fee.
+    """Represents a custom fractional fee in the Hiero SDK.
+
+    A fractional fee charges a fraction of a transferred token amount.
+    The fee can be configured with minimum and maximum limits and
+    a specified fee assessment method (inclusive or exclusive).
     """
 
     def __init__(
@@ -23,6 +34,17 @@ class CustomFractionalFee(CustomFee):
         fee_collector_account_id: typing.Optional["AccountId"] = None,
         all_collectors_are_exempt: bool = False,
     ):
+        """Initialize a CustomFractionalFee instance.
+
+        Args:
+            numerator (int): Numerator for the fractional fee calculation.
+            denominator (int): Denominator for the fractional fee calculation.
+            min_amount (int): Minimum possible fee amount.
+            max_amount (int): Maximum possible fee amount.
+            assessment_method (FeeAssessmentMethod): Fee calculation method.
+            fee_collector_account_id (AccountId, optional): Account to receive the fee.
+            all_collectors_are_exempt (bool): Whether fee collectors are exempt.
+        """
         super().__init__(fee_collector_account_id, all_collectors_are_exempt)
         self.numerator = numerator
         self.denominator = denominator
@@ -31,26 +53,72 @@ class CustomFractionalFee(CustomFee):
         self.assessment_method = assessment_method
 
     def set_numerator(self, numerator: int) -> "CustomFractionalFee":
+        """Set the numerator for the fractional fee.
+
+        Args:
+            numerator (int): The numerator value for the fee fraction.
+
+        Returns:
+            CustomFractionalFee: The updated instance.
+        """
         self.numerator = numerator
         return self
 
     def set_denominator(self, denominator: int) -> "CustomFractionalFee":
+        """Set the denominator for the fractional fee.
+
+        Args:
+            denominator (int): The denominator value for the fee fraction.
+
+        Returns:
+            CustomFractionalFee: The updated instance.
+        """
         self.denominator = denominator
         return self
 
     def set_min_amount(self, min_amount: int) -> "CustomFractionalFee":
+        """Set the minimum fee amount.
+
+        Args:
+            min_amount (int): The minimum fee amount allowed.
+
+        Returns:
+            CustomFractionalFee: The updated instance.
+        """
         self.min_amount = min_amount
         return self
 
     def set_max_amount(self, max_amount: int) -> "CustomFractionalFee":
+        """Set the maximum fee amount.
+
+        Args:
+            max_amount (int): The maximum fee amount allowed.
+
+        Returns:
+            CustomFractionalFee: The updated instance.
+        """
         self.max_amount = max_amount
         return self
 
     def set_assessment_method(self, assessment_method: FeeAssessmentMethod) -> "CustomFractionalFee":
+        """Set the assessment method for calculating the fee.
+
+        Args:
+            assessment_method (FeeAssessmentMethod): Defines how the fee is applied,
+                either inclusive or exclusive of the transferred amount.
+
+        Returns:
+            CustomFractionalFee: The updated instance.
+        """
         self.assessment_method = assessment_method
         return self
 
     def _to_proto(self) -> "custom_fees_pb2.CustomFee":
+        """Convert this CustomFractionalFee to its protobuf representation.
+
+        Returns:
+            custom_fees_pb2.CustomFee: The protobuf object representing this fee.
+        """
         from hiero_sdk_python.hapi.services import custom_fees_pb2
         from hiero_sdk_python.hapi.services.basic_types_pb2 import Fraction
 
@@ -70,15 +138,23 @@ class CustomFractionalFee(CustomFee):
 
     @classmethod
     def _from_proto(cls, proto_fee) -> "CustomFractionalFee":
-        """Create CustomFractionalFee from protobuf CustomFee message."""
-        from hiero_sdk_python.account.account_id import AccountId
-        
+        """Create a CustomFractionalFee object from a protobuf CustomFee message.
+
+        Args:
+            proto_fee (custom_fees_pb2.CustomFee): The protobuf message to deserialize.
+
+        Returns:
+            CustomFractionalFee: A new instance created from the protobuf data.
+        """
+        # Moved the import here to avoid a blank line issue
+        from hiero_sdk_python.account.account_id import AccountId 
+
         fractional_fee_proto = proto_fee.fractional_fee
-        
+
         fee_collector_account_id = None
-        if proto_fee.HasField("fee_collector_account_id"):  # Changed from WhichOneof
+        if proto_fee.HasField("fee_collector_account_id"):
             fee_collector_account_id = AccountId._from_proto(proto_fee.fee_collector_account_id)
-        
+
         return cls(
             numerator=fractional_fee_proto.fractional_amount.numerator,
             denominator=fractional_fee_proto.fractional_amount.denominator,
@@ -86,5 +162,5 @@ class CustomFractionalFee(CustomFee):
             max_amount=fractional_fee_proto.maximum_amount,
             assessment_method=FeeAssessmentMethod(fractional_fee_proto.net_of_transfers),
             fee_collector_account_id=fee_collector_account_id,
-            all_collectors_are_exempt=proto_fee.all_collectors_are_exempt
+            all_collectors_are_exempt=proto_fee.all_collectors_are_exempt,
         )


### PR DESCRIPTION
**Description**:
Add Google-style docstrings to `CustomFractionalFee` class and its methods.

* Added module-level and class-level docstrings in `custom_fractional_fee.py`
* Added descriptive docstrings for all setter methods and internal methods
* Updated `CHANGELOG.md` under `[Unreleased] → Added` section

**Related issue(s)**:

Fixes #492

**Notes for reviewer**:
This update improves code readability and consistency with Google-style documentation conventions.  
No logic, functionality, or API behavior was modified.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
