### PR TITLE
chore: implement __repr__ for custom fee classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- Added __repr__ method to CustomFee classes for easier debugging of fee attributes.
 - Add type hints to `setup_client()` and `create_new_account()` functions in `examples/account_create.py` (#418)
 - Added explicit read and write permissions to test.yml
 

--- a/examples/custom_fee.py
+++ b/examples/custom_fee.py
@@ -10,6 +10,8 @@ from hiero_sdk_python.tokens.fee_assessment_method import FeeAssessmentMethod
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.tokens.token_id import TokenId
 
+# --- Removed the non-functional code block before main() ---
+
 def main():
     # Create a CustomFixedFee
     fixed_fee = CustomFixedFee(
@@ -19,6 +21,9 @@ def main():
         all_collectors_are_exempt=False,
     )
     print("CustomFixedFee:")
+    # --- ADDED: Demonstrate __repr__ output ---
+    print(f"DEBUG REPR: {fixed_fee!r}") 
+    # ------------------------------------------
     print(f"Amount: {fixed_fee.amount}")
     print(f"Denominating Token ID: {fixed_fee.denominating_token_id}")
     print(f"Fee Collector Account ID: {fixed_fee.fee_collector_account_id}")
@@ -40,6 +45,9 @@ def main():
         all_collectors_are_exempt=False,
     )
     print("\nCustomFractionalFee:")
+    # --- ADDED: Demonstrate __repr__ output ---
+    print(f"DEBUG REPR: {fractional_fee!r}")
+    # ------------------------------------------
     print(f"Numerator: {fractional_fee.numerator}")
     print(f"Denominator: {fractional_fee.denominator}")
     print(f"Min Amount: {fractional_fee.min_amount}")
@@ -66,6 +74,9 @@ def main():
         all_collectors_are_exempt=True,
     )
     print("\nCustomRoyaltyFee:")
+    # --- ADDED: Demonstrate __repr__ output ---
+    print(f"DEBUG REPR: {royalty_fee!r}")
+    # ------------------------------------------
     print(f"Numerator: {royalty_fee.numerator}")
     print(f"Denominator: {royalty_fee.denominator}")
     print(f"Fallback Fee Amount: {royalty_fee.fallback_fee.amount}")

--- a/src/hiero_sdk_python/tokens/custom_fee.py
+++ b/src/hiero_sdk_python/tokens/custom_fee.py
@@ -13,6 +13,15 @@ class CustomFee(ABC):
     """
     Base class for custom fees.
     """
+    def __repr__(self) -> str:
+        """
+        Returns a string representation of the CustomFee object.
+        """
+        return (
+            f"{self.__class__.__name__}("
+            f"fee_collector_account_id={self.fee_collector_account_id!r}, "
+            f"all_collectors_are_exempt={self.all_collectors_are_exempt!r})"
+        )
 
     def __init__(
         self,

--- a/tests/unit/test_custom_fee.py
+++ b/tests/unit/test_custom_fee.py
@@ -9,6 +9,71 @@ from hiero_sdk_python.tokens.token_id import TokenId
 
 pytestmark = pytest.mark.unit
 
+# --- ADDED TESTS FOR ISSUE #583: __repr__ VERIFICATION ---
+
+def test_custom_fixed_fee_repr():
+    """Verifies the __repr__ output for CustomFixedFee."""
+    # Use the same setup values as test_custom_fixed_fee
+    fee_collector_id = AccountId(0, 0, 456)
+    
+    fee = CustomFixedFee(
+        amount=100,
+        denominating_token_id=TokenId(0, 0, 123),
+        fee_collector_account_id=fee_collector_id,
+        all_collectors_are_exempt=True,
+    )
+    
+    # The expected string must match the format implemented in CustomFee.__repr__
+    # Note the use of repr() on the objects to match the f-string's !r formatting
+    expected_repr = (
+        f"CustomFixedFee("
+        f"fee_collector_account_id={repr(fee_collector_id)}, "
+        f"all_collectors_are_exempt=True)"
+    )
+    assert repr(fee) == expected_repr
+
+def test_custom_fractional_fee_repr():
+    """Verifies the __repr__ output for CustomFractionalFee."""
+    # Use the same setup values as test_custom_fractional_fee
+    fee_collector_id = AccountId(0, 0, 456)
+    
+    fee = CustomFractionalFee(
+        numerator=1,
+        denominator=10,
+        min_amount=1,
+        max_amount=100,
+        assessment_method=FeeAssessmentMethod.EXCLUSIVE,
+        fee_collector_account_id=fee_collector_id,
+        all_collectors_are_exempt=False,
+    )
+    
+    expected_repr = (
+        f"CustomFractionalFee("
+        f"fee_collector_account_id={repr(fee_collector_id)}, "
+        f"all_collectors_are_exempt=False)"
+    )
+    assert repr(fee) == expected_repr
+
+def test_custom_royalty_fee_repr():
+    """Verifies the __repr__ output for CustomRoyaltyFee."""
+    # Use the same setup values as test_custom_royalty_fee
+    fee_collector_id = AccountId(0, 0, 456)
+    
+    fee = CustomRoyaltyFee(
+        numerator=5,
+        denominator=100,
+        fallback_fee=None, # Note: fallback_fee is NOT part of the base __repr__
+        fee_collector_account_id=fee_collector_id,
+        all_collectors_are_exempt=True,
+    )
+    
+    expected_repr = (
+        f"CustomRoyaltyFee("
+        f"fee_collector_account_id={repr(fee_collector_id)}, "
+        f"all_collectors_are_exempt=True)"
+    )
+    assert repr(fee) == expected_repr
+
 def test_custom_fixed_fee():
     fee = CustomFixedFee(
         amount=100,
@@ -73,3 +138,6 @@ def test_custom_royalty_fee():
     assert isinstance(new_fee.fallback_fee, CustomFixedFee)
     assert new_fee.fallback_fee.amount == 50
     assert new_fee.fallback_fee.denominating_token_id == TokenId(0, 0, 789)
+    
+    
+    


### PR DESCRIPTION
**Description**:
Implements the __repr__ method on CustomFee classes to improve debugging and object introspection.

* Implement `__repr__` method on the `CustomFee` base class to display essential attributes (`fee_collector_account_id`, `all_collectors_are_exempt`).
* Expand unit tests in `tests/unit/test_custom_fee.py` to verify the new `__repr__` output for all derived fee classes.
* Update `examples/custom_fee.py` to demonstrate the new debug-friendly object representation.

**Related issue(s)**:

Fixes #583

**Notes for reviewer**:
This change only affects object representation and does not alter transaction behavior. Please review the new test cases in `test_custom_fee.py` to ensure the format assertions are correct.

**Checklist**

- [x] Documented (Code comments, README, etc.) (The method includes a docstring comment.)
- [x] Tested (unit, integration, etc.) (New unit tests added in `tests/unit/test_custom_fee.py`.)