### PR TITLE
chore: Set env.example NETWORK to testnet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 OPERATOR_ID=<YOUR_OPERATOR_ID> #your private key, can be retrived from https://portal.hedera.com/dashboard
 OPERATOR_KEY=<YOUR_PRIVATE_KEY> # your account id, can be retrieved from https://portal.hedera.com/dashboard
-NETWORK=<NETWORK> #eg testnet/previewnet/mainnet
+NETWORK=testnet # the testnet hedera network
 
 # RECIPIENT_ID=<RECIPIENT_ID> #optional
 # RECIPIENT_KEY=<RECIPIENT_KEY>  #optional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - add AccountRecordsQuery class
 
 ### Changed
+
+- chore: Set env.example NETWORK to testnet as default to encourage test network usage (#659)
 - chore: validate that token airdrop transactions require an available token service on the channel (#632) 
 
 - chore: fix type hint for TokenCancelAirdropTransaction pending_airdrops parameter


### PR DESCRIPTION
Updated the NETWORK variable in .env.example to default to testnet to encourage developers to use the test network.

Resolves #659