### PR TITLE
fix: Improve type hinting in file_append_transaction.py #565

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,16 +48,15 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Converted monolithic function in `token_create_nft_infinite.py` to multiple modular functions for better structure and ease.
 - docs: Use relative paths for internal GitHub links (#560).
 - Update pyproject.toml maintainers list.
-– docs: Updated README.md/CHANGELOG.md and added blog.md, bud.md and setup.md (#474)
+  – docs: Updated README.md/CHANGELOG.md and added blog.md, bud.md and setup.md (#474)
 - renamed docs/sdk_developers/changelog.md to docs/sdk_developers/changelog_entry.md for clarity.
 
 ### Fixed
 
-- Add type hints to `setup_client()` and `create_new_account()` functions in `examples/account_create.py` (#418)
-- Added explicit read and write permissions to test.yml
-- Type hinting for `Topic` related transactions.
+- Improved type hinting in `file_append_transaction.py` to resolve 'mypy --strict` errors.
 
 ### Removed
+
 - Remove deprecated camelCase alias support and `_DeprecatedAliasesMixin`; SDK now only exposes snake_case attributes for `NftId`, `TokenInfo`, and `TransactionReceipt`. (Issue #428)
 
 ## [0.1.6] - 2025-10-21


### PR DESCRIPTION
**Description**:
Improves type hinting in file_append_transaction.py to resolve numerous mypy --strict errors.
This PR addresses the type definitions for the FileAppendTransaction class, which allows mypy to properly analyze the file in strict mode.

- Add `from __future__ import annotations` for modern type handling.
- Add missing type hints for function arguments and return values (e.g., `_build_proto_body`, `execute`, `sign`, `freeze_with`).
- Import types required for hinting (like `Client`, `PrivateKey`, `TransactionReceipt`) inside a `TYPE_CHECKING` block to prevent circular imports.
- Resolve `[attr-defined]` errors by adding `assert` checks for `Optional` types in `freeze_with`.
- Specify generic type for `self._signing_keys` from `list` to `List[PrivateKey]`.
---

**Related issue(s)**:

Fixes #495 

**Notes for reviewer**:
This PR significantly reduces the `mypy --strict` error count for this file. The few remaining errors (like `[import-untyped]` or `[no-untyped-call]` from `super())` are due to other modules in the SDK not being fully typed yet, which was noted as out-of-scope in the issue.

Tested locally by running `mypy --strict` (after temporarily renaming the mypy.ini to avoid the encoding error). This confirmed that the changes successfully fixed the type errors as intended.

---
**Checklist**

- [x] Documented (Code comments, README, etc.) - Type hints serve as documentation.
- [x] Tested (unit, integration, etc.) - Tested with mypy --strict.

