### PR TITLE
fix(file): Add missing type hints to FileAppendTransaction #495

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,24 @@ This project adheres to [Semantic Versioning](https://semver.org).
 This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+
 - Refactor `query_balance.py` into modular, reusable functions with `setup_client()`, `create_account()`, `get_balance()`, `transfer_hbars()`, and `main()` for improved readability, maintainability, and error handling.
 - Unified balance and transfer logging format — both now consistently display values in hbars for clarity.
 
 ### Added
 
 ### Changed
+
 - Refactored `examples/transfer_hbar.py` to improve modularity by separating transfer and balance query operations into dedicated functions
 - Enhanced contributing section in README.md with resource links
 - Refactored examples/topic_message_submit.py to be more modular
 
 ### Fixed
+
 - Added explicit read and write permissions to test.yml
+- Add missing type hints to `FileAppendTransaction` (Issue [#495](https://github.com/hiero-ledger/hiero-sdk-python/issues/495)).
 
 ## [0.1.6] - 2025-10-21
-
-
 
 ### Added
 
@@ -55,20 +57,18 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Improved `CONTRIBUTING.md` by explaining the /docs folder structure and fixing broken hyperlinks.(#431)
 - Converted class in `token_nft_info.py` to dataclass for simplicity.
 
-
 ### Fixed
 
 - Incompatible Types assignment in token_transfer_list.py
-- Corrected references to _require_not_frozen() and removed the surplus _is_frozen
+- Corrected references to \_require_not_frozen() and removed the surplus \_is_frozen
 - Removed duplicate static methods in `TokenInfo` class:
   - `_copy_msg_to_proto`
   - `_copy_key_if_present`
   - `_parse_custom_fees`
-  Kept robust versions with proper docstrings and error handling.
+    Kept robust versions with proper docstrings and error handling.
 - Add strict type hints to `TransactionGetReceiptQuery` (#420)
 - Fixed broken documentation links in CONTRIBUTING.md by converting absolute GitHub URLs to relative paths
 - Updated all documentation references to use local paths instead of pointing to hiero-sdk project hub
-
 
 ## [0.1.5] - 2025-09-25
 

--- a/src/hiero_sdk_python/file/file_append_transaction.py
+++ b/src/hiero_sdk_python/file/file_append_transaction.py
@@ -23,6 +23,10 @@ from hiero_sdk_python.hapi.services import file_append_pb2, timestamp_pb2
 from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
     SchedulableTransactionBody,
 )
+from hiero_sdk_python.client import Client
+from hiero_sdk_python.keys import PrivateKey
+from hiero_sdk_python.transaction.transaction_receipt import TransactionReceipt
+from hiero_sdk_python.hapi.services import transaction_body_pb2
 
 # pylint: disable=too-many-instance-attributes
 class FileAppendTransaction(Transaction):
@@ -61,7 +65,7 @@ class FileAppendTransaction(Transaction):
         self._current_chunk_index: int = 0
         self._total_chunks: int = self._calculate_total_chunks()
         self._transaction_ids: list[TransactionId] = []
-        self._signing_keys: list = []  # Store all signing keys for multi-chunk transactions
+        self._signing_keys: list[PrivateKey] = []  # Store all signing keys for multi-chunk transactions
 
     def _encode_contents(self, contents: Optional[str | bytes]) -> Optional[bytes]:
         """
@@ -158,7 +162,7 @@ class FileAppendTransaction(Transaction):
         self._total_chunks = self._calculate_total_chunks()
         return self
 
-    def _build_proto_body(self):
+    def _build_proto_body(self) -> file_append_pb2.FileAppendTransactionBody:
         """
         Returns the protobuf body for the file append transaction.
 
@@ -184,7 +188,7 @@ class FileAppendTransaction(Transaction):
             contents=chunk_contents
         )
 
-    def build_transaction_body(self):
+    def build_transaction_body(self) -> transaction_body_pb2.TransactionBody:
         """
         Builds the transaction body for this file append transaction.
 
@@ -208,7 +212,7 @@ class FileAppendTransaction(Transaction):
         schedulable_body.fileAppend.CopyFrom(file_append_body)
         return schedulable_body
 
-    def _get_method(self, channel: _Channel) -> _Method:
+    def _get_method(self, channel: _Channel) -> _Method[file_append_pb2.FileAppendTransactionBody, None]:
         """
         Gets the method to execute the file append transaction.
 
@@ -226,7 +230,7 @@ class FileAppendTransaction(Transaction):
             query_func=None
         )
 
-    def _from_proto(self, proto) -> 'FileAppendTransaction':
+    def _from_proto(self, proto: file_append_pb2.FileAppendTransactionBody) -> 'FileAppendTransaction':
         """
         Initializes a new FileAppendTransaction instance from a protobuf object.
 
@@ -242,7 +246,7 @@ class FileAppendTransaction(Transaction):
         self._total_chunks = self._calculate_total_chunks()
         return self
 
-    def _validate_chunking(self):
+    def _validate_chunking(self) -> None:
         """
         Validates that the transaction doesn't exceed the maximum number of chunks.
         
@@ -256,7 +260,7 @@ class FileAppendTransaction(Transaction):
             )
 
 
-    def freeze_with(self, client):
+    def freeze_with(self, client: Client) -> 'FileAppendTransaction':
         """
         Freezes the transaction by building the transaction body and setting necessary IDs.
         
@@ -310,7 +314,7 @@ class FileAppendTransaction(Transaction):
         return self
 
 
-    def execute(self, client):
+    def execute(self, client: Client) -> Optional[TransactionReceipt]:
         """
         Executes the file append transaction.
         
@@ -357,7 +361,7 @@ class FileAppendTransaction(Transaction):
             # Return the first response (as per JavaScript implementation)
             return responses[0] if responses else None
 
-    def sign(self, private_key):
+    def sign(self, private_key: PrivateKey) -> 'FileAppendTransaction':
         """
         Signs the transaction using the provided private key.
             


### PR DESCRIPTION
**Description**:
This PR adds missing type hints to the FileAppendTransaction class, as suggested in issue #495. This resolves a significant number of errors reported by mypy --strict.
- Adds type hints for imported classes like Client, PrivateKey, and TransactionReceipt.
- Updates function signatures (_build_proto_body, build_transaction_body, freeze_with, execute, sign, etc.) with correct argument and return types.
- Specifies the list type for _signing_keys as list[PrivateKey].

_**Related issue(s)**:_

Fixes #495 

**Notes for reviewer**:
Tested locally by running mypy --strict (after temporarily renaming the mypy.ini to avoid the encoding error). This confirmed that the changes successfully fixed the type errors as intended.

**Checklist**

- [x] Documented (Code comments, README, etc.) - Type hints serve as documentation.
- [x] Tested (unit, integration, etc.) - Tested with mypy --strict.
