### PR TITLE
fix: update team notification script and workflow for P0 issues

### DIFF
--- a/.github/scripts/p0_issues_notify_team.js
+++ b/.github/scripts/p0_issues_notify_team.js
@@ -4,7 +4,7 @@ const marker = '<!-- P0 Issue Notification -->';
 
   async function notifyTeam(github, owner, repo, issue, marker) {
     const comment = `${marker} :rotating_light: Attention Team :rotating_light: 
-@team-python-sdk/maintainers  @team-python-sdk/committers @team-python-sdk/triage
+@hiero-ledger/hiero-sdk-python-maintainers @hiero-ledger/hiero-sdk-python-committers @hiero-ledger/hiero-sdk-python-triage
 
 A new P0 issue has been created: #${issue.number} - ${issue.title || '(no title)'}
 Please prioritize this issue accordingly.

--- a/.github/workflows/bot-p0-issues-notify-team.yml
+++ b/.github/workflows/bot-p0-issues-notify-team.yml
@@ -13,7 +13,7 @@ permissions:
 jobs: 
   p0_notify_team:
     runs-on: ubuntu-latest
-    # Only run for workflow_dispatch, issues opened, or issues labeled with 'p0' (case-insensitive)
+    # Only run for issues labeled with 'p0' (case-insensitive)
     if: >
       (github.event_name == 'issues' && (
           (github.event.label.name == 'p0' || github.event.label.name == 'P0'))
@@ -26,12 +26,12 @@ jobs:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.1
 
       - name: Notify team of P0 issues
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd #v8.0.0
         with:
           script: |
             const script = require('./.github/scripts/p0_issues_notify_team.js');      

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
   `examples.yml` → `pr-check-examples.yml`,
   `test.yml` → `pr-check-test.yml` (#1043)
 - Cleaned up `token_airdrop_claim_auto` example for pylint compliance (no functional changes). (#1079)
+- Update team notification script and workflow for P0 issues 'p0_issues_notify_team.js'
 
 
 ### Fixed


### PR DESCRIPTION
This pull request updates the team notification process for P0 issues by refining the notification recipients. The main focus is on ensuring the correct team is notified.

**Team notification improvements:**

* Updated the notification script in `.github/scripts/p0_issues_notify_team.js` to mention the correct team handles: `@hiero-ledger/hiero-sdk-python-maintainers`, `@hiero-ledger/hiero-sdk-python-committers`, and `@hiero-ledger/hiero-sdk-python-triage` instead of the previous `@team-python-sdk` groups.


**Related issue(s)**:

Fixes #1111


**Checklist**

- [ ] Documented 
- [ ] Tested 
