### PR TITLE
Updating transaction_response.py with new content

### DIFF
--- a/transaction_response.py
+++ b/transaction_response.py
@@ -1,0 +1,56 @@
+"""
+transaction_response.py
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Represents the response from a transaction submitted to the Hedera network.
+Provides methods to retrieve the receipt and access core transaction details.
+"""
+from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.transaction.transaction_id import TransactionId
+from hiero_sdk_python.exceptions import ReceiptStatusError
+# pylint: disable=too-few-public-methods
+
+class TransactionResponse:
+    """
+    Represents the response from a transaction submitted to the Hedera network.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initialize a new TransactionResponse instance with default values.
+        """
+        self.transaction_id = TransactionId()
+        self.node_id: AccountId = AccountId()
+        self.hash: bytes = bytes()
+        self.validate_status: bool = False
+        self.transaction = None
+
+    def get_receipt(self, client):
+        """
+        Retrieves the receipt for this transaction from the Hedera network.
+
+        Args:
+            client (Client): The client instance to use for receipt retrieval
+
+        Returns:
+            TransactionReceipt: The receipt from the network, containing the status
+                               and any entities created by the transaction
+
+        Raises:
+            ReceiptStatusError: If the receipt status is not SUCCESS
+        """
+        # TODO: Decide how to avoid circular imports
+        from hiero_sdk_python.query.transaction_get_receipt_query import TransactionGetReceiptQuery
+        # TODO: Implement set_node_account_ids() to get failure reason for preHandle failures
+        receipt = (
+            TransactionGetReceiptQuery()
+            .set_transaction_id(self.transaction_id)
+            .execute(client)
+        )
+
+        # Validate the receipt status and raise ReceiptStatusError if not SUCCESS
+        if receipt.status != ResponseCode.SUCCESS:
+            raise ReceiptStatusError(receipt.status, self.transaction_id, receipt)
+
+        return receipt


### PR DESCRIPTION
### 1. **Updated `transaction_response. py`**
Mdified the `get_receipt()` method in `src/hiero_sdk_python/transaction/transaction_response.py` to:
- Import `ResponseCode` and `ReceiptStatusError`
- Validate the receipt status after retrieval
- **Raise `ReceiptStatusError`** when the receipt status is not `SUCCESS`
- Updated the docstring to document this behavior

**Key change:**
```python
# Validate the receipt status and raise ReceiptStatusError if not SUCCESS
if receipt. status != ResponseCode.SUCCESS:
    raise ReceiptStatusError(receipt.status, self.transaction_id, receipt)
```

### 2. **Example File Already Exists**
The example file at `examples/errors/receipt_status_error.py` already exists in the repository and demonstrates exactly how to handle `ReceiptStatusError`:
```python
except ReceiptStatusError as e:
    print(f"Transaction reached consensus but failed: {e}")
```

### 3. This Fixes

- The `execute()` method in `transaction. py` now **properly raises `ReceiptStatusError`** as documented in its docstring
- Users can now catch receipt status errors that occur after consensus is reached
- Transactions that fail post-consensus (e.g., insufficient funds, token supply full) will now properly raise an exception instead of silently returning a failed receipt.

**Related issue(s)**:

Fixes #930 


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
