### PR TITLE
refactor(examples): modularize transaction_to_bytes example (issue #1012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Added `docs/sdk_developers/training/transaction_lifecycle.md` to explain the typical lifecycle of executing a transaction using the Hedera Python SDK.
 - Add inactivity bot workflow to unassign stale issue assignees (#952)
 - Made custom fraction fee end to end
+- feat: AccountCreateTransaction now supports both PrivateKey and PublicKey [#939](https://github.com/hiero-ledger/hiero-sdk-python/issues/939)
 - Added Acceptance Criteria section to Good First Issue template for better contributor guidance (#997)
 - Added __str__() to CustomRoyaltyFee and updated examples and tests accordingly (#986)
 

--- a/examples/account/account_create_transaction_create_with_alias.py
+++ b/examples/account/account_create_transaction_create_with_alias.py
@@ -1,0 +1,132 @@
+"""
+Example: Create an account using a separate ECDSA key for the EVM alias.
+
+This demonstrates:
+- Using a "main" key for the account
+- Using a separate ECDSA public key as the EVM alias
+- The need to sign the transaction with the alias private key
+
+Usage:
+- uv run -m examples.account.account_create_transaction_create_with_alias
+- python -m examples.account.account_create_transaction_create_with_alias
+(we use -m because we use the util `info_to_dict`)
+"""
+
+import os
+import sys
+import json
+from dotenv import load_dotenv
+
+from examples.utils import info_to_dict
+
+from hiero_sdk_python import (
+    Client,
+    PrivateKey,
+    AccountCreateTransaction,
+    AccountInfoQuery,
+    Network,
+    AccountId,
+    Hbar,
+)
+
+load_dotenv()
+network_name = os.getenv("NETWORK", "testnet").lower()
+
+
+def setup_client():
+    """Setup Client."""
+    network = Network(network_name)
+    print(f"Connecting to Hedera {network_name} network!")
+    client = Client(network)
+
+    try:
+        operator_id = AccountId.from_string(os.getenv("OPERATOR_ID", ""))
+        operator_key = PrivateKey.from_string(os.getenv("OPERATOR_KEY", ""))
+        client.set_operator(operator_id, operator_key)
+        print(f"Client set up with operator id {client.operator_account_id}")
+        return client
+    except Exception:
+        print("Error: Please check OPERATOR_ID and OPERATOR_KEY in your .env file.")
+        sys.exit(1)
+
+def create_account_with_separate_ecdsa_alias(client: Client) -> None:
+    """Create an account whose alias comes from a separate ECDSA key."""
+    try:
+        print("\nSTEP 1: Generating main account key and separate ECDSA alias key...")
+
+        # Main account key (can be any key type, here ed25519)
+        main_private_key = PrivateKey.generate()
+        main_public_key = main_private_key.public_key()
+
+        # Separate ECDSA key used only for the EVM alias
+        alias_private_key = PrivateKey.generate("ecdsa")
+        alias_public_key = alias_private_key.public_key()
+        alias_evm_address = alias_public_key.to_evm_address()
+
+        if alias_evm_address is None:
+            print("❌ Error: Failed to generate EVM address from alias ECDSA key.")
+            sys.exit(1)
+
+        print(f"✅ Main account public key:  {main_public_key}")
+        print(f"✅ Alias ECDSA public key:   {alias_public_key}")
+        print(f"✅ Alias EVM address:        {alias_evm_address}")
+
+        print("\nSTEP 2: Creating the account with the EVM alias from the ECDSA key...")
+
+        # Use the helper that accepts both the main key and the ECDSA alias key
+        transaction = (
+            AccountCreateTransaction(
+                initial_balance=Hbar(5),
+                memo="Account with separate ECDSA alias",
+            )
+            .set_key_with_alias(main_private_key, alias_public_key)
+        )
+
+        # Freeze and sign:
+        # - operator key signs as payer (via client)
+        # - alias private key MUST sign to authorize the alias
+        transaction = (
+            transaction.freeze_with(client)
+            .sign(alias_private_key)
+        )
+
+        response = transaction.execute(client)
+        new_account_id = response.account_id
+
+        if new_account_id is None:
+            raise RuntimeError(
+                "AccountID not found in receipt. Account may not have been created."
+            )
+
+        print(f"✅ Account created with ID: {new_account_id}\n")
+
+        account_info = (
+            AccountInfoQuery()
+            .set_account_id(new_account_id)
+            .execute(client)
+        )
+
+        out = info_to_dict(account_info)
+        print("Account Info:")
+        print(json.dumps(out, indent=2) + "\n")
+
+        if account_info.contract_account_id is not None:
+            print(
+                f"✅ Contract Account ID (EVM alias on-chain): "
+                f"{account_info.contract_account_id}"
+            )
+        else:
+            print("❌ Error: Contract Account ID (alias) does not exist.")
+
+    except Exception as error:
+        print(f"❌ Error: {error}")
+        sys.exit(1)
+
+def main():
+    """Main entry point."""
+    client = setup_client()
+    create_account_with_separate_ecdsa_alias(client)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/account/account_create_transaction_evm_alias.py
+++ b/examples/account/account_create_transaction_evm_alias.py
@@ -1,5 +1,5 @@
-# uv run examples/account/account_create_transaction_evm_alias.py
-# python examples/account/account_create_transaction_evm_alias.py
+# uv run -m examples.account.account_create_transaction_evm_alias
+# python -m examples.account.account_create_transaction_evm_alias
 """
 Example: Create an account using an EVM-style alias (evm_address).
 """
@@ -8,6 +8,8 @@ import os
 import sys
 import json
 from dotenv import load_dotenv
+
+from examples.utils import info_to_dict
 
 from hiero_sdk_python import (
     Client,
@@ -39,22 +41,6 @@ def setup_client():
     except Exception:
         print("Error: Please check OPERATOR_ID and OPERATOR_KEY in your .env file.")
         sys.exit(1)
-
-def info_to_dict(info):
-    """Convert AccountInfo to dictionary for easy printing."""
-    out = {}
-    for name in dir(info):
-        if name.startswith("_"):
-            continue
-        try:
-            val = getattr(info, name)
-        except Exception as error:
-            out[name] = f"Error retrieving value: {error}"
-            continue
-        if callable(val):
-            continue
-        out[name] = str(val)
-    return out
 
 def create_account_with_alias(client):
     """Create an account with an alias transaction."""

--- a/examples/account/account_create_transaction_with_fallback_alias.py
+++ b/examples/account/account_create_transaction_with_fallback_alias.py
@@ -1,0 +1,117 @@
+"""
+Example: Create an account where the EVM alias is derived from the main ECDSA key.
+
+This demonstrates:
+- Passing only an ECDSA PrivateKey to `set_key_with_alias`
+- The alias being derived from the main key's EVM address (fallback behaviour)
+
+Usage:
+- uv run -m examples.account.account_create_transaction_with_fallback_alias
+- python -m examples.account.account_create_transaction_with_fallback_alias
+(we use -m because we use the util `info_to_dict`)
+"""
+
+import os
+import sys
+import json
+from dotenv import load_dotenv
+
+from examples.utils import info_to_dict
+
+from hiero_sdk_python import (
+    Client,
+    PrivateKey,
+    AccountCreateTransaction,
+    AccountInfoQuery,
+    Network,
+    AccountId,
+    Hbar,
+)
+
+load_dotenv()
+network_name = os.getenv("NETWORK", "testnet").lower()
+
+
+def setup_client():
+    """Setup Client."""
+    network = Network(network_name)
+    print(f"Connecting to Hedera {network_name} network!")
+    client = Client(network)
+
+    try:
+        operator_id = AccountId.from_string(os.getenv("OPERATOR_ID", ""))
+        operator_key = PrivateKey.from_string(os.getenv("OPERATOR_KEY", ""))
+        client.set_operator(operator_id, operator_key)
+        print(f"Client set up with operator id {client.operator_account_id}")
+        return client
+    except Exception:
+        print("Error: Please check OPERATOR_ID and OPERATOR_KEY in your .env file.")
+        sys.exit(1)
+
+def create_account_with_fallback_alias(client: Client) -> None:
+    """Create an account whose alias is derived from the main ECDSA key."""
+    try:
+        print("\nSTEP 1: Generating a single ECDSA key pair for the account...")
+        account_private_key = PrivateKey.generate("ecdsa")
+        account_public_key = account_private_key.public_key()
+        evm_address = account_public_key.to_evm_address()
+
+        if evm_address is None:
+            print("❌ Error: Failed to generate EVM address from ECDSA public key.")
+            sys.exit(1)
+
+        print(f"✅ Account ECDSA public key: {account_public_key}")
+        print(f"✅ Derived EVM address:      {evm_address}")
+
+        print("\nSTEP 2: Creating the account using the fallback alias behaviour...")
+        transaction = (
+            AccountCreateTransaction(
+                initial_balance=Hbar(5),
+                memo="Account with alias derived from main ECDSA key",
+            )
+            # Fallback path: only one ECDSA key is provided
+            .set_key_with_alias(account_private_key)
+        )
+
+        # Freeze & sign with the account key as well
+        transaction = (
+            transaction.freeze_with(client)
+            .sign(account_private_key)
+        )
+
+        response = transaction.execute(client)
+        new_account_id = response.account_id
+
+        if new_account_id is None:
+            raise RuntimeError(
+                "AccountID not found in receipt. Account may not have been created."
+            )
+
+        print(f"✅ Account created with ID: {new_account_id}\n")
+
+        account_info = (
+            AccountInfoQuery()
+            .set_account_id(new_account_id)
+            .execute(client)
+        )
+
+        out = info_to_dict(account_info)
+        print("Account Info:")
+        print(json.dumps(out, indent=2) + "\n")
+
+        print(
+            "✅ contract_account_id (EVM alias on-chain): "
+            f"{account_info.contract_account_id}"
+        )
+
+    except Exception as error:
+        print(f"❌ Error: {error}")
+        sys.exit(1)
+
+def main():
+    """Main entry point."""
+    client = setup_client()
+    create_account_with_fallback_alias(client)
+
+if __name__ == "__main__":
+    main()

--- a/examples/account/account_create_transaction_without_alias.py
+++ b/examples/account/account_create_transaction_without_alias.py
@@ -1,0 +1,110 @@
+"""
+Example: Create an account without using any alias.
+
+This demonstrates:
+- Using `set_key_without_alias` so that no EVM alias is set
+- The resulting `contract_account_id` being the zero-padded value
+
+Usage:
+- uv run -m examples.account.account_create_transaction_without_alias
+- python -m examples.account.account_create_transaction_without_alias
+(we use -m because we use the util `info_to_dict`)
+"""
+
+import os
+import sys
+import json
+from dotenv import load_dotenv
+
+from examples.utils import info_to_dict
+
+from hiero_sdk_python import (
+    Client,
+    PrivateKey,
+    AccountCreateTransaction,
+    AccountInfoQuery,
+    Network,
+    AccountId,
+    Hbar,
+)
+
+load_dotenv()
+network_name = os.getenv("NETWORK", "testnet").lower()
+
+
+def setup_client():
+    """Setup Client."""
+    network = Network(network_name)
+    print(f"Connecting to Hedera {network_name} network!")
+    client = Client(network)
+
+    try:
+        operator_id = AccountId.from_string(os.getenv("OPERATOR_ID", ""))
+        operator_key = PrivateKey.from_string(os.getenv("OPERATOR_KEY", ""))
+        client.set_operator(operator_id, operator_key)
+        print(f"Client set up with operator id {client.operator_account_id}")
+        return client
+    except Exception:
+        print("Error: Please check OPERATOR_ID and OPERATOR_KEY in your .env file.")
+        sys.exit(1)
+
+def create_account_without_alias(client: Client) -> None:
+    """Create an account explicitly without an alias."""
+    try:
+        print("\nSTEP 1: Generating a key pair for the account (no alias)...")
+        account_private_key = PrivateKey.generate()
+        account_public_key = account_private_key.public_key()
+
+        print(f"✅ Account public key (no alias): {account_public_key}")
+
+        print("\nSTEP 2: Creating the account without setting any alias...")
+
+        transaction = (
+            AccountCreateTransaction(
+                initial_balance=Hbar(5),
+                memo="Account created without alias",
+            )
+            .set_key_without_alias(account_private_key)
+        )
+
+        transaction = (
+            transaction.freeze_with(client)
+            .sign(account_private_key)
+        )
+
+        response = transaction.execute(client)
+        new_account_id = response.account_id
+
+        if new_account_id is None:
+            raise RuntimeError(
+                "AccountID not found in receipt. Account may not have been created."
+            )
+
+        print(f"✅ Account created with ID: {new_account_id}\n")
+
+        account_info = (
+            AccountInfoQuery()
+            .set_account_id(new_account_id)
+            .execute(client)
+        )
+
+        out = info_to_dict(account_info)
+        print("Account Info:")
+        print(json.dumps(out, indent=2) + "\n")
+
+        print(
+            "✅ contract_account_id (no alias, zero-padded): "
+            f"{account_info.contract_account_id}"
+        )
+
+    except Exception as error:
+        print(f"❌ Error: {error}")
+        sys.exit(1)
+
+def main():
+    """Main entry point."""
+    client = setup_client()
+    create_account_without_alias(client)
+
+if __name__ == "__main__":
+    main()

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -1,0 +1,23 @@
+def info_to_dict(info):
+    """
+    Convert an AccountInfo object into a dictionary of serializable strings.
+    Useful for pretty-printing information in examples.
+    """
+    out = {}
+
+    for name in dir(info):
+        if name.startswith("_"):
+            continue
+
+        try:
+            val = getattr(info, name)
+        except Exception as error:
+            out[name] = f"Error retrieving value: {error}"
+            continue
+
+        if callable(val):
+            continue
+
+        out[name] = str(val)
+
+    return out

--- a/tests/integration/account_create_transaction_e2e_test.py
+++ b/tests/integration/account_create_transaction_e2e_test.py
@@ -267,3 +267,103 @@ def test_create_account_with_decline_reward(env):
     assert info.account_id == account_id
     assert info.staked_account_id == env.operator_id
     assert info.decline_staking_reward is True
+
+def test_integration_account_create_transaction_can_execute_with_private_key(env):
+    """Test AccountCreateTransaction can be executed when key is a PrivateKey."""
+    new_account_private_key = PrivateKey.generate()
+    initial_balance = Hbar(2)
+
+    assert initial_balance.to_tinybars() == 200000000
+
+    tx = AccountCreateTransaction(
+        key=new_account_private_key,
+        initial_balance=initial_balance,
+        memo="Recipient Account With PrivateKey",
+    )
+
+    tx.freeze_with(env.client)
+    receipt = tx.execute(env.client)
+
+    assert receipt.status == ResponseCode.SUCCESS
+    assert receipt.account_id is not None, (
+        "AccountID not found in receipt. Account may not have been created."
+    )
+
+def test_proto_includes_alias_from_ecdsa_key(env):
+    """Proto alias should come from the separate ECDSA key when provided."""
+    # Main account key (can be any key type)
+    account_private_key = PrivateKey.generate()
+    account_public_key = account_private_key.public_key()
+
+    # Separate ECDSA key used only for alias
+    alias_private_key = PrivateKey.generate_ecdsa()
+    alias_public_key = alias_private_key.public_key()
+    expected_evm_address = alias_public_key.to_evm_address()
+
+    tx = (
+        AccountCreateTransaction(
+            key=account_public_key,
+            initial_balance=Hbar(2),
+            memo="Account with alias from ECDSA key",
+        )
+        .set_key_with_alias(account_public_key, alias_public_key)
+        .freeze_with(env.client)
+        .sign(alias_private_key)
+    )
+
+    receipt = tx.execute(env.client)
+    tx_body = tx.build_transaction_body()
+
+    assert receipt.account_id is not None, "AccountID not found in receipt. Account may not have been created."
+    # Alias in the proto must come from the ECDSA alias key
+    assert tx_body.cryptoCreateAccount.alias == expected_evm_address.address_bytes
+    # Key in the proto must still be the main account key
+    assert tx_body.cryptoCreateAccount.key == account_public_key._to_proto()
+
+def test_proto_includes_alias_from_main_key(env):
+    """Proto alias should be derived from the main ECDSA key when no separate alias key is provided."""
+    account_private_key = PrivateKey.generate_ecdsa()
+    account_public_key = account_private_key.public_key()
+    expected_evm_address = account_public_key.to_evm_address()
+
+    tx = (
+        AccountCreateTransaction(
+            initial_balance=Hbar(2),
+            memo="Account with alias from main key",
+        )
+        .set_key_with_alias(account_private_key)  # no ecdsa_key param
+    )
+
+    tx.freeze_with(env.client)
+    receipt = tx.execute(env.client)
+    tx_body = tx.build_transaction_body()
+
+    assert receipt.account_id is not None, "AccountID not found in receipt. Account may not have been created."
+    # Alias must be derived from the main ECDSA key
+    assert tx_body.cryptoCreateAccount.alias == expected_evm_address.address_bytes
+    # Key in proto is still the public key of the account
+    assert tx_body.cryptoCreateAccount.key == account_public_key._to_proto()
+
+def test_proto_excludes_alias_when_not_set(env):
+    """Proto should not include alias when we use the 'without alias' path."""
+    account_private_key = PrivateKey.generate()
+    account_public_key = account_private_key.public_key()
+
+    tx = (
+        AccountCreateTransaction(
+            key=account_public_key,
+            initial_balance=Hbar(2),
+            memo="Account without alias",
+        )
+        .set_key_without_alias(account_public_key)
+    )
+
+    tx.freeze_with(env.client)
+    receipt = tx.execute(env.client)
+    tx_body = tx.build_transaction_body()
+
+    assert receipt.account_id is not None, "AccountID not found in receipt. Account may not have been created."
+    # No alias should be set in the proto
+    assert not tx_body.cryptoCreateAccount.alias
+    # Key must still be present
+    assert tx_body.cryptoCreateAccount.key == account_public_key._to_proto()

--- a/tests/unit/test_account_create_transaction.py
+++ b/tests/unit/test_account_create_transaction.py
@@ -395,3 +395,131 @@ def test_create_account_transaction_with_set_alias_from_invalid_type():
 
     with pytest.raises(TypeError):
         tx.set_alias(1234)
+
+# This test uses fixture mock_account_ids as parameter
+def test_account_create_transaction_build_with_private_key(mock_account_ids):
+    """AccountCreateTransaction should accept also PrivateKey and serialize the PublicKey in the proto."""
+    operator_id, node_account_id = mock_account_ids
+
+    private_key = PrivateKey.generate()
+    public_key = private_key.public_key()
+
+    tx = (
+        AccountCreateTransaction()
+        .set_key_without_alias(private_key)
+        .set_initial_balance(100000000)
+        .set_account_memo("Account with private key")
+    )
+
+    tx.transaction_id = generate_transaction_id(operator_id)
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+
+    # In the proto  we should have the public key not the private one
+    assert body.cryptoCreateAccount.key.ed25519 == public_key.to_bytes_raw()
+    assert body.cryptoCreateAccount.initialBalance == 100000000
+    assert body.cryptoCreateAccount.memo == "Account with private key"
+
+# This test uses fixture mock_account_ids as parameter
+def test_create_account_transaction_set_key_with_alias_private_keys(mock_account_ids):
+    """set_key_with_alias should work also with PrivateKey ECDSA (account key + alias key)."""
+    operator_id, node_id = mock_account_ids
+
+    # Account key(ECDSA)
+    account_private_key = PrivateKey.generate_ecdsa()
+    account_public_key = account_private_key.public_key()
+
+    # Alias key (ECDSA)
+    alias_private_key = PrivateKey.generate_ecdsa()
+    alias_public_key = alias_private_key.public_key()
+    expected_evm_address = alias_public_key.to_evm_address()
+
+    tx = (
+        AccountCreateTransaction()
+        .set_key_with_alias(account_private_key, alias_private_key)
+    )
+
+    assert tx.key == account_private_key
+    assert tx.alias == expected_evm_address
+
+    tx.operator_account_id = operator_id
+    tx.node_account_id = node_id
+    tx_body = tx.build_transaction_body()
+
+    # In the proto we should have account public key
+    assert tx_body.cryptoCreateAccount.key == account_public_key._to_proto()
+    # Alias should be the address bytes from the key for the alias
+    assert tx_body.cryptoCreateAccount.alias == expected_evm_address.address_bytes
+
+# This test uses fixture mock_account_ids as parameter
+def test_create_account_transaction_set_key_with_alias_private_key_without_ecdsa_key(mock_account_ids):
+    """set_key_with_alias should work also without ecdsa_key."""
+    operator_id, node_id = mock_account_ids
+
+    # Account key(ECDSA)
+    account_private_key = PrivateKey.generate_ecdsa()
+    account_public_key = account_private_key.public_key()
+
+    expected_evm_address = account_public_key.to_evm_address()
+
+    tx = (
+        AccountCreateTransaction()
+        .set_key_with_alias(account_private_key)
+    )
+
+    assert tx.key == account_private_key
+    assert tx.alias == expected_evm_address
+
+    tx.operator_account_id = operator_id
+    tx.node_account_id = node_id
+    tx_body = tx.build_transaction_body()
+
+    # In the proto we should have account public key
+    assert tx_body.cryptoCreateAccount.key == account_public_key._to_proto()
+    # Alias should be the address bytes from the key for the alias
+    assert tx_body.cryptoCreateAccount.alias == expected_evm_address.address_bytes
+
+def test_set_key_without_alias_then_with_alias_overrides_alias():
+    """set_key_with_alias should ovveride set_key_without_alias"""
+    # Account key(ECDSA)
+    account_private_key = PrivateKey.generate_ecdsa()
+    account_public_key = account_private_key.public_key()
+
+    # Alias key (ECDSA)
+    alias_private_key = PrivateKey.generate_ecdsa()
+    alias_public_key = alias_private_key.public_key()
+    expected_evm_address = alias_public_key.to_evm_address()
+
+    tx = (
+        AccountCreateTransaction()
+        .set_key_without_alias(account_private_key)
+    )
+
+    assert tx.alias is None
+
+    tx.set_key_with_alias(account_private_key, alias_private_key)
+
+    assert tx.alias == expected_evm_address
+
+def test_set_key_with_alias_then_without_alias_overrides_alias():
+    """set_key_without_alias should ovveride set_key_with_alias"""
+    # Account key(ECDSA)
+    account_private_key = PrivateKey.generate_ecdsa()
+    account_public_key = account_private_key.public_key()
+
+    # Alias key (ECDSA)
+    alias_private_key = PrivateKey.generate_ecdsa()
+    alias_public_key = alias_private_key.public_key()
+    expected_evm_address = alias_public_key.to_evm_address()
+
+    tx = (
+        AccountCreateTransaction()
+        .set_key_with_alias(account_private_key, alias_private_key)
+    )
+
+    assert tx.alias == expected_evm_address
+
+    tx.set_key_without_alias(account_private_key)
+
+    assert tx.alias is None


### PR DESCRIPTION
This PR refactors the transaction_to_bytes example to improve readability and modularity.
- Extracts logic into reusable functions
- Adds validation and error messages
- Improves naming consistency
- Ensures the example follows the updated SDK structure

Related to: #1012

