### PR TITLE
feat: Add custom CodeRabbit instructions for examples

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -46,7 +46,10 @@ reviews:
 
         **Priority 4 - Consistency**: 
         - Verify standard patterns: `def main()`, `if __name__ == "__main__":`, `load_dotenv()`.
-        - Ensure imports come from `hiero_sdk_python`.
+        - **IMPORT RULES**: 
+          1. Accept both top-level imports (e.g., `from hiero_sdk_python import PrivateKey`) and fully qualified imports (e.g., `from hiero_sdk_python.crypto.private_key import PrivateKey`).
+          2. STRICTLY validate that the import path actually exists in the project structure. Compare against other files in `/examples` or your knowledge of the SDK file tree.
+          3. Flag hallucinations immediately (e.g., `hiero_sdk_python.keys` does not exist).
         - Check for `try-except` blocks with `sys.exit(1)` for critical failures.
 
         **Priority 5 - User Experience**: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Added GitHub workflow that makes sure newly added test files follow pytest test files naming conventions (#1054)
 - Added advanced issue template for contributors `.github/ISSUE_TEMPLATE/06_advanced_issue.yml`.
 - Add new tests to `tests/unit/topic_info_query_test.py` (#1124)
+- Added prompt for codeRabbit on how to review /examples ([#1180](https://github.com/hiero-ledger/hiero-sdk-python/issues/1180)) 
 
 ### Changed
 - Reduce office-hours reminder spam by posting only on each user's most recent open PR, grouping by author and sorting by creation time (#1121)


### PR DESCRIPTION

**Description:**
Configures CodeRabbit to apply maintainer-level review standards to the `/examples` directory.

* Adds `path_instructions` for `examples/**/*`.
* Enforces correct transaction lifecycle (`freeze` -> `sign` -> `execute`).
* Enforces role-based naming conventions.
* Prioritizes run-ability and explicitness for user documentation.

**Related issue(s)**:

Fixes #1180 

