### PR TITLE
chore: response code example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 ## [Unreleased]
 
 ### Added
+- `is_unknown` property added to `src/hiero_sdk_python/response_code.py`
+- Example `response_code.py`
 - Add `TokenFeeScheduleUpdateTransaction` class to support updating custom fee schedules on tokens (#471).
 - Add `examples/token_update_fee_schedule_fungible.py` and `examples/token_update_fee_schedule_nft.py` demonstrating the use of `TokenFeeScheduleUpdateTransaction`.
 - Update `docs/sdk_users/running_examples.md` to include `TokenFeeScheduleUpdateTransaction`.

--- a/examples/response_code.py
+++ b/examples/response_code.py
@@ -1,0 +1,50 @@
+from hiero_sdk_python import ResponseCode
+
+# Mock of a transaction receipt object
+class TransactionReceipt:
+    def __init__(self, status_code: int):
+        self.status = status_code
+
+def response_code(receipt: "TransactionReceipt"):
+    status_code = ResponseCode(receipt.status)
+    print(f"The response code is {status_code}")
+
+    if status_code == ResponseCode.SUCCESS:
+        print("✅ Transaction succeeded!")
+    elif status_code.is_unknown:
+        print(f"❓ Unknown transaction status: {status_code}")
+    else:
+        print("❌ Transaction failed!")
+
+def response_name(receipt: "TransactionReceipt"):
+    status_code = ResponseCode(receipt.status)
+    status_name = status_code.name
+    print(f"The response name is {status_name}")
+
+    if status_name == ResponseCode.SUCCESS.name:
+        print("✅ Transaction succeeded!")
+    elif status_code.is_unknown:
+        print(f"❓ Unknown transaction status: {status_name}")
+    else:
+        print("❌ Transaction failed!")
+
+def main():
+    print("=== Receipt Status Demo ===\n")
+
+    # Example 1: Transaction receipt is (SUCCESS)
+    receipt_success = TransactionReceipt(ResponseCode.SUCCESS)
+    response_code(receipt_success)
+    response_name(receipt_success)
+
+    # Example 2: Transaction receipt is (INVALID_SIGNATURE)
+    receipt_invalid_signature = TransactionReceipt(ResponseCode.INVALID_SIGNATURE)
+    response_code(receipt_invalid_signature)
+    response_name(receipt_invalid_signature)
+
+    # Example 3: Unknown status (e.g., 999)
+    receipt_unknown_status = TransactionReceipt(999)
+    response_code(receipt_unknown_status)
+    response_name(receipt_unknown_status)
+
+if __name__ == "__main__":
+    main()

--- a/src/hiero_sdk_python/response_code.py
+++ b/src/hiero_sdk_python/response_code.py
@@ -362,7 +362,11 @@ class ResponseCode(IntEnum):
         unknown._name_ = f'UNKNOWN_CODE_{value}'
         unknown._value_ = value
         return unknown
-    
+
+    @property
+    def is_unknown(self) -> bool:
+        return self.name.startswith("UNKNOWN_CODE_")
+
     @classmethod
     def get_name(cls,code: int) -> str:
         """


### PR DESCRIPTION
Creates a missing property and demonstrates response code using .value and .name on the enum

Fixes #
https://github.com/hiero-ledger/hiero-sdk-python/issues/765
