### PR TITLE
chore: update bot workflow for new changelog entry

### DIFF
--- a/.github/workflows/bot-workflows.yml
+++ b/.github/workflows/bot-workflows.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows:
       - "PR Formatting"
+      - "PR Changelog Check"
       - "Hiero Solo Integration Tests"
       - "Run Examples"
     types:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Added validation logic in `.github/workflows/pr-checks.yml` to detect when no new chnagelog entries are added under [Unreleased]
 
 ### Changed
-
+- bot workflows to include new changelog entry
 - Removed duplicate import of transaction_pb2 in transaction.py
 
 ### Fixed


### PR DESCRIPTION
I think we need to update the workflow bot, because the PR check now has been split in two
However, added this separately to check the changelog cehck is working ok
