### PR TITLE
ci: notify GFI support team only after first issue comment

### DIFF
--- a/.github/scripts/gfi_notify_team.js
+++ b/.github/scripts/gfi_notify_team.js
@@ -1,17 +1,18 @@
-// Script to notify the team when a GFI issue is labeled.
+// Script to notify the team when a GFI issue receives its first human comment.
 
 const marker = '<!-- GFI Issue Notification -->';
 const TEAM_ALIAS = '@hiero-ledger/hiero-sdk-good-first-issue-support';
 
-async function notifyTeam(github, owner, repo, issue, message, marker) {
-  const comment = `${marker} :wave: Hello Team :wave:
+async function notifyTeam(github, owner, repo, issue, message) {
+  const commentBody = `${marker} :wave: Hello Team :wave:
 ${TEAM_ALIAS}
 
 ${message}
 
-Repository: ${owner}/${repo} : Issue: #${issue.number} - ${issue.title || '(no title)'}
+Repository: ${owner}/${repo}  
+Issue: #${issue.number} - ${issue.title || '(no title)'}
 
-Best Regards,
+Best Regards,  
 Python SDK team`;
 
   try {
@@ -19,55 +20,86 @@ Python SDK team`;
       owner,
       repo,
       issue_number: issue.number,
-      body: comment,
+      body: commentBody,
     });
-    console.log(`Notified team about GFI issue #${issue.number}`);
+    console.log(`✅ Notified team about GFI issue #${issue.number}`);
     return true;
-  } catch (commentErr) {
-    console.log(`Failed to notify team about GFI issue #${issue.number}:`, commentErr.message || commentErr);
+  } catch (err) {
+    console.log(`❌ Failed to notify team for #${issue.number}:`, err.message);
     return false;
   }
 }
 
 module.exports = async ({ github, context }) => {
+  console.log('Context debug:', {
+    actor: context.actor,
+    eventName: context.eventName,
+    repo: context.repo,
+  });
+
   try {
     const { owner, repo } = context.repo;
-    const { issue, label } = context.payload;
+    const { issue, comment } = context.payload;
 
-    if (!issue?.number) return console.log('No issue in payload');
-
-    const labelName = label?.name;
-    if (!labelName) return;
-
-    let message = '';
-    if (labelName === 'Good First Issue') {
-      message = 'There is a new GFI in the Python SDK which is ready to be assigned';
-    } else if (labelName === 'Good First Issue Candidate') {
-      message = 'An issue in the Python SDK requires immediate attention to verify if it is a GFI and label it appropriately';
-    } else {
-      return;
+    if (!issue?.number || !comment) {
+      return console.log('No issue or comment found in payload');
     }
 
-    // Check for existing comment
-    const comments = await github.paginate(github.rest.issues.listComments, {
-      owner, repo, issue_number: issue.number, per_page: 100
-    });
+    // Ignore bot comments
+    if (comment.user?.type === 'Bot') {
+      return console.log('Ignoring bot comment');
+    }
+
+    const labels = issue.labels?.map(l => l.name) || [];
+    
+    const isGFI = labels.includes('good first issue') 
+
+    if (!isGFI) {
+      return console.log('Issue is not a GFI');
+    }
+
+    // Skip if already assigned
+    if (issue.assignees && issue.assignees.length > 0) {
+      return console.log('Issue already assigned');
+    }
+
+    // Fetch all issue comments
+    const comments = await github.paginate(
+      github.rest.issues.listComments,
+      {
+        owner,
+        repo,
+        issue_number: issue.number,
+        per_page: 100,
+      }
+    );
+
+    // Skip if notification already exists
     if (comments.some(c => c.body?.includes(marker))) {
       return console.log(`Notification already exists for #${issue.number}`);
     }
 
-    // Post notification
-    const success = await notifyTeam(github, owner, repo, issue, message, marker);
+    // Check if this is the FIRST non-bot comment
+    const earlierNonBotComments = comments.filter(c =>
+      c.id !== comment.id &&
+      c.user?.type !== 'Bot'
+    );
 
-    if (success) {
-      console.log('=== Summary ===');
-      console.log(`Repository: ${owner}/${repo}`);
-      console.log(`Issue Number: ${issue.number}`);
-      console.log(`Label: ${labelName}`);
-      console.log(`Message: ${message}`);
+    if (earlierNonBotComments.length > 0) {
+      return console.log('Not the first non-bot comment, skipping');
     }
 
+    const message = `@${comment.user.login} commented on this **Good First Issue** and may be ready to be assigned. Please review and assign if appropriate.`;
+
+
+    await notifyTeam(github, owner, repo, issue, message);
+
+    console.log('=== Summary ===');
+    console.log(`Repository: ${owner}/${repo}`);
+    console.log(`Issue Number: ${issue.number}`);
+    console.log(`Triggered by: @${comment.user.login}`);
+    console.log(`Message: ${message}`);
   } catch (err) {
-    console.log('❌ Error:', err.message);
+     console.log('❌ Error:', err.message);
   }
 };

--- a/.github/workflows/bot-gfi-notify-team.yml
+++ b/.github/workflows/bot-gfi-notify-team.yml
@@ -1,9 +1,9 @@
 # This workflow notifies the GFI support team when an issue is labeled as a GFI or GFI Candidate.
 name: GFI Issue Notification
 on:
-  issues:
+  issue_comment:
     types:
-      - labeled
+      - created
 
 permissions:
   issues: write
@@ -13,11 +13,17 @@ jobs:
   gfi_notify_team:
     runs-on: ubuntu-latest
     if: >
-      (github.event_name == 'issues' && (
-          github.event.label.name == 'Good First Issue' ||
-          github.event.label.name == 'Good First Issue Candidate'
-      ))
+      github.event.issue.labels &&
+      contains(
+        join(github.event.issue.labels.*.name, ','),
+        'Good First Issue'
+      )
 
+
+    concurrency:
+      group: gfi-notify-issue-${{ github.event.issue.number }}
+      cancel-in-progress: false
+      
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+﻿# Changelog
 
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org).
@@ -76,6 +76,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Added merge conflict bot workflow (`.github/workflows/bot-merge-conflict.yml`) and helper script (`.github/scripts/bot-merge-conflict.js`) to detect and notify about PR merge conflicts, with retry logic for unknown mergeable states, idempotent commenting, and push-to-main recheck logic (#1247)
 
 ### Changed
+- Updated Good First Issue notifications to trigger only after the first comment is posted, reducing noise on unassigned issues.(#1212)
 - Bumped requests from 2.32.3 to 2.32.4 to 2.32.5
 - Moved `docs/sdk_developers/how_to_link_issues.md` to `docs/sdk_developers/training/workflow/how_to_link_issues.md` and updated all references (#1222)
 - Moved docs/sdk_developers/project_structure.md to docs/sdk_developers/training/setup/project_structure.md and ensured all previous references are updated [#1223](https://github.com/hiero-ledger/hiero-sdk-python/issues/1223)


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->
Update the Good First Issue notification workflow to trigger only after the first non-bot comment is posted on a Good First Issue. This reduces noise on newly created issues and better signals contributor interest before notifying the support team.
* Remove notification on Good First Issue creation
* Add notification trigger on first non-bot issue comment
* Prevent duplicate notifications
* Skip notifications for already assigned issues

**Related issue(s)**:

Fixes #1212 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
Tested in a fork by commenting on Good First Issues and verifying:
- Notification is posted on the first non-bot comment
- No notification is posted for non-GFI issues
- Duplicate notifications are not created
- Assigned issues are ignored

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
