### PR TITLE
feat: Add automated merge conflict detection bot

### DIFF
--- a/.github/workflows/merge-conflict-bot.yml
+++ b/.github/workflows/merge-conflict-bot.yml
@@ -24,7 +24,7 @@ jobs:
       
       - name: Check for merge conflicts
         env:
-          GH_TOKEN: ${{ secrets.TEST_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
           REPO="${{ github.repository }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 - Add example demonstrating usage of `CustomFeeLimit` in `examples/transaction/custom_fee_limit.py`
+- Added `.github/workflows/merge-conflict-bot.yml` to automatically detect and notify users of merge conflicts in Pull Requests.
   
 ### Changed
 
@@ -53,7 +54,6 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Added `docs\sdk_developers\training\receipts.md` as a training guide for users to understand hedera receipts.
 - Add `set_token_ids`, `_from_proto`, `_validate_checksum` to TokenAssociateTransaction [#795]
 - docs: added `network_and_client.md` with a table of contents, and added external example scripts (`client.py`).
-- Added `.github/workflows/bot-merge-conflicts.yml` to automatically detect and notify users of merge conflicts in Pull Requests. 
 
 ### Changed
 


### PR DESCRIPTION


**Description**:
This PR adds a new GitHub Action workflow `.github/workflows/bot-merge-conflicts.yml` to improve the contributor experience. It automatically detects if a Pull Request has merge conflicts preventing it from being merged and posts a helpful comment guiding the user to relevant resolution documentation.

  * Add `.github/workflows/bot-merge-conflicts.yml`
  * Implement check for `mergeable_state` to detect "dirty" (conflicted) PRs
  * automated comment posting (limited to one comment per PR to avoid spam)
  * Align bot styling and security settings (`harden-runner`) with existing `bot-verified-commits.yml`

---

**Related issue(s)**:

Fixes #894 

---


**Checklist**

  - [x] Documented (Code comments, README, etc.)
  - [x] Tested (unit, integration, etc.)

-----
