### PR TITLE
chore: refactor custom_royalty_fee.py into  modular functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Replaced `ResponseCode.get_name(receipt.status)` with the  `ResponseCode(receipt.status).name` across examples and integration tests for consistency. (#1136)
 - Moved helpful references to Additional Context section and added clickable links.
 - Transformed `examples\tokens\custom_royalty_fee.py` to be an end-to-end example, that interacts with the Hedera network, rather than a static object demo.
+- Refactored `examples/tokens/custom_royalty_fee.py` by splitting monolithic function custom_royalty_fee_example() into modular functions create_royalty_fee_object(), create_token_with_fee(), verify_token_fee(), and main() to improve readability, cleaned up setup_client() (#1169)
 
 
 


### PR DESCRIPTION
**Description**:

The script examples/tokens/custom_royalty_fee.py is refactored into smaller, modular functions.

**Related issue(s)**:

Fixes #1169 

**Notes for reviewer**:
Based on the proposed solution, the main function does not exit in the catch block after print(f"Execution failed: {e}"). Should we explicitly exit with a non-zero status (e.g., sys. exit(1)  after this line? 
Please let me know if you have any additional review comments.

**Checklist**

- [X] Changelog Entry 
- [X] Tested (re-ran unit tests and the file)
- [X] Signed Commit
- [X] Issue resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized custom royalty fee example code into clearer, modular steps for improved readability and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->