### PR TITLE
chore: Release 0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+## [0.1.9] - 2025-11-26
+
 ### Added
 
--Removed `actions/checkout@v4` from `bot-verified-commits.yml`
-
+- Removed `actions/checkout@v4` from `bot-verified-commits.yml`
 - Add comprehensive documentation for `ReceiptStatusError` in `docs/sdk_developers/training/receipt_status_error.md`
 - Add practical example `examples/errors/receipt_status_error.py` demonstrating transaction error handling
 - Document error handling patterns and best practices for transaction receipts
-
 - fix `pull_request` to `pull_request_target` in `bot-verified-commits.yml`
 - Add more robust receipt checks and removed fallback to `examples/tokens/token_delete_transaction.py`
 - Add detail to `token_airdrop.py` and `token_airdrop_cancel.py`


### PR DESCRIPTION
This release adds several new features including BatchTransaction support, token metadata capabilities, and improved transaction APIs. It also includes numerous documentation improvements and new examples.

**New Features**
  - BatchTransaction class - New class for batching multiple transactions together (#811)
  - Token metadata support - Added set_metadata setter to TokenCreateTransaction for token metadata (max 100 bytes) (#866)
  - Hbar floating-point support - Improved Hbar class with HbarUnit to handle floating-point values (#737)
  - TokenAssociateTransaction enhancements - Added set_token_ids, _from_proto, _validate_checksum methods (#846)
  - TokenDissociateTransaction refactor - Now uses set_token_ids method with updated transaction fees (#830)
  - AccountCreateTransaction fields - Added alias, staked_account_id, staked_node_id, decline_staking_reward, and EvmAddress class (#779)
  - PublicKey support for keys - Allow PublicKey (not just PrivateKey) for TokenCreateTransaction and TopicCreateTransaction keys (#754, #809)

**Documentation & Examples**
  - Added ReceiptStatusError documentation and example for transaction error handling (#883)
  - Added Hedera Network guide (#874)
  - New examples: topic_info.py, topic_message.py, topic_id.py, account_info.py, account_balance_query.py
  - Token key examples: admin_key, supply_key, wipe_key, freeze_key, kyc_key, fee_schedule_key
  - Split account_allowance_nft.py into separate approve/delete examples (#781)
  - Added training documentation for transaction receipts
  - Added network_and_client.md guide with external example scripts

**Bug Fixes**
  - Fixed max_automatic_token_associations to allow -1 (unlimited) (#793)
  - Fixed staked node ID issue in account_create_transaction_e2e_test (#828)
  - Fixed KYC token example (#854)

**CI/CD Improvements**
  - Added verification bot for unverified PR commits (#756)
  - Added failed workflow notification bot (#758)
  - Upgraded dependencies: actions/checkout 5.0.0 → 6.0.0, step-security/harden-runner → 2.13.2, actions/setup-python 6.0.0 → 6.1.0