### PR TITLE
ci: reduce office-hours reminder spam by posting only on most recent PR per user

### DIFF
--- a/.github/workflows/bot-office-hours.yml
+++ b/.github/workflows/bot-office-hours.yml
@@ -37,9 +37,9 @@ jobs:
           echo "Meeting week detected. Proceeding to notify open PRs."
 
           REPO="${{ github.repository }}"
-          PR_LIST=$(gh pr list --repo $REPO --state open --json number --jq '.[].number')
+          PR_DATA=$(gh pr list --repo $REPO --state open --json number,author,createdAt)
 
-          if [ -z "$PR_LIST" ]; then
+          if [ -z "$PR_DATA" ] || [ "$PR_DATA" = "[]" ]; then
             echo "No open PRs found."
             exit 0
           fi
@@ -59,8 +59,8 @@ jobs:
           EOF
           )
 
-          for PR_NUM in $PR_LIST; do
-            echo "Processing PR #$PR_NUM"
+          echo "$PR_DATA" | jq -r 'group_by(.author.login) | .[] | sort_by(.createdAt) | reverse | .[0] | .number' | while read PR_NUM; do
+            echo "Processing most recent PR #$PR_NUM for user"
             
             ALREADY_COMMENTED=$(gh pr view $PR_NUM --repo $REPO --json comments --jq '.comments[].body' | grep -F "Office Hour Bot" || true)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Added GitHub workflow that makes sure newly added test files follow pytest test files naming conventions (#1054)
 
 ### Changed
+- Reduce office-hours reminder spam by posting only on each user's most recent open PR, grouping by author and sorting by creation time (#1121)
 - Pylint cleanup for token_airdrop_transaction_cancel.py (#1081) [@tiya-15](https://github.com/tiya-15)
 - Move `account_allowance_delete_transaction_hbar.py` from `examples/` to `examples/account/` for better organization (#1003)
 - Improved consistency of transaction examples (#1120)


### PR DESCRIPTION
## Description

Reduces spam from office-hours reminders by ensuring each user receives only one notification on their most recent open pull request, even if they have multiple PRs open.

## Problem

Currently, the office-hours bot posts reminders on all open PRs. When users have multiple PRs open, this creates unnecessary spam and redundant notifications.

## Solution

Modified `.github/workflows/bot-office-hours.yml` to intelligently filter PRs by author and only notify on the most recent one per user.

## Implementation Details

The workflow now:

1. **Retrieves all open PRs with metadata**
   - Uses `gh pr list --json number,author,createdAt` to fetch PR data including author and timestamps

2. **Groups and sorts by author**
   - Leverages `jq` to group PRs by `author.login`
   - Sorts each author's PRs by `createdAt` in descending order (newest first)

3. **Selects only the most recent PR per user**
   - Uses `group_by(.author.login) | .[] | sort_by(.createdAt) | reverse | .[0]`
   - Ensures each user receives exactly one notification on their latest PR

## Changes

- Modified: `.github/workflows/bot-office-hours.yml`
- Updated: `CHANGELOG.md`

## Testing

The changes can be tested by:
- Triggering the workflow with `workflow_dispatch`
- Verifying that users with multiple PRs only receive one notification on their most recent PR

## Related Issue

Closes #1121

## Checklist

- [x] Follows Conventional Commits specification
- [x] Includes changelog entry
- [x] Commits are signed (GPG + DCO)
- [x] Workflow logic preserves existing behavior for single-PR users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Office-hours reminders now post only on each author's most recent open PR, reducing notification spam.
  * System treats an empty PR payload as no open PRs to avoid unnecessary processing.
  * Status messages updated to indicate processing of the most recent PR per user rather than every PR.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->