### PR TITLE
chore: format examples/tokens directory using black code formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Added method chaining examples to the developer training guide (`docs/sdk_developers/training/coding_token_transactions.md`) (#1194)
 - Added documentation explaining how to pin GitHub Actions to specific commit SHAs (`docs/sdk_developers/how-to-pin-github-actions.md`)(#1211)
 - examples/mypy.ini for stricter type checking in example scripts
+- Formatted examples/tokens directory using black code formatter for consistent code style
 - Added a GitHub Actions workflow that reminds contributors to link pull requests to issues.
 - Added `__str__` and `__repr__` methods to `AccountInfo` class for improved logging and debugging experience (#1098)
 - Added Good First Issue (GFI) management and frequency documentation to clarify maintainer expectations and SDK-level GFI governance.

--- a/examples/tokens/custom_fee_fixed.py
+++ b/examples/tokens/custom_fee_fixed.py
@@ -24,24 +24,27 @@ from hiero_sdk_python.tokens.token_type import TokenType
 load_dotenv()
 network_name = os.getenv("NETWORK", "testnet").lower()
 
+
 def setup_client():
     """Initialize and set up the client with operator account"""
     # Initialize network and client
     network = Network(network_name)
     print(f"Connecting to Hedera {network_name} network!")
     client = Client(network)
-    
+
     # This disables the SSL error in the local development environment (Keep commented for production) #
-    
+
     # client.set_transport_security(False)
     # client.set_verify_certificates(False)
 
     try:
-        operator_id_str = os.getenv('OPERATOR_ID')
-        operator_key_str = os.getenv('OPERATOR_KEY')
+        operator_id_str = os.getenv("OPERATOR_ID")
+        operator_key_str = os.getenv("OPERATOR_KEY")
 
         if not operator_id_str or not operator_key_str:
-            raise ValueError("Environment variables OPERATOR_ID or OPERATOR_KEY are missing.")
+            raise ValueError(
+                "Environment variables OPERATOR_ID or OPERATOR_KEY are missing."
+            )
 
         operator_id = AccountId.from_string(operator_id_str)
         operator_key = PrivateKey.from_string(operator_key_str)
@@ -49,11 +52,12 @@ def setup_client():
         client.set_operator(operator_id, operator_key)
         print(f"Client set up with operator id {client.operator_account_id}")
         return client, operator_id, operator_key
-    
+
     except (TypeError, ValueError) as e:
         print(f"Error: {e}")
         print("Please check OPERATOR_ID and OPERATOR_KEY in your .env file.")
         sys.exit(1)
+
 
 def custom_fixed_fee_example():
     """
@@ -67,9 +71,9 @@ def custom_fixed_fee_example():
     print("\n--- Creating Custom Fixed Fee ---")
 
     fixed_fee = CustomFixedFee(
-        amount=Hbar(1).to_tinybars(), 
+        amount=Hbar(1).to_tinybars(),
         fee_collector_account_id=operator_id,
-        all_collectors_are_exempt=False
+        all_collectors_are_exempt=False,
     )
 
     print(f"Fee Definition: Pay 1 HBAR to {operator_id}")
@@ -85,17 +89,19 @@ def custom_fixed_fee_example():
         .set_supply_type(SupplyType.INFINITE)
         .set_initial_supply(1000)
         .set_admin_key(operator_key)
-        .set_custom_fees([fixed_fee]) 
+        .set_custom_fees([fixed_fee])
         .freeze_with(client)
         .sign(operator_key)
     )
 
     try:
         receipt = transaction.execute(client)
-        
+
         # Check if the status is explicitly SUCCESS
         if receipt.status != ResponseCode.SUCCESS:
-            print(f"Transaction failed with status: {ResponseCode(receipt.status).name}")
+            print(
+                f"Transaction failed with status: {ResponseCode(receipt.status).name}"
+            )
 
         token_id = receipt.token_id
         print(f"Token created successfully with ID: {token_id}")
@@ -117,6 +123,7 @@ def custom_fixed_fee_example():
         sys.exit(1)
     finally:
         client.close()
+
 
 if __name__ == "__main__":
     custom_fixed_fee_example()

--- a/examples/tokens/custom_royalty_fee.py
+++ b/examples/tokens/custom_royalty_fee.py
@@ -3,7 +3,7 @@ Run with:
 uv run examples/tokens/custom_royalty_fee.py
 python examples/tokens/custom_royalty_fee.py
 """
- 
+
 import os
 import sys
 from dotenv import load_dotenv
@@ -23,20 +23,23 @@ from hiero_sdk_python.tokens.token_type import TokenType
 
 load_dotenv()
 
+
 def setup_client():
     """Initialize and set up the client with operator account"""
-    
+
     try:
         network_name = os.getenv("NETWORK", "testnet").lower()
         network = Network(network_name)
         print(f"Connecting to the Hedera {network_name} network")
         client = Client(network)
 
-        operator_id_str = os.getenv('OPERATOR_ID')
-        operator_key_str = os.getenv('OPERATOR_KEY')
+        operator_id_str = os.getenv("OPERATOR_ID")
+        operator_key_str = os.getenv("OPERATOR_KEY")
 
         if not operator_id_str or not operator_key_str:
-            raise ValueError("Environment variables OPERATOR_ID or OPERATOR_KEY are missing.")
+            raise ValueError(
+                "Environment variables OPERATOR_ID or OPERATOR_KEY are missing."
+            )
 
         operator_id = AccountId.from_string(operator_id_str)
         operator_key = PrivateKey.from_string(operator_key_str)
@@ -44,63 +47,68 @@ def setup_client():
         client.set_operator(operator_id, operator_key)
         print(f"Client set up with operator id {client.operator_account_id}")
         return client, operator_id, operator_key
-    
+
     except (TypeError, ValueError) as e:
         print(f"Error: {e}")
         sys.exit(1)
 
+
 def create_royalty_fee_object(operator_id):
     """Creates the CustomRoyaltyFee object with a fallback fee."""
     fallback_fee = CustomFixedFee(
-            amount=Hbar(1).to_tinybars(),
-            fee_collector_account_id=operator_id,
-            all_collectors_are_exempt=False
-        )
-    
-    royalty_fee =  CustomRoyaltyFee(
-            numerator=5, 
-            denominator=100,
-            fallback_fee=fallback_fee,
-            fee_collector_account_id=operator_id,
-            all_collectors_are_exempt=False
+        amount=Hbar(1).to_tinybars(),
+        fee_collector_account_id=operator_id,
+        all_collectors_are_exempt=False,
+    )
+
+    royalty_fee = CustomRoyaltyFee(
+        numerator=5,
+        denominator=100,
+        fallback_fee=fallback_fee,
+        fee_collector_account_id=operator_id,
+        all_collectors_are_exempt=False,
     )
     print(f"Royalty Fee Configured: {royalty_fee.numerator}/{royalty_fee.denominator}")
     print(f"Fallback Fee: {Hbar.from_tinybars(fallback_fee.amount)} HBAR")
     return royalty_fee
 
+
 def create_token_with_fee(client, operator_id, operator_key, royalty_fee):
     """Creates a token with the specified royalty fee attached."""
-    
+
     print("\n--- Creating Token with Royalty Fee ---")
     transaction = (
-            TokenCreateTransaction()
-            .set_token_name("Royalty NFT Collection")
-            .set_token_symbol("RNFT")
-            .set_treasury_account_id(operator_id)
-            .set_admin_key(operator_key)
-            .set_supply_key(operator_key)
-            .set_token_type(TokenType.NON_FUNGIBLE_UNIQUE)
-            .set_decimals(0)
-            .set_initial_supply(0)
-            .set_supply_type(SupplyType.FINITE)
-            .set_max_supply(100)
-            .set_custom_fees([royalty_fee])
-            .freeze_with(client)
-            .sign(operator_key)
-        )  
+        TokenCreateTransaction()
+        .set_token_name("Royalty NFT Collection")
+        .set_token_symbol("RNFT")
+        .set_treasury_account_id(operator_id)
+        .set_admin_key(operator_key)
+        .set_supply_key(operator_key)
+        .set_token_type(TokenType.NON_FUNGIBLE_UNIQUE)
+        .set_decimals(0)
+        .set_initial_supply(0)
+        .set_supply_type(SupplyType.FINITE)
+        .set_max_supply(100)
+        .set_custom_fees([royalty_fee])
+        .freeze_with(client)
+        .sign(operator_key)
+    )
 
     receipt = transaction.execute(client)
     if receipt.status != ResponseCode.SUCCESS:
         print(f"Token creation failed: {ResponseCode(receipt.status).name}")
-        raise RuntimeError(f"Token creation failed: {ResponseCode(receipt.status).name}")
-        
+        raise RuntimeError(
+            f"Token creation failed: {ResponseCode(receipt.status).name}"
+        )
+
     token_id = receipt.token_id
     print(f"Token created successfully with ID: {token_id}")
     return token_id
-    
+
+
 def verify_token_fee(client, token_id):
     """Queries the network to verify the fee exists."""
-   
+
     print("\n--- Verifying Fee on Network ---")
     token_info = TokenInfoQuery().set_token_id(token_id).execute(client)
     retrieved_fees = token_info.custom_fees
@@ -112,7 +120,8 @@ def verify_token_fee(client, token_id):
             print(f"Fee Details: {fee}")
     else:
         print("Error: No custom fees found on the token.")
-    
+
+
 def main():
     """Main execution flow."""
     client, operator_id, operator_key = setup_client()
@@ -120,10 +129,13 @@ def main():
     with client:
         try:
             royalty_fee = create_royalty_fee_object(operator_id)
-            token_id = create_token_with_fee(client, operator_id, operator_key, royalty_fee)
+            token_id = create_token_with_fee(
+                client, operator_id, operator_key, royalty_fee
+            )
             verify_token_fee(client, token_id)
         except Exception as e:
             print(f"Execution failed: {e}")
-            
+
+
 if __name__ == "__main__":
     main()

--- a/examples/tokens/token_update_transaction_key.py
+++ b/examples/tokens/token_update_transaction_key.py
@@ -105,9 +105,7 @@ def update_wipe_key_full_validation(client, token_id, old_wipe_key):
     )
 
     if receipt.status != ResponseCode.SUCCESS:
-        print(
-            f"Token update failed with status: {ResponseCode(receipt.status).name}"
-        )
+        print(f"Token update failed with status: {ResponseCode(receipt.status).name}")
         sys.exit(1)
 
     print(f"Successfully updated wipe key")

--- a/examples/tokens/token_update_transaction_nft.py
+++ b/examples/tokens/token_update_transaction_nft.py
@@ -69,9 +69,7 @@ def create_nft(client, operator_id, operator_key, metadata_key):
 
     # Check if nft creation was successful
     if receipt.status != ResponseCode.SUCCESS:
-        print(
-            f"NFT creation failed with status: {ResponseCode(receipt.status).name}"
-        )
+        print(f"NFT creation failed with status: {ResponseCode(receipt.status).name}")
         sys.exit(1)
 
     # Get token ID from receipt


### PR DESCRIPTION
**Description**:
Format examples/tokens directory using black code formatter for consistent code style

- Format 5 Python files in examples/tokens directory using black
- Add changelog entry for code formatting improvement
- Ensure consistent code style across token examples

**Related issue(s)**:

Fixes #1300 

**Notes for reviewer**:
Black formatter was applied to examples/tokens directory. 5 files were reformatted:
- custom_fee_fixed.py
- custom_royalty_fee.py  
- token_airdrop_transaction_cancel.py
- token_update_transaction_key.py
- token_update_transaction_nft.py

39 files were already properly formatted and remained unchanged.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)