### PR TITLE
ci: switch verification workflow to pull_request_target

### DIFF
--- a/.github/workflows/bot-verified-commits.yml
+++ b/.github/workflows/bot-verified-commits.yml
@@ -22,10 +22,7 @@ jobs:
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
-
-      - name: Checkout repository
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-
+      
       - name: Check for unverified commits
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+-Removed `actions/checkout@v4` from `bot-verified-commits.yml`
+
 - Add comprehensive documentation for `ReceiptStatusError` in `docs/sdk_developers/training/receipt_status_error.md`
 - Add practical example `examples/errors/receipt_status_error.py` demonstrating transaction error handling
 - Document error handling patterns and best practices for transaction receipts


### PR DESCRIPTION
**Description**:

This PR updates the workflow trigger from pull_request to pull_request_target so that the verification bot can run with the required permissions for forked PRs.
Additionally, it adds the necessary issues: write permission to allow the bot to post comments without triggering the “Resource not accessible by integration (addComment)” error.


**Related issue(s)**:
[Issue 859](https://github.com/hiero-ledger/hiero-sdk-python/issues/859)

Fixes #

`pull_request` to `pull_request_target`
Added issues: write permission to GitHub Actions workflow

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
