### PR TITLE
added table of contents to docs/sdk_developers/merge_conflicts.md

### DIFF
--- a/docs/sdk_developers/merge_conflicts.md
+++ b/docs/sdk_developers/merge_conflicts.md
@@ -1,5 +1,22 @@
 ## Handling Conflicts
 
+## Table of Contents
+- [Handling Conflicts](#handling-conflicts)
+  - [1. See which files are conflicted](#1-see-which-files-are-conflicted)
+  - [2. Resolve conflicts manually](#2-resolve-conflicts-manually)
+  - [3. Resolving conflicts in VS Code (recommended):](#3-resolving-conflicts-in-vs-code-recommended)
+    - [Steps to resolve:](#steps-to-resolve)
+- [After fixing conflicts:](#after-fixing-conflicts)
+  - [4. Stage the resolved files](#4-stage-the-resolved-files)
+  - [5.Continue the rebase](#5continue-the-rebase)
+  - [6. After Rebase is Completed](#6-after-rebase-is-completed)
+- [Common issues](#common-issues)
+- [If you need to stop](#if-you-need-to-stop)
+- [What NOT to do](#what-not-to-do)
+- [Recovery Tips:](#recovery-tips)
+  - [If you are completely stuck](#if-you-are-completely-stuck)
+
+
 Conflicts are common if main has updates to the files you are working on. In which case, you'll have to run a rebase.
 
 If you are warned of a conflict:


### PR DESCRIPTION
**Description**:
<!--
I have added a table of contents to merge_conflicts.md hat links all headings and subheadings correctly.
Now all information in the doc is better organized and easily accessible.

**Related issue(s)**:

Fixes #608

**Notes for reviewer**:
<img width="1155" height="635" alt="image" src="https://github.com/user-attachments/assets/71732b92-6949-4958-b4fd-84321aee8c0d" />


**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
