### PR TITLE
Add hiero_python_sdk_team.md 

### DIFF
--- a/docs/maintainers/hiero_python_sdk_team.md
+++ b/docs/maintainers/hiero_python_sdk_team.md
@@ -1,0 +1,16 @@
+# Hiero SDK Python Team
+
+## Triage Members
+| Role | GitHub Team Link |
+|------|-----------------|
+| Triage Members | [Link](https://github.com/orgs/hiero-ledger/teams/hiero-sdk-python-triage) |
+
+## Committer Members
+| Role | GitHub Team Link |
+|------|-----------------|
+| Committer Members | [Link](https://github.com/orgs/hiero-ledger/teams/hiero-sdk-python-committers) |
+
+## Maintainer Members
+| Role | GitHub Team Link |
+|------|-----------------|
+| Maintainer Members | [Link](https://github.com/orgs/hiero-ledger/teams/hiero-sdk-python-maintainers) |


### PR DESCRIPTION
**Description**:
This PR adds documentation for the Hiero SDK Python team.

It includes:
- A table for triage members
- A table for committer members
- A table for maintainer members

Each table links to the official GitHub team page as requested.

**Related issue(s)**:
Fixes #1064

**Notes for reviewer**:
This change adds documentation only; no code logic is affected.

**Checklist**
- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)

