### PR TITLE
docs: add guide for resolving changelog conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Added Google-style docstrings to `CustomFractionalFee` class and its methods in `custom_fractional_fee.py`.
 - Added `dependabot.yaml` file to enable automated dependency management.
 - Common issues guide for SDK developers at `examples/sdk_developers/common_issues.md`
+- Added documentation for resolving changelog conflicts in `docs/common_issues.md`
 
 ### Changed
 - Refactored `examples/topic_create.py` to be more modular by splitting functions and renaming `create_topic()` to `main()`.

--- a/docs/common_issues.md
+++ b/docs/common_issues.md
@@ -1,0 +1,28 @@
+## Resolving Changelog Conflicts
+
+A common issue you may face when submitting a pull request (PR) is a "changelog conflict." This happens when your PR modifies the `CHANGELOG.md` file, but another PR that also modified it was merged before yours.
+
+### Common Causes
+
+There are two main reasons this happens:
+
+1.  **SDK Version Bump (Scenario A):** The SDK launched a new version (e.g., `0.1.5` became `0.1.6`) while your PR was open. Your changelog entry was under the `[Unreleased]` section, but that section is now part of the `[0.1.6]` release. Your entry needs to be moved to the *new* `[Unreleased]` section.
+2.  **Same Section Conflict (Scenario B):** Another PR was merged that added its own changelog entry to the *exact same* `[Unreleased]` section as yours (e.g., you both added a line under `Changed`). The file now has a conflict because Git doesn't know which line should come first.
+
+### How to Resolve the Conflict
+
+To fix this, you need to sync your branch with the main project (known as `upstream`) and then fix the conflict. This is done using a `rebase`.
+
+**1. Sync Your Local `main` Branch**
+
+First, ensure your local `main` branch has the latest changes from the `hiero-ledger` project.
+
+```bash
+# Switch to your main branch
+git checkout main
+
+# Fetch all the latest changes from the upstream (original) repository
+git fetch upstream
+
+# Pull those changes into your local main branch
+git pull upstream main


### PR DESCRIPTION
**Description**:
Adds a new guide to common_issues.md explaining how to resolve changelog conflicts.

This PR expands the documentation to help new contributors, covering the two most common causes of changelog conflicts:

SDK version bumps (Scenario A)

Same-section edit conflicts (Scenario B)

Add new "Resolving Changelog Conflicts" section to docs/common_issues.md.

Include a step-by-step Git workflow using git rebase to resolve conflicts.

Provide clear examples for both conflict scenarios.

Related issue(s):

Fixes #518

Notes for reviewer:

This is a documentation-only change as requested in the "good first issue."

Checklist

[x] Documented (This PR is documentation)

[ ] Tested (N/A)