### PR TITLE
docs: Add Google-style docstrings to contract_id.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 - add AccountRecordsQuery class
 
+- docs: Add Google-style docstrings to `ContractId` class and methods in `contract_id.py`.
+
 ### Changed
 
 ### Fixed

--- a/src/hiero_sdk_python/contract/contract_id.py
+++ b/src/hiero_sdk_python/contract/contract_id.py
@@ -1,5 +1,8 @@
 """
-Contract ID class.
+Represents a Contract ID on the Hedera network.
+
+Provides utilities for creating, parsing from strings, converting to protobuf
+format, and validating checksums associated with a contract.
 """
 
 import re
@@ -18,19 +21,24 @@ if TYPE_CHECKING:
 
 EVM_ADDRESS_REGEX = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.([a-fA-F0-9]{40}$)")
 
+
 @dataclass(frozen=True)
 class ContractId:
     """
-    Represents a contract ID on the network.
+    Represents a unique contract ID on the Hedera network.
 
-    A contract ID consists of three components: shard, realm, and contract (number).
-    These components uniquely identify a contract in the network.
+    A contract ID can be represented by its shard, realm, and contract number,
+    or by a 20-byte EVM address.
 
     Attributes:
-        shard (int): The shard number. Defaults to 0.
-        realm (int): The realm number. Defaults to 0.
-        contract (int): The contract number. Defaults to 0.
-        evm_address (bytes): The EVM address of the contract. Defaults to None.
+        shard (int): The shard number (non-negative). Defaults to 0.
+        realm (int): The realm number (non-negative). Defaults to 0.
+        contract (int): The contract number (non-negative). Defaults to 0.
+        evm_address (Optional[bytes]): The 20-byte EVM address of the contract.
+            Defaults to None.
+        checksum (Optional[str]): A network-specific checksum computed from
+            the shard, realm, and contract numbers. Not used if `evm_address`
+            is set.
     """
 
     shard: int = 0
@@ -43,6 +51,14 @@ class ContractId:
     def _from_proto(cls, contract_id_proto: basic_types_pb2.ContractID) -> "ContractId":
         """
         Creates a ContractId instance from a protobuf ContractID object.
+
+        Args:
+            contract_id_proto (basic_types_pb2.ContractID): The protobuf
+                ContractID object to convert from.
+
+        Returns:
+            ContractId: A new ContractId instance populated with data from
+            the protobuf object.
         """
         return cls(
             shard=contract_id_proto.shardNum,
@@ -53,6 +69,10 @@ class ContractId:
     def _to_proto(self):
         """
         Converts the ContractId instance to a protobuf ContractID object.
+
+        Returns:
+            basic_types_pb2.ContractID: The corresponding protobuf
+            ContractID object.
         """
         return basic_types_pb2.ContractID(
             shardNum=self.shard,
@@ -64,7 +84,21 @@ class ContractId:
     @classmethod
     def from_string(cls, contract_id_str: str) -> "ContractId":
         """
-        Parses a string in the format 'shard.realm.contract' to create a ContractId instance.
+        Parses a string to create a ContractId instance.
+
+        The string can be in the format 'shard.realm.contract' (e.g., "0.0.123"),
+        'shard.realm.contract-checksum' (e.g., "0.0.123-vfmkw"),
+        or 'shard.realm.evm_address' (e.g., "0.0.a...f").
+
+        Args:
+            contract_id_str (str): The contract ID string to parse.
+
+        Returns:
+            ContractId: A new ContractId instance.
+
+        Raises:
+            ValueError: If the contract ID string is None, not a string,
+                or in an invalid format.
         """
         if contract_id_str is None or not isinstance(contract_id_str, str):
             raise ValueError(
@@ -86,7 +120,7 @@ class ContractId:
             try:
                 shard, realm, contract, checksum = parse_from_string(contract_id_str)
 
-                contract_id: ContractId =  cls(
+                contract_id: ContractId = cls(
                     shard=int(shard),
                     realm=int(realm),
                     contract=int(contract)
@@ -102,16 +136,29 @@ class ContractId:
 
     def __str__(self):
         """
-        Returns the string representation of the ContractId in the format 'shard.realm.contract'.
+        Returns the string representation of the ContractId.
+
+        Format will be 'shard.realm.contract' or 'shard.realm.evm_address_hex'
+        if evm_address is set. Does not include a checksum.
+
+        Returns:
+            str: The string representation of the ContractId.
         """
         if self.evm_address is not None:
             return f"{self.shard}.{self.realm}.{self.evm_address.hex()}"
-        
+
         return f"{self.shard}.{self.realm}.{self.contract}"
 
     def to_evm_address(self) -> str:
         """
-        Converts the ContractId to an EVM address.
+        Converts the ContractId to a 20-byte EVM address string (hex).
+
+        If the `evm_address` attribute is set, it returns that.
+        Otherwise, it computes the 20-byte EVM address from the shard, realm,
+        and contract numbers (e.g., [4-byte shard][8-byte realm][8-byte contract]).
+
+        Returns:
+            str: The 20-byte EVM address as a hex-encoded string.
         """
         if self.evm_address is not None:
             return self.evm_address.hex()
@@ -127,7 +174,20 @@ class ContractId:
         return evm_bytes.hex()
 
     def validate_checksum(self, client: "Client") -> None:
-        """Validate the checksum for the contractId"""
+        """
+        Validates the checksum (if present) against a client's network.
+
+        The checksum is validated against the ledger ID of the provided client.
+        This method does nothing if no checksum is present on the ContractId.
+
+        Args:
+            client (Client): The client instance, which contains the network
+                ledger ID used for checksum validation.
+
+        Raises:
+            ValueError: If the checksum is present but invalid or does not
+                match the client's network.
+        """
         validate_checksum(
             self.shard,
             self.realm,
@@ -138,8 +198,20 @@ class ContractId:
 
     def to_string_with_checksum(self, client: "Client") -> str:
         """
-        Returns the string representation of the ContractId with checksum 
-        in 'shard.realm.contract-checksum' format.
+        Generates a string representation with a network-specific checksum.
+
+        Format: 'shard.realm.contract-checksum' (e.g., "0.0.123-vfmkw").
+
+        Args:
+            client (Client): The client instance used to generate the
+                network-specific checksum.
+
+        Returns:
+            str: The string representation with checksum.
+
+        Raises:
+            ValueError: If the ContractId has an `evm_address` set,
+                as checksums cannot be applied to EVM addresses.
         """
         if self.evm_address is not None:
             raise ValueError("to_string_with_checksum cannot be applied to ContractId with evm_address")


### PR DESCRIPTION
**Description**:
Adds comprehensive Google-style docstrings to the `ContractId` class and its methods to improve code clarity and documentation.

* Add module-level docstring to `contract_id.py`.
* Add Google-style class docstring for `ContractId`.
* Add Google-style method docstrings for all class methods.
* Update `CHANGELOG.md` with an entry for this change.

**Related issue(s)**:

Fixes #638

**Notes for reviewer**:
This is a documentation-only update as required by the issue. No functional code or logic was changed.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)