### PR TITLE
feat(account): improve NFT allowance deletion with receipt checks and strict verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,23 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- Added Improved NFT allowance deletion flow with receipt-based status checks and strict `SPENDER_DOES_NOT_HAVE_ALLOWANCE` verification.
 - Add `max_automatic_token_associations`, `staked_account_id`, `staked_node_id` and `decline_staking_reward` fields to `AccountUpdateTransaction` (#801)
 - Added docs/sdk_developers/training/setup: a training to set up as a developer to the python sdk
 - Add example demonstrating usage of `CustomFeeLimit` in `examples/transaction/custom_fee_limit.py`
 - Added `.github/workflows/merge-conflict-bot.yml` to automatically detect and notify users of merge conflicts in Pull Requests.
-- Added `.github/workflows/bot-office-hours.yml` to automate the Weekly Office Hour Reminder.  
+- Added `.github/workflows/bot-office-hours.yml` to automate the Weekly Office Hour Reminder.
 - feat: Implement account creation with EVM-style alias transaction example.
 - Added validation logic in `.github/workflows/pr-checks.yml` to detect when no new chnagelog entries are added under [Unreleased]
 
 ### Changed
+
 - bot workflows to include new changelog entry
 - Removed duplicate import of transaction_pb2 in transaction.py
 - feat: Add string representation method for `CustomFractionalFee` class and update `custom_fractional_fee.py` example.
 
 ### Fixed
+
 - fixed workflow: changelog check with improved sensitivity to deletions, additions, new releases
 
 ## [0.1.9] - 2025-11-26


### PR DESCRIPTION
**Description**:
Refactored NFT allowance deletion example with full try/except handling, explicit receipt-status validation, improved error messages, and stricter verification of `SPENDER_DOES_NOT_HAVE_ALLOWANCE`.

**Related issue(s)**:

Fixes #875 


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
