### PR TITLE
chore: rename/response code name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,9 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Rename test files across the repository to ensure they consistently end with _test.py (#1055)
 - Cleaned up `token_airdrop_claim_signature_required` example for pylint compliance (no functional changes). (#1080)
 - Rename the file 'test_token_fee_schedule_update_transaction_e2e.py' to make it ends with _test.py as all other test files.(#1117)
-- Format token examples with Black for consistent code style and improved readability (#1119)
+- Format token examples with Black for consistent code style and improved readability (#1119) 
+- Replaced `ResponseCode.get_name(receipt.status)` with the  `ResponseCode(receipt.status).name` across examples and integration tests for consistency. (#1136)
+
 
 
 ### Fixed

--- a/examples/query/payment_query.py
+++ b/examples/query/payment_query.py
@@ -61,7 +61,7 @@ def create_fungible_token(client, operator_id, operator_key):
 
     if receipt.status != ResponseCode.SUCCESS:
         print(
-            f"Fungible token creation failed with status: {ResponseCode.get_name(receipt.status)}"
+            f"Fungible token creation failed with status: {ResponseCode(receipt.status).name}"
         )
         sys.exit(1)
 

--- a/examples/tokens/token_revoke_kyc_transaction.py
+++ b/examples/tokens/token_revoke_kyc_transaction.py
@@ -92,7 +92,7 @@ def associate_token(client, token_id, account_id, account_private_key):
 
     if receipt.status != ResponseCode.SUCCESS:
         print(
-            f"Token association failed with status: {ResponseCode.get_name(receipt.status)}"
+            f"Token association failed with status: {ResponseCode(receipt.status).name}"
         )
         sys.exit(1)
 
@@ -118,7 +118,7 @@ def create_test_account(client):
     # Check if account creation was successful
     if receipt.status != ResponseCode.SUCCESS:
         print(
-            f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+            f"Account creation failed with status: {ResponseCode(receipt.status).name}"
         )
         sys.exit(1)
 
@@ -142,7 +142,7 @@ def grant_kyc(client, token_id, account_id, kyc_private_key):
 
     if receipt.status != ResponseCode.SUCCESS:
         print(
-            f"Token grant KYC failed with status: {ResponseCode.get_name(receipt.status)}"
+            f"Token grant KYC failed with status: {ResponseCode(receipt.status).name}"
         )
         sys.exit(1)
 
@@ -189,7 +189,7 @@ def token_revoke_kyc():
     # Check if the transaction was successful
     if receipt.status != ResponseCode.SUCCESS:
         print(
-            f"Token revoke KYC failed with status: {ResponseCode.get_name(receipt.status)}"
+            f"Token revoke KYC failed with status: {ResponseCode(receipt.status).name}"
         )
         sys.exit(1)
 

--- a/examples/tokens/token_update_transaction_fungible.py
+++ b/examples/tokens/token_update_transaction_fungible.py
@@ -70,7 +70,7 @@ def create_fungible_token(client, operator_id, operator_key, metadata_key):
     # Check if token creation was successful
     if receipt.status != ResponseCode.SUCCESS:
         print(
-            f"Fungible token creation failed with status: {ResponseCode.get_name(receipt.status)}"
+            f"Fungible token creation failed with status: {ResponseCode(receipt.status).name}"
         )
         sys.exit(1)
 
@@ -109,7 +109,7 @@ def update_token_data(
 
     if receipt.status != ResponseCode.SUCCESS:
         print(
-            f"Token metadata update failed with status: {ResponseCode.get_name(receipt.status)}"
+            f"Token metadata update failed with status: {ResponseCode(receipt.status).name}"
         )
         sys.exit(1)
 

--- a/examples/tokens/token_update_transaction_key.py
+++ b/examples/tokens/token_update_transaction_key.py
@@ -62,7 +62,7 @@ def create_fungible_token(client, operator_id, admin_key, wipe_key):
     # Check if token creation was successful
     if receipt.status != ResponseCode.SUCCESS:
         print(
-            f"Fungible token creation failed with status: {ResponseCode.get_name(receipt.status)}"
+            f"Fungible token creation failed with status: {ResponseCode(receipt.status).name}"
         )
         sys.exit(1)
 
@@ -106,7 +106,7 @@ def update_wipe_key_full_validation(client, token_id, old_wipe_key):
 
     if receipt.status != ResponseCode.SUCCESS:
         print(
-            f"Token update failed with status: {ResponseCode.get_name(receipt.status)}"
+            f"Token update failed with status: {ResponseCode(receipt.status).name}"
         )
         sys.exit(1)
 

--- a/examples/tokens/token_update_transaction_nft.py
+++ b/examples/tokens/token_update_transaction_nft.py
@@ -70,7 +70,7 @@ def create_nft(client, operator_id, operator_key, metadata_key):
     # Check if nft creation was successful
     if receipt.status != ResponseCode.SUCCESS:
         print(
-            f"NFT creation failed with status: {ResponseCode.get_name(receipt.status)}"
+            f"NFT creation failed with status: {ResponseCode(receipt.status).name}"
         )
         sys.exit(1)
 
@@ -109,7 +109,7 @@ def update_nft_data(
 
     if receipt.status != ResponseCode.SUCCESS:
         print(
-            f"NFT data update failed with status: {ResponseCode.get_name(receipt.status)}"
+            f"NFT data update failed with status: {ResponseCode(receipt.status).name}"
         )
         sys.exit(1)
 

--- a/tests/integration/file_update_transaction_e2e_test.py
+++ b/tests/integration/file_update_transaction_e2e_test.py
@@ -29,7 +29,7 @@ def test_integration_file_update_transaction_can_execute(env):
     )
     assert (
         receipt.status == ResponseCode.SUCCESS
-    ), f"File creation failed with status: {ResponseCode.get_name(receipt.status)}"
+    ), f"File creation failed with status: {ResponseCode(receipt.status).name}"
 
     file_id = receipt.file_id
     assert file_id is not None, "File ID should not be None"
@@ -53,7 +53,7 @@ def test_integration_file_update_transaction_can_execute(env):
     )
     assert (
         receipt.status == ResponseCode.SUCCESS
-    ), f"File update failed with status: {ResponseCode.get_name(receipt.status)}"
+    ), f"File update failed with status: {ResponseCode(receipt.status).name}"
 
     # Query file info and check if everything is updated
     info = FileInfoQuery().set_file_id(file_id).execute(env.client)
@@ -85,7 +85,7 @@ def test_integration_file_update_transaction_cannot_update_immutable_file(env):
     receipt = FileCreateTransaction().set_contents("Immutable file").execute(env.client)
     assert (
         receipt.status == ResponseCode.SUCCESS
-    ), f"File creation failed with status: {ResponseCode.get_name(receipt.status)}"
+    ), f"File creation failed with status: {ResponseCode(receipt.status).name}"
 
     file_id = receipt.file_id
     assert file_id is not None, "File ID should not be None"
@@ -121,7 +121,7 @@ def test_integration_file_update_transaction_fails_when_key_is_invalid(env):
     )
     assert (
         receipt.status == ResponseCode.SUCCESS
-    ), f"File creation failed with status: {ResponseCode.get_name(receipt.status)}"
+    ), f"File creation failed with status: {ResponseCode(receipt.status).name}"
 
     file_id = receipt.file_id
     assert file_id is not None, "File ID should not be None"

--- a/tests/integration/token_revoke_kyc_transaction_e2e_test.py
+++ b/tests/integration/token_revoke_kyc_transaction_e2e_test.py
@@ -24,7 +24,7 @@ def test_token_revoke_kyc_transaction_can_execute():
             .set_initial_balance(Hbar(2))
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode(receipt.status).name}"
         account_id = receipt.account_id
 
         # Create a new token and set the kyc key to be the operator's key
@@ -39,7 +39,7 @@ def test_token_revoke_kyc_transaction_can_execute():
             .sign(new_account_private_key)
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Token association failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token association failed with status: {ResponseCode(receipt.status).name}"
         
         # Grant KYC to the new account first
         receipt = (
@@ -48,7 +48,7 @@ def test_token_revoke_kyc_transaction_can_execute():
             .set_token_id(token_id)
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Token grant KYC failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token grant KYC failed with status: {ResponseCode(receipt.status).name}"
         
         # Revoke KYC from the new account
         receipt = (
@@ -57,7 +57,7 @@ def test_token_revoke_kyc_transaction_can_execute():
             .set_token_id(token_id)
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Token revoke KYC failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token revoke KYC failed with status: {ResponseCode(receipt.status).name}"
     finally:
         env.close()
 
@@ -76,7 +76,7 @@ def test_token_revoke_kyc_transaction_fails_with_no_kyc_key():
             .set_initial_balance(Hbar(2))
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode(receipt.status).name}"
         account_id = receipt.account_id
         
         # Create a new token without KYC key
@@ -91,7 +91,7 @@ def test_token_revoke_kyc_transaction_fails_with_no_kyc_key():
             .sign(new_account_private_key)
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Token association failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token association failed with status: {ResponseCode(receipt.status).name}"
         
         # Try to revoke KYC for token without KYC key - should fail with TOKEN_HAS_NO_KYC_KEY
         receipt = (
@@ -100,7 +100,7 @@ def test_token_revoke_kyc_transaction_fails_with_no_kyc_key():
             .set_token_id(token_id)
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.TOKEN_HAS_NO_KYC_KEY, f"Token revoke KYC should have failed with TOKEN_HAS_NO_KYC_KEY status but got: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.TOKEN_HAS_NO_KYC_KEY, f"Token revoke KYC should have failed with TOKEN_HAS_NO_KYC_KEY status but got: {ResponseCode(receipt.status).name}"
         
         # Try to revoke KYC with non-KYC key - should fail with TOKEN_HAS_NO_KYC_KEY
         receipt = (
@@ -109,7 +109,7 @@ def test_token_revoke_kyc_transaction_fails_with_no_kyc_key():
             .set_token_id(token_id)
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.TOKEN_HAS_NO_KYC_KEY, f"Token revoke KYC should have failed with TOKEN_HAS_NO_KYC_KEY status but got: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.TOKEN_HAS_NO_KYC_KEY, f"Token revoke KYC should have failed with TOKEN_HAS_NO_KYC_KEY status but got: {ResponseCode(receipt.status).name}"
     finally:
         env.close()
         
@@ -128,7 +128,7 @@ def test_token_revoke_kyc_transaction_fails_when_account_not_associated():
             .set_initial_balance(Hbar(2))
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode(receipt.status).name}"
         account_id = receipt.account_id
         
         # Create a new token and set the kyc key to be the operator's key
@@ -141,6 +141,6 @@ def test_token_revoke_kyc_transaction_fails_when_account_not_associated():
             .set_token_id(token_id)
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT, f"Token revoke KYC should have failed with TOKEN_NOT_ASSOCIATED_TO_ACCOUNT status but got: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT, f"Token revoke KYC should have failed with TOKEN_NOT_ASSOCIATED_TO_ACCOUNT status but got: {ResponseCode(receipt.status).name}"
     finally:
         env.close()

--- a/tests/integration/token_update_transaction_e2e_test.py
+++ b/tests/integration/token_update_transaction_e2e_test.py
@@ -39,7 +39,7 @@ def test_integration_token_update_transaction_can_execute():
            .freeze_with(env.client)
            .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Token update transaction failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token update transaction failed with status: {ResponseCode(receipt.status).name}"
         
         info = (
             TokenInfoQuery()
@@ -73,7 +73,7 @@ def test_integration_token_update_preserves_fields_without_updating_parameters()
             .set_token_id(token_id)
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Token update transaction failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token update transaction failed with status: {ResponseCode(receipt.status).name}"
         
         info = (
             TokenInfoQuery()
@@ -114,7 +114,7 @@ def test_integration_token_update_transaction_different_keys():
             .set_initial_balance(Hbar(2))
         )
         receipt = tx.execute(env.client)
-        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode(receipt.status).name}"
         
         # Create fungible token with initial metadata and pause keys both set to the first key
         token_id = create_fungible_token(env, opts=[
@@ -141,7 +141,7 @@ def test_integration_token_update_transaction_different_keys():
             .set_fee_schedule_key(keys[7])
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Token update transaction failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token update transaction failed with status: {ResponseCode(receipt.status).name}"
         
         # Query token info and verify updates
         info = (
@@ -178,7 +178,7 @@ def test_integration_token_update_transaction_treasury():
             .set_initial_balance(Hbar(2))
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Account creation failed with status: {ResponseCode(receipt.status).name}"
         account_id = receipt.account_id
         
         # Create fungible token
@@ -191,7 +191,7 @@ def test_integration_token_update_transaction_treasury():
             .freeze_with(env.client)
         )
         receipt = tx.sign(new_private_key).execute(env.client)
-        assert receipt.status == ResponseCode.SUCCESS, f"Token association failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token association failed with status: {ResponseCode(receipt.status).name}"
         
         # Update token with new treasury account
         receipt = (
@@ -203,7 +203,7 @@ def test_integration_token_update_transaction_treasury():
             .sign(new_private_key)
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode(receipt.status).name}"
         
         # Query token info and verify updates
         info = (
@@ -227,7 +227,7 @@ def test_integration_token_update_transaction_fail_invalid_token_id():
 
         receipt = tx.execute(env.client)
         
-        assert receipt.status == ResponseCode.INVALID_TOKEN_ID, f"Token update should have failed with INVALID_TOKEN_ID status but got: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.INVALID_TOKEN_ID, f"Token update should have failed with INVALID_TOKEN_ID status but got: {ResponseCode(receipt.status).name}"
     finally:
         env.close()
 
@@ -256,7 +256,7 @@ def test_integration_token_update_transaction_fungible_metadata():
             .set_metadata(new_metadata)
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode(receipt.status).name}"
         
         # Query token info and verify updated metadata
         info = (
@@ -294,7 +294,7 @@ def test_integration_token_update_transaction_nft_metadata():
             .set_metadata(new_metadata)
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode(receipt.status).name}"
         
         # Query token info and verify updated metadata
         info = (
@@ -342,7 +342,7 @@ def test_integration_token_update_transaction_metadata_immutable_fungible_token(
             .sign(metadata_key)
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode(receipt.status).name}"
         
         # Query token info and verify updated metadata
         info = (
@@ -390,7 +390,7 @@ def test_integration_token_update_transaction_metadata_immutable_nft():
             .sign(metadata_key)
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode(receipt.status).name}"
         
         # Query token info and verify updated metadata
         info = (
@@ -426,7 +426,7 @@ def test_token_update_transaction_cannot_update_metadata_fungible():
             .set_token_memo("updated memo")
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode(receipt.status).name}"
         
         # Query token info and verify metadata remains unchanged
         info = (
@@ -462,7 +462,7 @@ def test_integration_token_update_transaction_cannot_update_metadata_nft():
             .set_token_memo("asdf")
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode(receipt.status).name}"
         
         # Query token info and verify metadata remains unchanged
         info = (
@@ -498,7 +498,7 @@ def test_integration_token_update_transaction_erase_metadata_fungible_token():
             .set_metadata(b"")
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode(receipt.status).name}"
 
         # Query token info and verify metadata was erased
         info = (
@@ -534,7 +534,7 @@ def test_integration_token_update_transaction_erase_metadata_nft():
             .set_metadata(b"")
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode(receipt.status).name}"
 
         # Query token info and verify metadata was erased
         info = (
@@ -571,7 +571,7 @@ def test_integration_token_update_transaction_cannot_update_metadata_without_key
             .execute(env.client)
         )
         
-        assert receipt.status == ResponseCode.INVALID_SIGNATURE, f"Token update should have failed with INVALID_SIGNATURE status but got: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.INVALID_SIGNATURE, f"Token update should have failed with INVALID_SIGNATURE status but got: {ResponseCode(receipt.status).name}"
     finally:
         env.close()
         
@@ -600,7 +600,7 @@ def test_integration_token_update_transaction_cannot_update_metadata_without_key
             .execute(env.client)
         )
 
-        assert receipt.status == ResponseCode.INVALID_SIGNATURE, f"Token update should have failed with INVALID_SIGNATURE status but got: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.INVALID_SIGNATURE, f"Token update should have failed with INVALID_SIGNATURE status but got: {ResponseCode(receipt.status).name}"
     finally:
         env.close()
 
@@ -624,7 +624,7 @@ def test_integration_token_update_transaction_cannot_update_immutable_fungible_t
             .execute(env.client)
         )
         
-        assert receipt.status == ResponseCode.TOKEN_IS_IMMUTABLE, f"Token update should have failed with TOKEN_IS_IMMUTABLE status but got: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.TOKEN_IS_IMMUTABLE, f"Token update should have failed with TOKEN_IS_IMMUTABLE status but got: {ResponseCode(receipt.status).name}"
     finally:
         env.close()
 
@@ -647,7 +647,7 @@ def test_integration_token_update_transaction_cannot_update_immutable_nft():
             .execute(env.client)
         )
         
-        assert receipt.status == ResponseCode.TOKEN_IS_IMMUTABLE, f"Token update should have failed with TOKEN_IS_IMMUTABLE status but got: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.TOKEN_IS_IMMUTABLE, f"Token update should have failed with TOKEN_IS_IMMUTABLE status but got: {ResponseCode(receipt.status).name}"
     finally:
         env.close()
 
@@ -675,7 +675,7 @@ def test_integration_token_update_auto_renew_account():
            .sign(recipient.key)
            .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Token update transaction failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token update transaction failed with status: {ResponseCode(receipt.status).name}"
         
         new_info = (
             TokenInfoQuery()
@@ -710,7 +710,7 @@ def test_integration_token_update_expiration_time():
            .freeze_with(env.client)
            .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Token update transaction failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token update transaction failed with status: {ResponseCode(receipt.status).name}"
         
         new_info = (
             TokenInfoQuery()
@@ -756,7 +756,7 @@ def test_integration_token_update_kyc_key_fungible_token():
             .sign(new_kyc_key)
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode(receipt.status).name}"
 
         token_info = TokenInfoQuery(token_id=token_id).execute(env.client)
         assert token_info.kyc_key.to_string() == new_kyc_key.public_key().to_string(), "Updated kyc_key mismatch"
@@ -808,7 +808,7 @@ def test_integration_token_update_kyc_key_nft():
             .sign(new_kyc_key)
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode(receipt.status).name}"
 
         token_info = TokenInfoQuery(token_id=token_id).execute(env.client)
         assert token_info.kyc_key.to_string() == new_kyc_key.public_key().to_string(), "Updated kyc_key mismatch"
@@ -849,7 +849,7 @@ def test_integation_token_update_fee_schedule_key_fungible_token():
             .sign(admin_key)
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode(receipt.status).name}"
 
         token_info = TokenInfoQuery(token_id=token_id).execute(env.client)
         assert token_info.fee_schedule_key.to_string() == new_fee_schedule_key.public_key().to_string(), "Updated fee_schedule_key mismatch"
@@ -895,7 +895,7 @@ def test_integation_token_update_fee_schedule_key_nft():
             .sign(admin_key)
             .execute(env.client)
         )
-        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode(receipt.status).name}"
 
         token_info = TokenInfoQuery(token_id=token_id).execute(env.client)
         assert token_info.fee_schedule_key.to_string() == new_fee_schedule_key.public_key().to_string(), "Updated fee_schedule_key mismatch"
@@ -942,7 +942,7 @@ def test_integration_token_update_with_public_key():
             .execute(env.client)
         )
         
-        assert receipt.status == ResponseCode.SUCCESS, f"Token update transaction failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token update transaction failed with status: {ResponseCode(receipt.status).name}"
         
         # Query the token and verify the freeze key matches the public key
         info = TokenInfoQuery().set_token_id(token_id).execute(env.client)
@@ -1001,7 +1001,7 @@ def test_integration_token_update_non_custodial_workflow():
         
         receipt = tx_from_bytes.execute(env.client)
         
-        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token update failed with status: {ResponseCode(receipt.status).name}"
         
         # PROOF: Query the token and check if the freeze key matches
         token_info = TokenInfoQuery(token_id=token_id).execute(env.client)
@@ -1042,7 +1042,7 @@ def test_integration_token_update_with_ecdsa_public_key():
             .execute(env.client)
         )
         
-        assert receipt.status == ResponseCode.SUCCESS, f"Token update transaction failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token update transaction failed with status: {ResponseCode(receipt.status).name}"
         
         # Query the token and verify the admin key matches the public key
         token_info = TokenInfoQuery(token_id=token_id).execute(env.client)
@@ -1085,7 +1085,7 @@ def test_integration_token_update_with_mixed_key_types():
             .execute(env.client)
         )
         
-        assert receipt.status == ResponseCode.SUCCESS, f"Token update transaction failed with status: {ResponseCode.get_name(receipt.status)}"
+        assert receipt.status == ResponseCode.SUCCESS, f"Token update transaction failed with status: {ResponseCode(receipt.status).name}"
         
         # Query the token and verify all keys are correctly set
         token_info = TokenInfoQuery(token_id=token_id).execute(env.client)


### PR DESCRIPTION
**Description**:
Replace all usages of `ResponseCode.get_name(receipt.status)` with the canonical  `ResponseCode(receipt.status).name` .

- Replace `ResponseCode.get_name(receipt.status)` in examples
- Replace `ResponseCode.get_name(receipt.status)` in integration tests


Fixes #1136 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized how status codes are accessed throughout examples and integration tests for improved code consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->