### PR TITLE
fix: correct typo in workflow.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# Changelog
+# Changelog
 
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org).
@@ -111,6 +111,8 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- Fixed typo in workflow.md documentation - changed 'reslve' to 'resolve' in the changelog update section (#1248)
+
 - Fixed the README account balance example to use correct SDK APIs and provide a runnable testnet setup. (#1250)
 - Fix token association verification in `token_airdrop_transaction.py` to correctly check if tokens are associated by using `token_id in token_balances` instead of incorrectly displaying zero balances which was misleading (#[815])
 - Fixed inactivity bot workflow not checking out repository before running (#964)
@@ -151,6 +153,8 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Moved query examples to their respective domain folders to improve structure matching.
 
 ### Fixed
+
+- Fixed typo in workflow.md documentation - changed 'reslve' to 'resolve' in the changelog update section (#1248)
 
 - fixed workflow: changelog check with improved sensitivity to deletions, additions, new releases
 
@@ -211,6 +215,8 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- Fixed typo in workflow.md documentation - changed 'reslve' to 'resolve' in the changelog update section (#1248)
+
 - chore: updated solo action to avoid v5
 - chore: fix test.yml workflow to log import errors (#740)
 - chore: fixed integration test names without a test prefix or postfix
@@ -267,6 +273,8 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Refactor `AbstractTokenTransferTransaction` to unify Token/NFT transfer logic.
 
 ### Fixed
+
+- Fixed typo in workflow.md documentation - changed 'reslve' to 'resolve' in the changelog update section (#1248)
 
 - Added explicit read permissions to examples.yml (#623)
 - Removed deprecated Logger.warn() method and legacy parameter swap logic from get_logger() (#673).
@@ -340,6 +348,8 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- Fixed typo in workflow.md documentation - changed 'reslve' to 'resolve' in the changelog update section (#1248)
+
 - Add type hints to `setup_client()` and `create_new_account()` functions in `examples/account_create.py` (#418)
 - Added explicit read and write permissions to test.yml
 - Type hinting for `Topic` related transactions.
@@ -387,6 +397,8 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Converted class in `token_nft_info.py` to dataclass for simplicity.
 
 ### Fixed
+
+- Fixed typo in workflow.md documentation - changed 'reslve' to 'resolve' in the changelog update section (#1248)
 
 - Incompatible Types assignment in token_transfer_list.py
 - Corrected references to \_require_not_frozen() and removed the surplus \_is_frozen
@@ -455,6 +467,8 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - assert relationship.freeze_status == TokenFreezeStatus.FROZEN, f"Expected freeze status to be FROZEN, but got {relationship.freeze_status}" → assert relationship.freeze_status == TokenFreezeStatus.UNFROZEN, f"Expected freeze status to be UNFROZEN, but got {relationship.freeze_status}"
 
 ### Fixed
+
+- Fixed typo in workflow.md documentation - changed 'reslve' to 'resolve' in the changelog update section (#1248)
 
 - Format account_create_transaction.py and add type hints
 - Format account_balance.py and fix pylint issues
@@ -529,6 +543,8 @@ contract_call_local_pb2.ContractLoginfo -> contract_types_pb2.ContractLoginfo
 - ContractUpdateTransaction class
 
 ### Fixed
+
+- Fixed typo in workflow.md documentation - changed 'reslve' to 'resolve' in the changelog update section (#1248)
 
 - missing ECDSA support in query.py and contract_create_transaction.py (was only creating ED25519 keys)
 - Applied linting and code formatting across the consensus module
@@ -627,6 +643,8 @@ contract_call_local_pb2.ContractLoginfo -> contract_types_pb2.ContractLoginfo
 
 ### Fixed
 
+- Fixed typo in workflow.md documentation - changed 'reslve' to 'resolve' in the changelog update section (#1248)
+
 - fixed INVALID_NODE_ACCOUNT during node switching
 - fixed ed25519 key ambiguity (PrivateKey.from_string -> PrivateKey.from_string_ed25519 in examples)
 
@@ -645,6 +663,8 @@ contract_call_local_pb2.ContractLoginfo -> contract_types_pb2.ContractLoginfo
 - use SEC1 ECPrivateKey instead of PKCS#8
 
 ### Fixed
+
+- Fixed typo in workflow.md documentation - changed 'reslve' to 'resolve' in the changelog update section (#1248)
 
 - PR checks
 - misnamed parameter (ECDSASecp256k1=pub_bytes -> ECDSA_secp256k1=pub_bytes)
@@ -682,6 +702,8 @@ contract_call_local_pb2.ContractLoginfo -> contract_types_pb2.ContractLoginfo
 - N/A
 
 ### Fixed
+
+- Fixed typo in workflow.md documentation - changed 'reslve' to 'resolve' in the changelog update section (#1248)
 
 - N/A
 

--- a/docs/sdk_developers/workflow.md
+++ b/docs/sdk_developers/workflow.md
@@ -116,7 +116,7 @@ Under the existing [UNRELEASED] section, add a one-sentence description of your 
 
 See [Changelog Entry Guide](/docs/sdk_developers/changelog_entry.md)
 
-- ✅ **IMPORTANT** keep your main and branch regularly else your changelog will be out of date and it will be more difficult to reslve.
+- ✅ **IMPORTANT** keep your main and branch regularly else your changelog will be out of date and it will be more difficult to resolve.
 
 
 ### Workflow 5: Submit Your Pull Request


### PR DESCRIPTION
Fixed typo in changelog update section - changed 'reslve' to 'resolve'

Fixes #1248

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
