### PR TITLE
fix: Improve type conflict in token_cancel_airdrop_transaction.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
-
 ### Added
+
 - Add Google-style docstrings to `AccountInfo` class and its methods in `account_info.py`.
 
 - add AccountRecordsQuery class
 
 ### Changed
+
+- chore: fix type hint for TokenCancelAirdropTransaction pending_airdrops parameter
 
 ### Fixed
 
@@ -20,10 +22,10 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Breaking Changes
 
-
 ## [0.1.7] - 2025-10-28
 
 ### Added
+
 - Expanded `README.md` with a new "Follow Us" section detailing how to watch, star, and fork the repository (#472).
 - Refactored `examples/topic_create.py` into modular functions for better readability and reuse.
 - Add Rebasing and Signing section to signing.md with instructions for maintaining commit verification during rebase operations (#556)
@@ -63,7 +65,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Converted monolithic function in `token_create_nft_infinite.py` to multiple modular functions for better structure and ease.
 - docs: Use relative paths for internal GitHub links (#560).
 - Update pyproject.toml maintainers list.
-– docs: Updated README.md/CHANGELOG.md and added blog.md, bud.md and setup.md (#474)
+  – docs: Updated README.md/CHANGELOG.md and added blog.md, bud.md and setup.md (#474)
 - renamed docs/sdk_developers/changelog.md to docs/sdk_developers/changelog_entry.md for clarity.
 - Refactor `query_balance.py` into modular, reusable functions with `setup_client()`, `create_account()`, `get_balance()`, `transfer_hbars()`, and `main()` for improved readability, maintainability, and error handling.
 - Unified balance and transfer logging format — both now consistently display values in hbars for clarity.
@@ -75,6 +77,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Type hinting for `Topic` related transactions.
 
 ### Removed
+
 - Remove deprecated camelCase alias support and `_DeprecatedAliasesMixin`; SDK now only exposes snake_case attributes for `NftId`, `TokenInfo`, and `TransactionReceipt`. (Issue #428)
 
 ## [0.1.6] - 2025-10-21
@@ -131,6 +134,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 ## [0.1.5] - 2025-09-25
 
 ### Added
+
 - ScheduleSignTransaction class
 - NodeUpdateTransaction class
 - NodeDeleteTransaction class

--- a/src/hiero_sdk_python/tokens/token_cancel_airdrop_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_cancel_airdrop_transaction.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services import basic_types_pb2, token_cancel_airdrop_pb2
 from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
@@ -12,12 +13,12 @@ class TokenCancelAirdropTransaction(Transaction):
 
     This transaction allows users to cancel one or more airdrops for both fungible tokens and NFTs.
     """
-    def __init__(self, pending_airdrops: list[PendingAirdropId]=None) -> None:
+    def __init__(self, pending_airdrops: Optional[list[PendingAirdropId]] = None) -> None:
         """
         Initializes a new TokenCancelAirdropTransaction instance.
 
         Args:
-            pending_airdrops (list[PendingAirdropId], optional): An initial list of pending airdrop IDs.
+            pending_airdrops (Optional[list[PendingAirdropId]]): An optional list of pending airdrop IDs.
         """
         super().__init__()
         self.pending_airdrops: list[PendingAirdropId] = pending_airdrops or []


### PR DESCRIPTION


**Description**:
This PR fixes a type hint conflict in the `TokenCancelAirdropTransaction` class where the `pending_airdrops` parameter was incorrectly typed as `list[PendingAirdropId]=None`, creating a type conflict since `None` is not a valid list.

**Changes:**
- Import `Optional` from typing module
- Update type hint for `pending_airdrops` parameter to `Optional[list[PendingAirdropId]]`
- Update corresponding docstring to reflect the correct type

---

**Related issue(s)**:

Fixes #629 

---

**Notes for reviewer**:
- This is a straightforward type hint fix that resolves the mypy type conflict
- No functionality changes - only type annotations updated
- All existing tests continue to pass
- Follows Python typing best practices using `Optional` for nullable parameters

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
- [x] Changelog entry added under `[UNRELEASED]`
- [x] Commits signed with `-S -s` flags


