### PR TITLE
chore: move common_issues.md from examples to docs for better organiz…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 - Added Google-style docstrings to `CustomFractionalFee` class and its methods in `custom_fractional_fee.py`.
 - Added `dependabot.yaml` file to enable automated dependency management.
-- Common issues guide for SDK developers at `examples/sdk_developers/common_issues.md`
+- Common issues guide for SDK developers at `docs/sdk_developers/common_issues.md`
 - Added documentation for resolving changelog conflicts in `docs/common_issues.md`
 - - Added comprehensive changelog entry guide at `docs/sdk_developers/changelog.md` to help contributors create proper changelog entries (#532).
 - docs: Added Google-style docstrings to `CustomFixedFee` class and its methods in `custom_fixed_fee.py`.
@@ -25,18 +25,22 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Changed
 
+- Moved `examples/sdk_developers/common_issues.md` to `docs/sdk_developers/common_issues.md` for better documentation organization
 - Renamed `examples/nft_allowance.py` to `examples/account_allowance_nft.py` for consistency with account class naming scheme
 - Added changelog conflict resolution examples to `docs/common_issues.md`
 - Refactored `examples/topic_create.py` to be more modular by splitting functions and renaming `create_topic()` to `main()`.
 - Refactored `examples/transfer_hbar.py` to improve modularity by separating transfer and balance query operations into dedicated functions
 - Enhanced contributing section in README.md with resource links
 - Refactored examples/topic_message_submit.py to be more modular
-- Added "One Issue Per Pull Request" section to `examples/sdk_developers/common_issues.md`.
+- Added "One Issue Per Pull Request" section to `docs/sdk_developers/common_issues.md`.
 - docs: Improved the contributing section in the README.md file
 - Refactored `examples/transfer_nft.py` to be more modular by isolating transfer logic.
+- Refactored `examples/file_append.py` into modular functions for better readability, reuse, and consistency across examples.
+- Ensured identical runtime behavior and output to the previous version to maintain backward compatibility.
 - Renamed `examples/hbar_allowance.py` to `examples/account_allowance_hbar.py` for naming consistency
 - Converted monolithic function in `token_create_nft_infinite.py` to multiple modular functions for better structure and ease.
 - docs: Use relative paths for internal GitHub links (#560).
+- Update pyproject.toml maintainers list.
 
 ### Fixed
 

--- a/docs/sdk_developers/common_issues.md
+++ b/docs/sdk_developers/common_issues.md
@@ -29,7 +29,7 @@ git commit -S -s -m "your commit message"
 
 **How to set up GPG signing:**
 
-1. Check our comprehensive guide: [Signing Guide](../docs/sdk_developers/signing.md)
+1. Check our comprehensive guide: [Signing Guide](signing.md)
 2. Generate a GPG key if you don't have one
 3. Add your GPG key to your GitHub account
 4. Configure Git to use your GPG key
@@ -82,7 +82,7 @@ Every contribution **must include an entry in CHANGELOG.md** under the `[Unrelea
 ## [Unreleased]
 
 ### Added
-- Common issues guide for SDK developers at `examples/sdk_developers/common_issues.md`
+- Common issues guide for SDK developers at `docs/sdk_developers/common_issues.md`
 ```
 
 **Why this matters:**
@@ -157,10 +157,10 @@ The Hiero Python SDK community is here to help! Here are the best ways to get su
 
 **4. Documentation Resources**
 - [CONTRIBUTING.md](../../CONTRIBUTING.md) - Complete contribution guidelines
-- [Signing Guide](../docs/sdk_developers/signing.md) - GPG and DCO setup
-- [Rebasing Guide](../docs/sdk_developers/rebasing.md) - Keep your branch up to date
-- [Linting Guide](../docs/sdk_developers/linting.md) - Code quality tools
-- [Types Guide](../docs/sdk_developers/types.md) - Python type hints
+- [Signing Guide](signing.md) - GPG and DCO setup
+- [Rebasing Guide](rebasing.md) - Keep your branch up to date
+- [Linting Guide](linting.md) - Code quality tools
+- [Types Guide](types.md) - Python type hints
 
 **Tips for getting help:**
 - Provide context: share error messages, screenshots, or logs

--- a/examples/file_append.py
+++ b/examples/file_append.py
@@ -36,18 +36,8 @@ def setup_client():
     
     return client
 
-def file_append():
-    """
-    Demonstrates appending content to a file on the network by:
-    1. Setting up client with operator account
-    2. Creating a file with initial content
-    3. Appending additional content to the file
-    """
-    client = setup_client()
-    
-    file_private_key = PrivateKey.generate_ed25519()
-    
-    # Step 1: Create a file with initial content
+def create_file(client, file_private_key):
+    """Create a file with initial content"""
     print("Creating file with initial content...")
     create_receipt = (
         FileCreateTransaction()
@@ -66,7 +56,10 @@ def file_append():
     file_id = create_receipt.file_id
     print(f"File created successfully with ID: {file_id}")
     
-    # Step 2: Append content to the file (single chunk)
+    return file_id
+
+def append_file_single(client, file_id, file_private_key):
+    """Append content to the file (single chunk)"""
     print("\nAppending content to file (single chunk)...")
     append_receipt = (
         FileAppendTransaction()
@@ -82,8 +75,9 @@ def file_append():
         sys.exit(1)
     
     print("Content appended successfully!")
-    
-    # Step 3: Append large content (multi-chunk)
+
+def append_file_large(client, file_id, file_private_key):
+    """Append large content to the file (multi-chunk)"""
     print("\nAppending large content (multi-chunk)...")
     large_content = b"Large content that will be split into multiple chunks. " * 100
     
@@ -105,5 +99,25 @@ def file_append():
     print("Large content appended successfully!")
     print(f"Total chunks used: {FileAppendTransaction().set_contents(large_content).get_required_chunks()}")
 
+def main():
+    """
+    Demonstrates appending content to a file on the network by:
+    1. Setting up client with operator account
+    2. Creating a file with initial content
+    3. Appending additional content to the file
+    """
+    client = setup_client()
+    
+    file_private_key = PrivateKey.generate_ed25519()
+    
+    # Step 1: Create a file with initial content
+    file_id = create_file(client, file_private_key)
+    
+    # Step 2: Append content to the file (single chunk)
+    append_file_single(client, file_id, file_private_key)
+    
+    # Step 3: Append large content (multi-chunk)
+    append_file_large(client, file_id, file_private_key)
+
 if __name__ == "__main__":
-    file_append() 
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ name = "hiero-sdk-python"
 dynamic = ["version"]
 description = "A Hiero SDK in pure Python"
 maintainers = [
-    { name = "Nadine Loepfe", email = "nadine.loepfe@hashgraph.com" }
+    { name = "Nadine Loepfe", email = "nadine.loepfe@hashgraph.com" },
+    { name = "Sophie Bulloch", email = "exploreriii57@gmail.com" }
 ]
 authors = [
     { name = "Nadine Loepfe", email = "nadine.loepfe@hashgraph.com" },


### PR DESCRIPTION
Fixes #516

## Changes Made
- Moved [examples/sdk_developers/common_issues.md](cci:7://file:///f:/hiero-sdk-python/examples/sdk_developers/common_issues.md:0:0-0:0) to [docs/sdk_developers/common_issues.md](cci:7://file:///f:/hiero-sdk-python/docs/sdk_developers/common_issues.md:0:0-0:0)
- Updated all internal links in the file to work correctly in the new location
- Updated references in CHANGELOG.md from old path to new path
- Added changelog entry documenting the move
- Deleted empty [examples/sdk_developers](cci:7://file:///f:/hiero-sdk-python/examples/sdk_developers:0:0-0:0) directory

## Acceptance Criteria Met
- ✅ Content in common_issues.md is otherwise the same
- ✅ Location is in /docs/sdk_developers
- ✅ All URLs work correctly
- ✅ References to examples/sdk_developers replaced with docs/sdk_developers
- ✅ Changelog entry added
- ✅ Commits are signed and verified