### PR TITLE
docs: Update non-functional Discord and Hedera links to new invite li…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Changed
 
+- Updated all occurrences of non-functional Discord invite links throughout the documentation with the new, stable Hyperledger and Hedera invite links (#603).
 - Refactored TopicId class to use @dataclass decorator for reducing boilerplate code
 - Renamed `examples/nft_allowance.py` to `examples/account_allowance_nft.py` for consistency with account class naming scheme
 - Added changelog conflict resolution examples to `docs/common_issues.md`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,7 +225,7 @@ pip install -U hiero-sdk-python
   - [ ] Additional information such as: expected vs actual behavior and a minimal working example are not required but will be helpful.
   - [ ] Click 'create'.
 - Bugs impacting security. Workflow:
-  - [ ] Ensure you have joined the [Hiero Python SDK Discord](https://discord.com/channels/905194001349627914/1336494517544681563).
+  - [ ] Ensure you have joined the [Hiero Python SDK Discord]( https://discord.gg/hyperledger).
   - [ ] Contact [maintainers](MAINTAINERS.md) directly on discord stating there is an issue requiring immediate follow-up.
   - [ ] Prepare sufficient documentation, such as logs, screenshots and information on how to replicate to share with the maintainer once asked.
 
@@ -278,8 +278,8 @@ We strive to be a welcoming community with lots of activity, opportunities and s
 
 ### Socials
 
-- Join us on [Hiero Python SDK Discord](https://discord.com/channels/905194001349627914/1336494517544681563), add it to your favourites andchat with the Hiero Python SDK community and maintainers. Feel free to ask questions, propose ideas, or discuss your PR.
-- Discuss programming or issues with the Hedera community [Hedera Developer Support Discord](https://discord.com/channels/373889138199494658/1106578684573388900).
+- Join us on [Hiero Python SDK Discord](https://discord.gg/hyperledger), add it to your favourites andchat with the Hiero Python SDK community and maintainers. Feel free to ask questions, propose ideas, or discuss your PR.
+- Discuss programming or issues with the Hedera community [Hedera Developer Support Discord]( https://discord.gg/UuQevYMP).
 - Check the [Issues](https://github.com/hiero-ledger/hiero-sdk-python/issues) page for ongoing discussions. Comment on an issue and see the conversation grow.
 
 - Learn about our recent activities at [Hiero Blog](https://hiero.org/blog/)

--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ Following the steps in this guide is the best way to ensure your pull request (P
 Our guide also explains how you can contribute in other ways, like submitting **bug reports** and proposing new **feature requests**.
 
 ### Links
-- [Hiero Python SDK Discord](https://discord.com/channels/905194001349627914/1336494517544681563)
-- [Hedera Developer Support Discord](https://discord.com/channels/373889138199494658/1106578684573388900).
+- [Hiero Python SDK Discord](https://discord.gg/hyperledger)
+- [Hedera Developer Support Discord](https://discord.gg/UuQevYMP).
 - [Hiero Blog](https://hiero.org/blog/)
 - [LFDT Youtube Channel](https://www.youtube.com/@lfdecentralizedtrust/videos)
 - [Hiero LFTD Calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/hiero?view=week)

--- a/docs/sdk_developers/testing.md
+++ b/docs/sdk_developers/testing.md
@@ -1192,7 +1192,7 @@ If you encounter issues or have questions:
 1. **Check this guide** - Most common scenarios are covered
 2. **Review existing tests** - Look at similar tests in the codebase
 3. **Check documentation** - See `/docs/sdk_developers/`
-4. **Ask in Discord** - Link to be updated soon <!--[Hiero Python SDK Discord](https://discord.com/channels/905194001349627914/1336494517544681563)-->
+4. **Ask in Discord** - Link to be updated soon <!--[Hiero Python SDK Discord](  https://discord.gg/hyperledger)-->
 5. **Open an issue** - For bugs or unclear documentation
 
 ### Useful Resources

--- a/examples/sdk_developers/common_issues.md
+++ b/examples/sdk_developers/common_issues.md
@@ -141,7 +141,7 @@ You're stuck, have questions, or need help with your contribution.
 The Hiero Python SDK community is here to help! Here are the best ways to get support:
 
 **1. Discord Community**
-- Join the [Hiero Python SDK Discord](https://discord.com/channels/905194001349627914/1336494517544681563)
+- Join the [Hiero Python SDK Discord]( https://discord.gg/hyperledger)
 - Ask questions, discuss your PR, or get real-time help from maintainers and community members
 - This is the fastest way to get unstuck
 
@@ -175,7 +175,7 @@ The Hiero Python SDK community is here to help! Here are the best ways to get su
 If you encounter an issue not covered in this guide, please:
 
 1. Search existing [Issues](https://github.com/hiero-ledger/hiero-sdk-python/issues) and [Discussions](https://github.com/hiero-ledger/hiero-sdk-python/discussions)
-2. Ask in the [Discord](https://discord.com/channels/905194001349627914/1336494517544681563)
+2. Ask in the [Discord]( https://discord.gg/hyperledger)
 3. Create a new issue with the `documentation` label if something should be added to this guide
 
 Happy contributing! 🎉


### PR DESCRIPTION
PR Description for Issue #603: Update Discord Links
Description:

<!-- One or two line summary of what this PR does and why it is needed, followed by a list of changes in imperative, present tense for use in the commit message or changelog. -->

Update all non-functional Discord invite links across the repository documentation to use the new, stable Hyperledger and Hedera invite links.

Update all links referencing Hiero/LFDT to the stable Hyperledger invite: https://discord.gg/hyperledger.

Update all links referencing Hedera support to the stable Hedera invite: https://discord.gg/UuQevYMP.

Update CHANGELOG.md with a summary of the change.

Related issue(s):

Fixes #603

Notes for reviewer:

<!-- Provide logs, performance numbers or screenshots of the new functionality -->

This PR is a maintenance fix to ensure community members can successfully join the required Discord servers for support, which was not possible with the old, broken shortcode links. No functional code changes were made.

Checklist

[x] Documented (Code comments, README, etc.)

[ ] Tested (unit, integration, etc.)