### PR TITLE
feat: add explicit assignees mention to `issue reminder bot`

### DIFF
--- a/.github/scripts/bot-issue-reminder-no-pr.sh
+++ b/.github/scripts/bot-issue-reminder-no-pr.sh
@@ -134,8 +134,12 @@ echo "$ALL_ISSUES_JSON" | jq -c '.' | while read -r ISSUE_JSON; do
 
   echo "[REMIND] Issue #$ISSUE assigned for $DIFF_DAYS days, posting reminder."
 
-  # Post reminder comment
-  MESSAGE="Hi, this is ReminderBot. This issue has been assigned but has had no pull request created. Are you still planning on working on the issue?
+  ASSIGNEE_MENTIONS=$(echo "$ISSUE_JSON" | jq -r '.assignees[].login | "@" + .' | xargs)
+
+  MESSAGE="Hi ${ASSIGNEE_MENTIONS} 👋
+
+This issue has been assigned but no pull request has been created yet.
+Are you still planning on working on it?
 
 From the Python SDK Team"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Refactored `examples/tokens/custom_royalty_fee.py` by splitting monolithic function custom_royalty_fee_example() into modular functions create_royalty_fee_object(), create_token_with_fee(), verify_token_fee(), and main() to improve readability, cleaned up setup_client() (#1169)
 - Added comprehensive unit tests for Timestamp class (#1158)
 - Enhance unit and integration test review instructions for clarity and coverage `.coderabbit.yaml`.
+- Issue reminder bot now explicitly mentions assignees (e.g., `@user`) in comments. ([#1232](https://github.com/hiero-ledger/hiero-sdk-python/issues/1232))
 
 
 ### Fixed


### PR DESCRIPTION
**Description**:
This PR updates the `bot-issue-reminder-no-pr.sh` script to explicitly mention assigned users (e.g., `@user`) in the automated reminder comment.

Fixes #1232 

**Notes for reviewer**:

### Screenshots
**New Reminder Format:**
![9dd87c6e-9330-4d42-a009-7229f2e4988c](https://github.com/user-attachments/assets/4042f30c-f3f0-4bc9-acee-23c03d440e50)

### Testing
- Verified the `jq` logic locally to ensure it correctly extracts and formats `assignees[].login` into a space-separated string prefixed with `@`.
- The script continues to respect the `DRY_RUN` environment variable.

**Checklist**
- [x] Logic verifies correctly against GitHub API JSON structure.
- [x] Formatting respects the requested style ("Hi @user 👋").
- [x] Added entry to `CHANGELOG.md`.