### PR TITLE
feat: add concurrency to workflow bot

### DIFF
--- a/.github/workflows/bot-workflows.yml
+++ b/.github/workflows/bot-workflows.yml
@@ -11,6 +11,9 @@ on:
 permissions:
   contents: read
   pull-requests: write
+concurrency:
+  group: "workflow-failure-${{ github.event.workflow_run.head_branch }}"
+  cancel-in-progress: true
 jobs:
   notify-pr:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - fix: Allow `max_automatic_token_associations` to be set to -1 (unlimited) in `AccountCreateTransaction` and add field to `AccountInfo`.
 - Allow `PrivateKey` to be used for keys in `TopicCreateTransaction` for consistency.
 - Update github actions checkout from 5.0.0 to 5.0.1 (#814)
+- changed to add concurrency to workflow bot
 
 ### Fixed
 - chore: fix test.yml workflow to log import errors (#740)


### PR DESCRIPTION
Adds concurrency to attempt workflow bot to not re-trigger each time while it is loading

**Related issue(s)**:

Fixes # https://github.com/hiero-ledger/hiero-sdk-python/issues/842

