### PR TITLE
chore: add localhost and local as network names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Dependabot alerts (version bumps)
 - Fixed incorrect `TokenType` import (protobuf vs. SDK enum) in 18 example files.
 - Update `schedule_sign_transaction_e2e_test` to check for key presence instead of relying on index.
+- Add `localhost` and `local` as network names
   
 ### Breaking Changes
 - chore: changed the file names airdrop classes (#631)

--- a/src/hiero_sdk_python/client/network.py
+++ b/src/hiero_sdk_python/client/network.py
@@ -59,6 +59,12 @@ class Network:
         'solo': [
             ("localhost:50211", AccountId(0, 0, 3))
         ],
+        'localhost': [
+            ("localhost:50211", AccountId(0, 0, 3))
+        ],
+        'local': [
+            ("localhost:50211", AccountId(0, 0, 3))
+        ],
     }
 
     LEDGER_ID: Dict[str, bytes] = {


### PR DESCRIPTION
**Description**:
enable 'localhost' and 'local' as network names in the `network.py`

Fixes #767 