### PR TITLE
fix: Reorganize examples to mirror src structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - bot workflows to include new changelog entry
 - Removed duplicate import of transaction_pb2 in transaction.py
 - feat: Add string representation method for `CustomFractionalFee` class and update `custom_fractional_fee.py` example.
+- Moved query examples to their respective domain folders to improve structure matching.
 
 ### Fixed
 - fixed workflow: changelog check with improved sensitivity to deletions, additions, new releases

--- a/examples/account/account_records_query.py
+++ b/examples/account/account_records_query.py
@@ -1,7 +1,7 @@
 """
 Example demonstrating account records query on the network.
-uv run examples/query/account_records_query.py
-python examples/query/account_records_query.py
+uv run examples/account/account_records_query.py
+python examples/account/account_records_query.py
 """
 
 import os

--- a/examples/file/file_contents_query.py
+++ b/examples/file/file_contents_query.py
@@ -1,7 +1,7 @@
 """
 This example demonstrates how to query file contents using the Python SDK.
-uv run examples/query/file_contents_query.py
-python examples/query/file_contents_query.py
+uv run examples/file/file_contents_query.py
+python examples/file/file_contents_query.py
 """
 
 import os

--- a/examples/file/file_info_query.py
+++ b/examples/file/file_info_query.py
@@ -1,7 +1,7 @@
 """
 This example demonstrates how to query file info using the Python SDK.
-uv run examples/query/file_info_query.py
-python examples/query/file_info_query.py
+uv run examples/file/file_info_query.py
+python examples/file/file_info_query.py
 """
 
 import os

--- a/examples/schedule/schedule_info_query.py
+++ b/examples/schedule/schedule_info_query.py
@@ -1,7 +1,7 @@
 """
 Example demonstrating schedule info query on the network.
-uv run examples/query/schedule_info_query.py
-python examples/query/schedule_info_query.py
+uv run examples/schedule/schedule_info_query.py
+python examples/schedule/schedule_info_query.py
 """
 
 import datetime


### PR DESCRIPTION
**Description**:
This PR moves several example scripts from the generic `examples/query/` directory to domain-specific directories (`examples/account/`, `examples/file/`, `examples/schedule/`). This structural change ensures that `scripts/examples/match_examples_src.py` correctly identifies these examples as existing counterparts to their source files, properly solving the "missing examples" false positives.

---

**Related issue(s)**:

Fixes #880 

**Notes for reviewer**:
I verified the fix by running `python scripts/examples/match_examples_src.py`. The moved files are now correctly matched with their `src/` counterparts and no longer appear in the "Unmatched src files" list. 

Though its working but i didn't change any of those code of  `match_examples_src.py` file.

---

**Checklist**

  - [x] Documented (Code comments, README, etc.)
  - [x] Tested (unit, integration, etc.)

