### PR TITLE
fix: Improve type hinting in file_append_transaction.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
-
 ### Added
+
 - Add Google-style docstrings to `AccountInfo` class and its methods in `account_info.py`.
 
 - add AccountRecordsQuery class
@@ -17,13 +17,14 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 ### Fixed
 
 - Added explicit read permissions to examples.yml (#623)
+- Improved type hinting in `file_append_transaction.py` to resolve 'mypy --strict` errors. ([#495](https://github.com/hiero-ledger/hiero-sdk-python/issues/495))
 
 ### Breaking Changes
-
 
 ## [0.1.7] - 2025-10-28
 
 ### Added
+
 - Expanded `README.md` with a new "Follow Us" section detailing how to watch, star, and fork the repository (#472).
 - Refactored `examples/topic_create.py` into modular functions for better readability and reuse.
 - Add Rebasing and Signing section to signing.md with instructions for maintaining commit verification during rebase operations (#556)
@@ -63,7 +64,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Converted monolithic function in `token_create_nft_infinite.py` to multiple modular functions for better structure and ease.
 - docs: Use relative paths for internal GitHub links (#560).
 - Update pyproject.toml maintainers list.
-– docs: Updated README.md/CHANGELOG.md and added blog.md, bud.md and setup.md (#474)
+  – docs: Updated README.md/CHANGELOG.md and added blog.md, bud.md and setup.md (#474)
 - renamed docs/sdk_developers/changelog.md to docs/sdk_developers/changelog_entry.md for clarity.
 - Refactor `query_balance.py` into modular, reusable functions with `setup_client()`, `create_account()`, `get_balance()`, `transfer_hbars()`, and `main()` for improved readability, maintainability, and error handling.
 - Unified balance and transfer logging format — both now consistently display values in hbars for clarity.
@@ -75,6 +76,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Type hinting for `Topic` related transactions.
 
 ### Removed
+
 - Remove deprecated camelCase alias support and `_DeprecatedAliasesMixin`; SDK now only exposes snake_case attributes for `NftId`, `TokenInfo`, and `TransactionReceipt`. (Issue #428)
 
 ## [0.1.6] - 2025-10-21
@@ -131,6 +133,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 ## [0.1.5] - 2025-09-25
 
 ### Added
+
 - ScheduleSignTransaction class
 - NodeUpdateTransaction class
 - NodeDeleteTransaction class


### PR DESCRIPTION
**Description**:
Improves type hinting in file_append_transaction.py to resolve numerous mypy --strict errors.
This PR addresses the type definitions for the FileAppendTransaction class, which allows mypy to properly analyze the file in strict mode.

- Add `from __future__ import annotations` for modern type handling.
- Add missing type hints for function arguments and return values (e.g., `_build_proto_body`, `execute`, `sign`, `freeze_with`).
- Import types required for hinting (like `Client`, `PrivateKey`, `TransactionReceipt`) inside a `TYPE_CHECKING` block to prevent circular imports.
- Resolve `[attr-defined]` errors by adding `assert` checks for `Optional` types in `freeze_with`.
- Specify generic type for `self._signing_keys` from `list` to `List[PrivateKey]`.
---

**Related issue(s)**:

Fixes #495 

**Notes for reviewer**:
This PR significantly reduces the `mypy --strict` error count for this file. The few remaining errors (like `[import-untyped]` or `[no-untyped-call]` from `super())` are due to other modules in the SDK not being fully typed yet, which was noted as out-of-scope in the issue.

Tested locally by running `mypy --strict` (after temporarily renaming the mypy.ini to avoid the encoding error). This confirmed that the changes successfully fixed the type errors as intended.

---
**Checklist**

- [x] Documented (Code comments, README, etc.) - Type hints serve as documentation.
- [x] Tested (unit, integration, etc.) - Tested with mypy --strict.

