### PR TITLE
chore: move helpful references to additional context

### DIFF
--- a/.github/ISSUE_TEMPLATE/05_intermediate_issue.yml
+++ b/.github/ISSUE_TEMPLATE/05_intermediate_issue.yml
@@ -59,10 +59,6 @@ body:
         > - A large architectural redesign
         > - A change requiring extensive cross-module refactors
         > - A breaking API change
-        >
-        > 📖 Helpful references:
-        > - `docs/sdk_developers/training`
-        > - `docs/sdk_developers/rebasing.md`
 
   - type: textarea
     id: problem
@@ -208,6 +204,8 @@ body:
       description: |
         Add any links, references, or extra notes that may help.
       value: |
-        Optional.
+        - [SDK Developer Docs](https://github.com/hiero-ledger/hiero-sdk-python/tree/main/docs/sdk_developers)
+        - [SDK Developer Training](https://github.com/hiero-ledger/hiero-sdk-python/tree/main/docs/sdk_developers/training)
+
     validations:
       required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Transformed `examples/tokens/custom_fee_fixed.py` to be an end-to-end example, that interacts with the Hedera network, rather than a static object demo.
 - Format token examples with Black for consistent code style and improved readability (#1119) 
 - Replaced `ResponseCode.get_name(receipt.status)` with the  `ResponseCode(receipt.status).name` across examples and integration tests for consistency. (#1136)
+- Moved helpful references to Additional Context section and added clickable links.
 
 
 


### PR DESCRIPTION
**Description**:
Moved useful resources from issue description to the section `section 📚 Additional Context or Resources` in file `.github/ISSUE_TEMPLATE/05_intermedite_issue.yml`.
Made the useful resources active links.


**Related issue(s)**:

Fixes #1141 

**Notes for reviewer**:
Tested on my fork
<img width="1694" height="617" alt="Schermata da 2025-12-19 12-55-48" src="https://github.com/user-attachments/assets/f0a8ae50-ec72-489e-a5aa-9f80b62a4959" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized issue template references to improve navigation and resource discoverability
  * Enhanced changelog with updated links to SDK developer documentation and training resources

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->