### PR TITLE
fix: Resolve __eq__ type conflict in CustomFee class (#627)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 - Added explicit read permissions to examples.yml (#623)
 - Improved type hinting in `file_append_transaction.py` to resolve 'mypy --strict` errors. ([#495](https://github.com/hiero-ledger/hiero-sdk-python/issues/495))
+- fix: Resolve `__eq__` type conflict in `CustomFee` class (#627)
 
 ### Breaking Changes
 

--- a/src/hiero_sdk_python/tokens/custom_fee.py
+++ b/src/hiero_sdk_python/tokens/custom_fee.py
@@ -60,6 +60,9 @@ class CustomFee(ABC):
     def _validate_checksums(self, client: Client) -> None:
         if self.fee_collector_account_id is not None:
             self.fee_collector_account_id.validate_checksum(client)
-            
-    def __eq__(self, other: "CustomFee") -> bool:
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, CustomFee):
+            return NotImplemented
+        
         return self.fee_collector_account_id == other.fee_collector_account_id and self.all_collectors_are_exempt == other.all_collectors_are_exempt


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->
Resolves a Python type conflict in the `CustomFee` class `__eq__` method, as described in issue #627.

* Change `__eq__` parameter type from `CustomFee` to `object` to match the base class.
* Add `isinstance` check inside `__eq__` for type-safe comparison.
* Update `CHANGELOG.md` with an entry for this fix.

**Related issue(s)**:

Fixes #627

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
This is a fresh PR to replace #654. This new branch contains a single, signed ("Verified") commit with the fix and changelog update, resolving the previous "unverified commit" issue from the merge.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)