### PR TITLE
feat: Add key format tests

### DIFF
--- a/tests/unit/test_key_format.py
+++ b/tests/unit/test_key_format.py
@@ -1,0 +1,73 @@
+"""Tests for the key_format module."""
+
+import pytest
+
+from hiero_sdk_python.crypto.private_key import PrivateKey
+from hiero_sdk_python.hapi.services import basic_types_pb2
+from hiero_sdk_python.utils.key_utils import Key, key_to_proto
+from hiero_sdk_python.utils.key_format import format_key
+
+pytestmark = pytest.mark.unit
+
+def test_format_key_ed25519():
+    """Test formatting an Ed25519 key."""
+    private_key = PrivateKey.generate_ed25519()
+    public_key = private_key.public_key()
+
+    proto_key = key_to_proto(public_key)
+    formatted = format_key(proto_key)
+
+    expected = f"ed25519({public_key.to_bytes_raw().hex()})"
+
+    assert formatted == expected
+
+def test_format_key_none():
+    """Test formatting a None key."""
+    formatted = format_key(None)
+
+    assert formatted == "None" 
+
+def test_format_key_threshold_key():
+    """Test formatting a ThresholdKey."""
+
+    key = basic_types_pb2.Key()
+    key.thresholdKey.threshold = 2
+
+    formatted = format_key(key)
+
+    assert formatted == "thresholdKey(...)"
+
+def test_format_key_contract_id():
+    """Test formatting a ContractID key."""
+
+    key = basic_types_pb2.Key()
+    key.contractID.shardNum = 0
+    key.contractID.realmNum = 0
+    key.contractID.contractNum = 5678
+
+    expected_inner = str(key.contractID) 
+    expected = f"contractID({expected_inner})"
+
+    formatted = format_key(key)
+
+    assert formatted == expected
+
+def test_format_key_keylist():
+    """Test formatting a KeyList."""
+
+    key = basic_types_pb2.Key()
+    key.keyList.keys.add()
+
+    formatted = format_key(key)
+
+    assert formatted == "keyList(...)"
+
+def test_format_key_unknown():
+    """Test formatting an unknown key type."""
+    key = basic_types_pb2.Key()
+    # Intentionally not setting any known key type
+
+    formatted = format_key(key)
+    expected = str(key).replace("\n", " ")
+
+    assert formatted == expected


### PR DESCRIPTION
**Description**: 
Added unit tests for:
* key_format.py. 

The goal of this PR is to increase test coverage of key_format.py to be <= 85%

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #990 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
* Ensured coverage percentage is <= 85%
* Used command pytest --cov=. --cov-report=term-missing tests/unit
* Provided coverage photo
<img width="960" height="229" alt="2025-12-10" src="https://github.com/user-attachments/assets/23d1785b-805f-46a0-a0f5-45d7f161a56c" />


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
