### PR TITLE
fix: correct step-security/harden-runner SHA in merge conflict bot workflow

### DIFF
--- a/.github/workflows/bot-merge-conflict.yml
+++ b/.github/workflows/bot-merge-conflict.yml
@@ -33,7 +33,7 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
 
       - name: Harden the runner
-        uses: step-security/harden-runner@20cf3052978e1b6646b35198a5d69ed51a6c9d71 # v2.14.0
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
         with:
           egress-policy: audit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- Fixed step-security/harden-runner action SHA in merge conflict bot workflow (#1278)
 - Fixed the README account balance example to use correct SDK APIs and provide a runnable testnet setup. (#1250)
 - Fix token association verification in `token_airdrop_transaction.py` to correctly check if tokens are associated by using `token_id in token_balances` instead of incorrectly displaying zero balances which was misleading (#[815])
 - Fixed inactivity bot workflow not checking out repository before running (#964)


### PR DESCRIPTION
Fixes #1278

Corrected the SHA for step-security/harden-runner action in merge conflict bot workflow.

- From: 20cf3052978e1b6646b35198a5d69ed51a6c9d71
- To: 20cf305ff2072d973412fa9b1e3a4f227bda3c76

Also fixed duplicate Fixed section in CHANGELOG.md as suggested by CodeRabbit.