### PR TITLE
chore: Use typing.NamedTuple for Operator in client.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,11 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - chore: Update env.example NETWORK to encourage testnet or local usage (#659)
 - chore: fix type hint for TokenCancelAirdropTransaction pending_airdrops parameter
 - chore: Moved documentation file `common_issues.md` from `examples/sdk_developers/` to `docs/sdk_developers/` for unified documentation management (#516).
+
 - chore: Refactored the script of examples/custom_fee.py into modular functions 
+
+- fix: Replaced `collections.namedtuple` with `typing.NamedTuple` in `client.py` for improved type checking.
+
 
 ### Fixed
 

--- a/src/hiero_sdk_python/client/client.py
+++ b/src/hiero_sdk_python/client/client.py
@@ -2,8 +2,7 @@
 Client module for interacting with the Hedera network.
 """
 
-from collections import namedtuple
-from typing import List, Union
+from typing import NamedTuple, List, Union
 
 import grpc
 
@@ -18,7 +17,10 @@ from hiero_sdk_python.crypto.private_key import PrivateKey
 
 from .network import Network
 
-Operator = namedtuple('Operator', ['account_id', 'private_key'])
+class Operator(NamedTuple):
+    """A named tuple for the operator's account ID and private key."""
+    account_id: AccountId
+    private_key: PrivateKey
 
 class Client:
     """


### PR DESCRIPTION
**Description**:

This PR refactors `client.py` to use `typing.NamedTuple` instead of `collections.namedtuple` for the `Operator` class. This improves type checking support.

* Removed `collections.namedtuple` import.
* Replaced `Operator = namedtuple(...)` with `class Operator(NamedTuple):...`
---
**Related issue(s)**:

Fixes #665 
---
**Checklist**

- [x] Documented (Added docstring to new class)
- [x] Tested (This is a type-only refactor, no logic change)