### PR TITLE
fix: Use SDK TokenType enum instead of protobuf in examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - fix: Resolve `__eq__` type conflict in `CustomFee` class (#627)
 - Fixes a type conflict in `token_id.py` where `from_string` could receive `None`, preventing a runtime error by raising a `ValueError` if the input is missing. #630
 - Dependabot alerts (version bumps)
+- Fixed incorrect `TokenType` import (protobuf vs. SDK enum) in 18 example files.
   
 ### Breaking Changes
 - chore: changed the file names airdrop classes (#631)

--- a/examples/query_account_info.py
+++ b/examples/query_account_info.py
@@ -21,7 +21,7 @@ from hiero_sdk_python.tokens.token_create_transaction import TokenCreateTransact
 from hiero_sdk_python.tokens.token_associate_transaction import TokenAssociateTransaction
 from hiero_sdk_python.tokens.token_grant_kyc_transaction import TokenGrantKycTransaction
 from hiero_sdk_python.tokens.supply_type import SupplyType
-from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenType
+from hiero_sdk_python.tokens.token_type import TokenType
 from hiero_sdk_python.tokens.token_mint_transaction import TokenMintTransaction
 from hiero_sdk_python.tokens.nft_id import NftId
 

--- a/examples/query_nft_info.py
+++ b/examples/query_nft_info.py
@@ -13,7 +13,7 @@ from hiero_sdk_python import (
     PrivateKey,
     Network,
 )
-from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenType
+from hiero_sdk_python.tokens.token_type import TokenType
 from hiero_sdk_python.query.token_nft_info_query import TokenNftInfoQuery
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.nft_id import NftId

--- a/examples/query_payment.py
+++ b/examples/query_payment.py
@@ -13,7 +13,7 @@ from hiero_sdk_python import (
     PrivateKey,
     Network,
 )
-from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenType
+from hiero_sdk_python.tokens.token_type import TokenType
 from hiero_sdk_python.query.account_balance_query import CryptoGetAccountBalanceQuery
 from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.query.token_info_query import TokenInfoQuery

--- a/examples/query_token_info_fungible.py
+++ b/examples/query_token_info_fungible.py
@@ -14,7 +14,7 @@ from hiero_sdk_python import (
     PrivateKey,
     Network,
 )
-from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenType
+from hiero_sdk_python.tokens.token_type import TokenType
 from hiero_sdk_python.query.token_info_query import TokenInfoQuery
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.supply_type import SupplyType

--- a/examples/query_token_info_nft.py
+++ b/examples/query_token_info_nft.py
@@ -14,7 +14,7 @@ from hiero_sdk_python import (
     PrivateKey,
     Network,
 )
-from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenType
+from hiero_sdk_python.tokens.token_type import TokenType
 from hiero_sdk_python.query.token_info_query import TokenInfoQuery
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.supply_type import SupplyType

--- a/examples/token_burn_fungible.py
+++ b/examples/token_burn_fungible.py
@@ -13,7 +13,7 @@ from hiero_sdk_python import (
     PrivateKey,
     Network,
 )
-from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenType
+from hiero_sdk_python.tokens.token_type import TokenType
 from hiero_sdk_python.query.token_info_query import TokenInfoQuery
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.supply_type import SupplyType

--- a/examples/token_burn_nft.py
+++ b/examples/token_burn_nft.py
@@ -13,7 +13,7 @@ from hiero_sdk_python import (
     PrivateKey,
     Network,
 )
-from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenType
+from hiero_sdk_python.tokens.token_type import TokenType
 from hiero_sdk_python.query.token_info_query import TokenInfoQuery
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.supply_type import SupplyType

--- a/examples/token_grant_kyc.py
+++ b/examples/token_grant_kyc.py
@@ -14,7 +14,7 @@ from hiero_sdk_python import (
     Network,
 )
 from hiero_sdk_python.account.account_create_transaction import AccountCreateTransaction
-from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenType
+from hiero_sdk_python.tokens.token_type import TokenType
 from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.supply_type import SupplyType

--- a/examples/token_reject_fungible_token.py
+++ b/examples/token_reject_fungible_token.py
@@ -15,7 +15,7 @@ from hiero_sdk_python import (
     TransferTransaction,
 )
 from hiero_sdk_python.account.account_create_transaction import AccountCreateTransaction
-from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenType
+from hiero_sdk_python.tokens.token_type import TokenType
 from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.query.account_balance_query import CryptoGetAccountBalanceQuery
 from hiero_sdk_python.response_code import ResponseCode

--- a/examples/token_reject_nft.py
+++ b/examples/token_reject_nft.py
@@ -15,7 +15,7 @@ from hiero_sdk_python import (
     TransferTransaction,
 )
 from hiero_sdk_python.account.account_create_transaction import AccountCreateTransaction
-from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenType
+from hiero_sdk_python.tokens.token_type import TokenType
 from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.query.account_balance_query import CryptoGetAccountBalanceQuery
 from hiero_sdk_python.response_code import ResponseCode

--- a/examples/token_revoke_kyc.py
+++ b/examples/token_revoke_kyc.py
@@ -14,7 +14,7 @@ from hiero_sdk_python import (
     Network,
 )
 from hiero_sdk_python.account.account_create_transaction import AccountCreateTransaction
-from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenType
+from hiero_sdk_python.tokens.token_type import TokenType
 from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.supply_type import SupplyType

--- a/examples/token_update_fungible.py
+++ b/examples/token_update_fungible.py
@@ -13,7 +13,7 @@ from hiero_sdk_python import (
     PrivateKey,
     Network,
 )
-from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenType
+from hiero_sdk_python.tokens.token_type import TokenType
 from hiero_sdk_python.query.token_info_query import TokenInfoQuery
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.supply_type import SupplyType

--- a/examples/token_update_key.py
+++ b/examples/token_update_key.py
@@ -14,7 +14,7 @@ from hiero_sdk_python import (
     PrivateKey,
     Network,
 )
-from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenType
+from hiero_sdk_python.tokens.token_type import TokenType
 from hiero_sdk_python.query.token_info_query import TokenInfoQuery
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.token_key_validation import TokenKeyValidation

--- a/examples/token_update_nft.py
+++ b/examples/token_update_nft.py
@@ -13,7 +13,7 @@ from hiero_sdk_python import (
     PrivateKey,
     Network,
 )
-from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenType
+from hiero_sdk_python.tokens.token_type import TokenType
 from hiero_sdk_python.query.token_info_query import TokenInfoQuery
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.supply_type import SupplyType

--- a/examples/token_update_nfts.py
+++ b/examples/token_update_nfts.py
@@ -13,7 +13,7 @@ from hiero_sdk_python import (
     PrivateKey,
     Network,
 )
-from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenType
+from hiero_sdk_python.tokens.token_type import TokenType
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.nft_id import NftId
 from hiero_sdk_python.tokens.supply_type import SupplyType

--- a/examples/transfer_nft.py
+++ b/examples/transfer_nft.py
@@ -15,7 +15,7 @@ from hiero_sdk_python import (
     TransferTransaction,
 )
 from hiero_sdk_python.account.account_create_transaction import AccountCreateTransaction
-from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenType
+from hiero_sdk_python.tokens.token_type import TokenType
 from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.nft_id import NftId

--- a/tests/integration/token_create_transaction_e2e_test.py
+++ b/tests/integration/token_create_transaction_e2e_test.py
@@ -3,7 +3,7 @@ import pytest
 
 from hiero_sdk_python.Duration import Duration
 from hiero_sdk_python.crypto.private_key import PrivateKey
-from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenType
+from hiero_sdk_python.tokens.token_type import TokenType
 from hiero_sdk_python.query.token_info_query import TokenInfoQuery
 from hiero_sdk_python.timestamp import Timestamp
 from hiero_sdk_python.tokens.token_create_transaction import TokenCreateTransaction, TokenParams

--- a/tests/integration/utils_for_test.py
+++ b/tests/integration/utils_for_test.py
@@ -7,7 +7,7 @@ from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.client.client import Client
 from hiero_sdk_python.client.network import Network
 from hiero_sdk_python.crypto.private_key import PrivateKey
-from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenType
+from hiero_sdk_python.tokens.token_type import TokenType
 from hiero_sdk_python.logger.log_level import LogLevel
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.supply_type import SupplyType


### PR DESCRIPTION
**Description**:

This PR fixes issue #726, where multiple example files were incorrectly importing the Protobuf-generated `TokenType` instead of the SDK's Python `TokenType` enum.

This change replaces:
`from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenType`

with the correct SDK-level import:
`from hiero_sdk_python.tokens.token_type import TokenType`

This fix was applied to 18 example files to ensure they all use the correct enum.

---

**Related issue(s)**:

Fixes #726 

---

**Checklist**

- [x] Documented (Updated CHANGELOG.md)
- [x] Tested (This is a direct import fix)