### PR TITLE
docs: add fix: inactivity bot pagination and assignment date detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- Fix inactivity bot execution for local dry-run testing.
 - Added documentation: "Testing GitHub Actions using Forks" (`docs/sdk_developers/training/testing_forks.md`).
 - Unified the inactivity-unassign bot into a single script with `DRY_RUN` support, and fixed handling of cross-repo PR references for stale detection.
 - Added unit tests for `SubscriptionHandle` class covering cancellation state, thread management, and join operations.


### PR DESCRIPTION
**Description:**
This PR fixes a critical bug in the inactivity bot where users were being incorrectly unassigned from issues.

Previously, the bot only fetched the first page of the issue timeline (30 events). If the assignment event was older or the issue had high activity, the "assigned" event was missed. The bot would then fall back to the **issue creation date**, incorrectly marking recent assignments on old issues as "stale" (e.g., calculating 50+ days inactivity for a 1-day old assignment).

**Changes:**
* Enable **pagination** (`--paginate`) for the GitHub API timeline request to fetch all events.
* Flatten the paginated JSON response using `jq -s 'add'` to ensure a single searchable array.
* Remove the unsafe fallback to `issue_created_at`. If no assignment event is found, the bot now skips the check rather than unassigning the user.

**Related issue(s)**:

Fixes #1074

**Notes for reviewer**:
Tested locally with `DRY_RUN=1`. The bot now correctly identifies assignment events even on older issues.

**Example Log (Before Fix - Issue #526):**
> `[INFO] Assignment source: issue_created_at`
> `[INFO] Assigned at: (~50 days ago)` -> **WRONG**

**Example Log (After Fix - Issue #526):**
> `[INFO] Assignment source: assignment_event`
> `[INFO] Assigned at: (~1 days ago)` -> **CORRECT**

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)