### PR TITLE
fix: raise ReceiptStatusError when receipt status is not SUCCESS

### DIFF
--- a/transaction_response.py
+++ b/transaction_response.py
@@ -1,0 +1,56 @@
+"""
+transaction_response.py
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Represents the response from a transaction submitted to the Hedera network.
+Provides methods to retrieve the receipt and access core transaction details.
+"""
+from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.transaction.transaction_id import TransactionId
+from hiero_sdk_python.exceptions import ReceiptStatusError
+# pylint: disable=too-few-public-methods
+
+class TransactionResponse:
+    """
+    Represents the response from a transaction submitted to the Hedera network.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initialize a new TransactionResponse instance with default values.
+        """
+        self.transaction_id = TransactionId()
+        self.node_id: AccountId = AccountId()
+        self.hash: bytes = bytes()
+        self.validate_status: bool = False
+        self.transaction = None
+
+    def get_receipt(self, client):
+        """
+        Retrieves the receipt for this transaction from the Hedera network.
+
+        Args:
+            client (Client): The client instance to use for receipt retrieval
+
+        Returns:
+            TransactionReceipt: The receipt from the network, containing the status
+                               and any entities created by the transaction
+
+        Raises:
+            ReceiptStatusError: If the receipt status is not SUCCESS
+        """
+        # TODO: Decide how to avoid circular imports
+        from hiero_sdk_python.query.transaction_get_receipt_query import TransactionGetReceiptQuery
+        # TODO: Implement set_node_account_ids() to get failure reason for preHandle failures
+        receipt = (
+            TransactionGetReceiptQuery()
+            .set_transaction_id(self.transaction_id)
+            .execute(client)
+        )
+
+        # Validate the receipt status and raise ReceiptStatusError if not SUCCESS
+        if receipt.status != ResponseCode.SUCCESS:
+            raise ReceiptStatusError(receipt.status, self.transaction_id, receipt)
+
+        return receipt


### PR DESCRIPTION
**Description**:
Update `get_receipt()` to validate transaction status and raise an exception on failure, ensuring alignment with SDK documentation and expected behavior.

  * Import `ResponseCode` and `ReceiptStatusError` in `transaction_response.py`
  * Update `get_receipt()` to raise `ReceiptStatusError` when receipt status is not `SUCCESS`
  * Update docstrings to reflect that `ReceiptStatusError` is raised

**Related issue(s)**:

Fixes #930

**Notes for reviewer**:
The `execute()` method in `transaction.py` relies on `get_receipt()` to finalize the transaction. Previously, it would return a receipt even if the consensus status was a failure (e.g., `INSUFFICIENT_PAYER_BALANCE`), requiring manual status checks by the user.

With this change, the SDK proactively raises `ReceiptStatusError` on failure. I verified that the existing example at `examples/errors/receipt_status_error.py` now functions as intended, catching the error as shown below:

```python
except ReceiptStatusError as e:
    print(f"Transaction reached consensus but failed: {e}")
```

**Checklist**

  - [x] Documented (Code comments, README, etc.)
  - [x] Tested (unit, integration, etc.)