### PR TITLE
chore: refactor examples/topic_create.py to be more modular

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Common issues guide for SDK developers at `examples/sdk_developers/common_issues.md`
 
 ### Changed
+- Refactored `examples/topic_create.py` to be more modular by splitting functions and renaming `create_topic()` to `main()`.
 - Refactored `examples/transfer_hbar.py` to improve modularity by separating transfer and balance query operations into dedicated functions
 - Enhanced contributing section in README.md with resource links
 - Refactored examples/topic_message_submit.py to be more modular

--- a/examples/topic_create.py
+++ b/examples/topic_create.py
@@ -1,7 +1,6 @@
 """
 uv run examples/topic_create.py
 python examples/topic_create.py
-
 """
 import os
 import sys
@@ -17,7 +16,8 @@ from hiero_sdk_python import (
 
 load_dotenv()
 
-def create_topic():
+# set up the Hedera client with operator credentials
+def setup_client():
     network = Network(network='testnet')
     client = Client(network)
 
@@ -25,7 +25,10 @@ def create_topic():
     operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY'))
 
     client.set_operator(operator_id, operator_key)
+    return client, operator_key
 
+# create a new topic on Hedera network
+def create_topic(client, operator_key):
     transaction = (
         TopicCreateTransaction(
             memo="Python SDK created topic",
@@ -46,5 +49,11 @@ def create_topic():
         print(f"Topic creation failed: {str(e)}")
         sys.exit(1)
 
+
+def main():
+    client, operator_key = setup_client()
+    create_topic(client, operator_key)
+
+
 if __name__ == "__main__":
-    create_topic()
+    main()


### PR DESCRIPTION
**Description**:
Refactored examples/topic_create.py to make it more modular. Split the original create_topic() function into setup_client() and create_topic(), and renamed create_topic() to main() to improve readability and maintainability.

**Changes**:

- Add setup_client() function to initialize the client
- Add create_topic() function for topic creation
- Rename old create_topic() to main() and call the two new functions from it

**Related issue(s)**: Refactor examples/topic_create.py to be more modular

Fixes #507

**Notes for reviewer**:
- Script output remains identical to previous version
- No functionality changes, only code structure refactoring

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (ran script on testnet & topic creation verified via HashScan)
