### PR TITLE
chore: format examples/account with black

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Changed
 
+- Format `examples/account` Python examples using `black` for consistent code style and improved readability (#1301)
 -Update GitHub workflow names in `.github/workflows/bot-workflows.yml` to match correct references [(#1284)]
 - Renamed templates for improved clarity [(#1265)]
 - Updated Good First Issue notifications to trigger only after the first comment is posted, reducing noise on unassigned issues.(#1212)

--- a/examples/account/account_allowance_approve_transaction_hbar.py
+++ b/examples/account/account_allowance_approve_transaction_hbar.py
@@ -29,7 +29,6 @@ Notes:
     allowances and does not demonstrate revoking allowances or token/NFT usage.
 """
 
-
 import os
 import sys
 

--- a/examples/account/account_allowance_approve_transaction_nft.py
+++ b/examples/account/account_allowance_approve_transaction_nft.py
@@ -27,7 +27,6 @@ Usage:
     uv run examples/account/account_allowance_approve_transaction_nft.py
 """
 
-
 import os
 import sys
 from dotenv import load_dotenv
@@ -46,13 +45,14 @@ from hiero_sdk_python import (
     NftId,
     TokenAssociateTransaction,
     AccountAllowanceApproveTransaction,
-    TransferTransaction
+    TransferTransaction,
 )
 from hiero_sdk_python.account.account_create_transaction import AccountCreateTransaction
 
 load_dotenv()
 
-network_name = os.getenv('NETWORK', 'testnet').lower()
+network_name = os.getenv("NETWORK", "testnet").lower()
+
 
 def setup_client():
     """Initialize and set up the client with operator account"""
@@ -70,16 +70,17 @@ def setup_client():
 
     operator_id = AccountId.from_string(operator_id_str)
     operator_key = PrivateKey.from_string(operator_key_str)
-    
+
     client.set_operator(operator_id, operator_key)
     print(f"Client setup for NFT Owner (Operator): {client.operator_account_id}")
     return client, operator_id, operator_key
+
 
 def create_account(client, memo="Test Account"):
     """Create a new Hedera account with an initial balance."""
     private_key = PrivateKey.generate_ed25519()
     public_key = private_key.public_key()
-    
+
     tx = (
         AccountCreateTransaction()
         .set_key(public_key)
@@ -87,14 +88,15 @@ def create_account(client, memo="Test Account"):
         .set_account_memo(memo)
         .execute(client)
     )
-    
+
     if tx.status != ResponseCode.SUCCESS:
         print(f"Account creation failed: {ResponseCode(tx.status).name}")
         sys.exit(1)
-        
+
     account_id = tx.account_id
     print(f"Created new account ({memo}): {account_id}")
     return account_id, private_key
+
 
 def create_nft_token(client, owner_id, owner_key):
     """Create a new non-fungible token (NFT) with the owner as treasury."""
@@ -113,15 +115,16 @@ def create_nft_token(client, owner_id, owner_key):
         .freeze_with(client)
         .sign(owner_key)
     )
-    
+
     receipt = tx.execute(client)
-    
+
     if receipt.status != ResponseCode.SUCCESS:
         print(f"Token creation failed: {ResponseCode(receipt.status).name}")
         sys.exit(1)
-        
+
     print(f"NFT Owner ({owner_id}) created NFT Token: {receipt.token_id}")
     return receipt.token_id
+
 
 def mint_nft(client, token_id, metadata_list):
     """Mint NFT(s) with metadata."""
@@ -131,14 +134,17 @@ def mint_nft(client, token_id, metadata_list):
         .set_metadata(metadata_list)
         .execute(client)
     )
-    
+
     if tx.status != ResponseCode.SUCCESS:
         print(f"Mint failed: {ResponseCode(tx.status).name}")
         sys.exit(1)
-        
+
     serials = tx.serial_numbers
-    print(f"NFT Owner ({client.operator_account_id}) minted {len(serials)} NFT(s) for Token {token_id}: {serials}")
+    print(
+        f"NFT Owner ({client.operator_account_id}) minted {len(serials)} NFT(s) for Token {token_id}: {serials}"
+    )
     return [NftId(token_id, s) for s in serials]
+
 
 def associate_token_with_account(client, account_id, private_key, token_id):
     """Associate a token with an account."""
@@ -150,46 +156,53 @@ def associate_token_with_account(client, account_id, private_key, token_id):
         .sign(private_key)
         .execute(client)
     )
-    
+
     if tx.status != ResponseCode.SUCCESS:
         print(f"Association failed: {ResponseCode(tx.status).name}")
         sys.exit(1)
-        
+
     print(f"Associated token {token_id} with Receiver account {account_id}")
+
 
 def approve_nft_allowance(client, nft_id, owner_id, spender_id, owner_key):
     """Approve NFT allowance for a spender."""
     tx = (
         AccountAllowanceApproveTransaction()
-        .approve_token_nft_allowance_all_serials(
-            nft_id.token_id, owner_id, spender_id
-        )
+        .approve_token_nft_allowance_all_serials(nft_id.token_id, owner_id, spender_id)
         .freeze_with(client)
         .sign(owner_key)
         .execute(client)
     )
-    
+
     if tx.status != ResponseCode.SUCCESS:
         print(f"Approval failed: {ResponseCode(tx.status).name}")
         sys.exit(1)
-        
-    print(f"NFT Owner ({owner_id}) approved Spender ({spender_id}) for NFT {nft_id.token_id} (all serials)")
+
+    print(
+        f"NFT Owner ({owner_id}) approved Spender ({spender_id}) for NFT {nft_id.token_id} (all serials)"
+    )
+
 
 def transfer_nft_using_allowance(spender_client, nft_id, owner_id, receiver_id):
     """Transfer an NFT using approved allowance via the spender client."""
-    print(f"Spender ({spender_client.operator_account_id}) transferring NFT {nft_id} from Owner ({owner_id})...")
-    
+    print(
+        f"Spender ({spender_client.operator_account_id}) transferring NFT {nft_id} from Owner ({owner_id})..."
+    )
+
     tx = (
         TransferTransaction()
         .add_approved_nft_transfer(nft_id, owner_id, receiver_id)
         .execute(spender_client)
     )
-    
+
     if tx.status != ResponseCode.SUCCESS:
         print(f"Transfer failed: {ResponseCode(tx.status).name}")
         sys.exit(1)
-        
-    print(f"SUCCESS: Spender ({spender_client.operator_account_id}) transferred NFT {nft_id} to Receiver ({receiver_id})")
+
+    print(
+        f"SUCCESS: Spender ({spender_client.operator_account_id}) transferred NFT {nft_id} to Receiver ({receiver_id})"
+    )
+
 
 def main():
     """End-to-end demonstration."""
@@ -216,16 +229,18 @@ def main():
         spender_client = Client(owner_client.network)
         spender_client.set_operator(spender_id, spender_key)
         print(f"Client setup for Spender: {spender_id}")
-        
+
         # Transfer NFT using the allowance
         transfer_nft_using_allowance(spender_client, nft_id, owner_id, receiver_id)
 
     except Exception as e:
         print(f"Error: {e}")
         import traceback
+
         traceback.print_exc()
     finally:
         owner_client.close()
+
 
 if __name__ == "__main__":
     main()

--- a/examples/account/account_allowance_delete_transaction_nft.py
+++ b/examples/account/account_allowance_delete_transaction_nft.py
@@ -31,12 +31,13 @@ from hiero_sdk_python import (
     TokenId,
     TokenAssociateTransaction,
     AccountAllowanceApproveTransaction,
-    TransferTransaction
+    TransferTransaction,
 )
 from hiero_sdk_python.account.account_create_transaction import AccountCreateTransaction
 
 load_dotenv()
-network_name = os.getenv('NETWORK', 'testnet').lower()
+network_name = os.getenv("NETWORK", "testnet").lower()
+
 
 def setup_client():
     """Initialize and set up the client with operator account"""
@@ -55,17 +56,18 @@ def setup_client():
 
     operator_id = AccountId.from_string(operator_id_str)
     operator_key = PrivateKey.from_string(operator_key_str)
-    
+
     client.set_operator(operator_id, operator_key)
     print(f"Client setup for NFT Owner (Operator): {client.operator_account_id}")
-    
+
     return client, operator_id, operator_key
+
 
 def create_account(client, memo="Test Account"):
     """Create a new Hedera account."""
     private_key = PrivateKey.generate_ed25519()
     public_key = private_key.public_key()
-    
+
     tx = (
         AccountCreateTransaction()
         .set_key(public_key)
@@ -77,7 +79,9 @@ def create_account(client, memo="Test Account"):
     try:
         receipt = tx
         if receipt.status != ResponseCode.SUCCESS:
-            print(f"Account creation failed ({memo}): {ResponseCode(receipt.status).name}")
+            print(
+                f"Account creation failed ({memo}): {ResponseCode(receipt.status).name}"
+            )
             sys.exit(1)
 
         account_id = receipt.account_id
@@ -87,9 +91,10 @@ def create_account(client, memo="Test Account"):
         print(f"Account creation exception ({memo}): {e}")
         sys.exit(1)
 
+
 def create_nft_token(client, owner_id, owner_key):
     """Create a new non-fungible token (NFT)."""
-    
+
     tx = (
         TokenCreateTransaction()
         .set_token_name("DeleteTest NFT")
@@ -104,7 +109,7 @@ def create_nft_token(client, owner_id, owner_key):
         .freeze_with(client)
         .sign(owner_key)
     )
-    
+
     try:
         receipt = tx.execute(client)
 
@@ -117,6 +122,7 @@ def create_nft_token(client, owner_id, owner_key):
     except Exception as e:
         print(f"Token creation exception: {e}")
         sys.exit(1)
+
 
 def mint_nft(client, token_id, metadata_list):
     """Mint NFT(s)."""
@@ -134,11 +140,14 @@ def mint_nft(client, token_id, metadata_list):
             sys.exit(1)
 
         serials = receipt.serial_numbers
-        print(f"NFT Owner ({client.operator_account_id}) minted {len(serials)} NFT(s) for Token {token_id}: {serials}")
+        print(
+            f"NFT Owner ({client.operator_account_id}) minted {len(serials)} NFT(s) for Token {token_id}: {serials}"
+        )
         return [NftId(token_id, s) for s in serials]
     except Exception as e:
         print(f"NFT minting exception: {e}")
         sys.exit(1)
+
 
 def associate_token_with_account(client, account_id, private_key, token_id):
     """Associate a token with an account."""
@@ -154,7 +163,9 @@ def associate_token_with_account(client, account_id, private_key, token_id):
 
         receipt = tx
         if receipt.status != ResponseCode.SUCCESS:
-            print(f"Token association failed for {account_id}: {ResponseCode(receipt.status).name}")
+            print(
+                f"Token association failed for {account_id}: {ResponseCode(receipt.status).name}"
+            )
             sys.exit(1)
 
         print(f"Associated token {token_id} with Receiver account {account_id}")
@@ -162,14 +173,19 @@ def associate_token_with_account(client, account_id, private_key, token_id):
         print(f"Token association exception for {account_id}: {e}")
         sys.exit(1)
 
-def approve_nft_allowance_all_serials(client, token_id: TokenId, owner_id: AccountId, spender_id: AccountId, owner_key: PrivateKey):
+
+def approve_nft_allowance_all_serials(
+    client,
+    token_id: TokenId,
+    owner_id: AccountId,
+    spender_id: AccountId,
+    owner_key: PrivateKey,
+):
     """Approve NFT allowance for ALL serials for a spender."""
     try:
         tx = (
             AccountAllowanceApproveTransaction()
-            .approve_token_nft_allowance_all_serials(
-                token_id, owner_id, spender_id
-            )
+            .approve_token_nft_allowance_all_serials(token_id, owner_id, spender_id)
             .freeze_with(client)
             .sign(owner_key)
             .execute(client)
@@ -180,23 +196,32 @@ def approve_nft_allowance_all_serials(client, token_id: TokenId, owner_id: Accou
             print(f"Allowance approval failed: {ResponseCode(receipt.status).name}")
             sys.exit(1)
 
-        print(f"NFT Owner ({owner_id}) approved Spender ({spender_id}) for ALL serials of token {token_id}")
+        print(
+            f"NFT Owner ({owner_id}) approved Spender ({spender_id}) for ALL serials of token {token_id}"
+        )
     except Exception as e:
         print(f"Allowance approval exception: {e}")
         sys.exit(1)
 
-def delete_nft_allowance_all_serials(client, token_id: TokenId, owner_id: AccountId, spender_id: AccountId, owner_key: PrivateKey):
+
+def delete_nft_allowance_all_serials(
+    client,
+    token_id: TokenId,
+    owner_id: AccountId,
+    spender_id: AccountId,
+    owner_key: PrivateKey,
+):
     """
     Revokes an "approve for all serials" NFT allowance from a spender.
     """
-    print(f"NFT Owner ({owner_id}) deleting 'approve for all' allowance for {token_id} from Spender ({spender_id})...")
-    
+    print(
+        f"NFT Owner ({owner_id}) deleting 'approve for all' allowance for {token_id} from Spender ({spender_id})..."
+    )
+
     try:
         tx = (
             AccountAllowanceApproveTransaction()
-            .delete_token_nft_allowance_all_serials(
-                token_id, owner_id, spender_id
-            )
+            .delete_token_nft_allowance_all_serials(token_id, owner_id, spender_id)
             .freeze_with(client)
             .sign(owner_key)
             .execute(client)
@@ -212,13 +237,18 @@ def delete_nft_allowance_all_serials(client, token_id: TokenId, owner_id: Accoun
         print(f"Allowance deletion exception: {e}")
         sys.exit(1)
 
-def verify_allowance_removed(spender_client, nft_id: NftId, owner_id: AccountId, receiver_id: AccountId):
+
+def verify_allowance_removed(
+    spender_client, nft_id: NftId, owner_id: AccountId, receiver_id: AccountId
+):
     """
     Try to transfer NFT after allowance removal (should fail).
     This transaction is paid for and signed by the SPENDER.
     """
-    print(f"\nVerifying allowance removal by Spender ({spender_client.operator_account_id}) attempting transfer...")
-    
+    print(
+        f"\nVerifying allowance removal by Spender ({spender_client.operator_account_id}) attempting transfer..."
+    )
+
     try:
         receipt = (
             TransferTransaction()
@@ -227,16 +257,21 @@ def verify_allowance_removed(spender_client, nft_id: NftId, owner_id: AccountId,
         )
 
         if receipt.status == ResponseCode.SPENDER_DOES_NOT_HAVE_ALLOWANCE:
-            print("Verification SUCCEEDED: Transfer failed with SPENDER_DOES_NOT_HAVE_ALLOWANCE as expected.")
+            print(
+                "Verification SUCCEEDED: Transfer failed with SPENDER_DOES_NOT_HAVE_ALLOWANCE as expected."
+            )
         elif receipt.status == ResponseCode.SUCCESS:
             print(f"Verification FAILED: Transfer succeeded unexpectedly!")
             sys.exit(1)
         else:
-            print(f"Verification FAILED: Transfer failed with an unexpected status: {ResponseCode(receipt.status).name}")
+            print(
+                f"Verification FAILED: Transfer failed with an unexpected status: {ResponseCode(receipt.status).name}"
+            )
             sys.exit(1)
     except Exception as e:
         print(f"Verification exception while attempting transfer as spender: {e}")
         sys.exit(1)
+
 
 def main():
     """End-to-end demonstration of NFT allowance deletion."""
@@ -250,23 +285,27 @@ def main():
         # 2. Create and mint NFT
         token_id = create_nft_token(owner_client, owner_id, owner_key)
         nft_ids = mint_nft(owner_client, token_id, [b"Metadata 1"])
-        nft_id = nft_ids[0] # The specific NFT we will try to transfer
+        nft_id = nft_ids[0]  # The specific NFT we will try to transfer
 
         # 3. Associate receiver
         associate_token_with_account(owner_client, receiver_id, receiver_key, token_id)
 
         # 4. Approve allowance (for all serials)
-        approve_nft_allowance_all_serials(owner_client, token_id, owner_id, spender_id, owner_key)
+        approve_nft_allowance_all_serials(
+            owner_client, token_id, owner_id, spender_id, owner_key
+        )
 
         # 5. Delete the "all serials" allowance
-        delete_nft_allowance_all_serials(owner_client, token_id, owner_id, spender_id, owner_key)
+        delete_nft_allowance_all_serials(
+            owner_client, token_id, owner_id, spender_id, owner_key
+        )
 
         # 6. Verify deletion
         print("\nSetting up client for the Spender...")
         spender_client = Client(owner_client.network)
         spender_client.set_operator(spender_id, spender_key)
         print(f"Client setup for Spender: {spender_id}")
-        
+
         # We try to transfer the specific serial (nft_id)
         verify_allowance_removed(spender_client, nft_id, owner_id, receiver_id)
 
@@ -274,6 +313,7 @@ def main():
         print(f"Error: {e}")
     finally:
         owner_client.close()
+
 
 if __name__ == "__main__":
     main()

--- a/examples/account/account_create_transaction.py
+++ b/examples/account/account_create_transaction.py
@@ -13,7 +13,7 @@ The example creates an account with:
 Usage:
     Run this script directly:
         python examples/account/account_create_transaction.py
-    
+
     Or using uv:
         uv run examples/account/account_create_transaction.py
 
@@ -27,6 +27,7 @@ Environment Variables:
     OPERATOR_KEY (str): The private key of the operator account
     NETWORK (str, optional): Network to use (default: "testnet")
 """
+
 import sys
 from hiero_sdk_python import (
     Client,
@@ -35,12 +36,13 @@ from hiero_sdk_python import (
     ResponseCode,
 )
 
+
 def create_new_account(client: Client) -> None:
     """
     Create a new Hedera account with generated keys and initial balance.
 
     This function generates a new Ed25519 key pair, creates an account creation
-    transaction, signs it with the operator key, and executes it on the network. 
+    transaction, signs it with the operator key, and executes it on the network.
     The new account is created with an initial balance and a custom memo.
 
     Args:
@@ -62,7 +64,7 @@ def create_new_account(client: Client) -> None:
     Example Output:
         Transaction status: ResponseCode.SUCCESS
         Account creation successful. New Account ID: 0.0.123456
-        New Account Private Key:  302e020100300506032b657004220420... 
+        New Account Private Key:  302e020100300506032b657004220420...
         New Account Public Key: 302a300506032b6570032100...
     """
     new_account_private_key = PrivateKey.generate("ed25519")
@@ -93,13 +95,16 @@ def create_new_account(client: Client) -> None:
             print(f"   New Account Private Key: {new_account_private_key.to_string()}")
             print(f"   New Account Public Key: {new_account_public_key.to_string()}")
         else:
-            raise Exception("AccountID not found in receipt.  Account may not have been created.")
+            raise Exception(
+                "AccountID not found in receipt.  Account may not have been created."
+            )
 
     except Exception as e:
         print(f"❌ Account creation failed: {str(e)}")
         sys.exit(1)
 
-if __name__ == "__main__": 
+
+if __name__ == "__main__":
     client = Client.from_env()
     print(f"Operator: {client.operator_account_id}")
     create_new_account(client)

--- a/examples/account/account_create_transaction_create_with_alias.py
+++ b/examples/account/account_create_transaction_create_with_alias.py
@@ -97,21 +97,15 @@ def create_account_with_ecdsa_alias(
     alias_public_key = alias_private_key.public_key()
 
     # Use the helper that accepts both the main key and the ECDSA alias key
-    transaction = (
-        AccountCreateTransaction(
-            initial_balance=Hbar(5),
-            memo="Account with separate ECDSA alias",
-        )
-        .set_key_with_alias(main_private_key, alias_public_key)
-    )
+    transaction = AccountCreateTransaction(
+        initial_balance=Hbar(5),
+        memo="Account with separate ECDSA alias",
+    ).set_key_with_alias(main_private_key, alias_public_key)
 
     # Freeze and sign:
     # - operator key signs as payer (via client)
     # - alias private key MUST sign to authorize the alias
-    transaction = (
-        transaction.freeze_with(client)
-        .sign(alias_private_key)
-    )
+    transaction = transaction.freeze_with(client).sign(alias_private_key)
 
     response = transaction.execute(client)
     new_account_id = response.account_id
@@ -136,11 +130,7 @@ def fetch_account_info(client: Client, account_id: AccountId) -> AccountInfo:
         AccountInfo: The account info object.
     """
     print("\nSTEP 3: Fetching account information...")
-    account_info = (
-        AccountInfoQuery()
-        .set_account_id(account_id)
-        .execute(client)
-    )
+    account_info = AccountInfoQuery().set_account_id(account_id).execute(client)
     return account_info
 
 

--- a/examples/account/account_create_transaction_evm_alias.py
+++ b/examples/account/account_create_transaction_evm_alias.py
@@ -23,7 +23,8 @@ from hiero_sdk_python import (
 )
 
 load_dotenv()
-network_name = os.getenv('NETWORK', 'testnet').lower()
+network_name = os.getenv("NETWORK", "testnet").lower()
+
 
 def setup_client():
     network = Network(network_name)
@@ -32,8 +33,8 @@ def setup_client():
 
     # Get the operator account from the .env file
     try:
-        operator_id = AccountId.from_string(os.getenv('OPERATOR_ID', ''))
-        operator_key = PrivateKey.from_string(os.getenv('OPERATOR_KEY', ''))
+        operator_id = AccountId.from_string(os.getenv("OPERATOR_ID", ""))
+        operator_key = PrivateKey.from_string(os.getenv("OPERATOR_KEY", ""))
         # Set the operator (payer) account for the client
         client.set_operator(operator_id, operator_key)
         print(f"Client set up with operator id {client.operator_account_id}")
@@ -41,6 +42,7 @@ def setup_client():
     except Exception:
         print("Error: Please check OPERATOR_ID and OPERATOR_KEY in your .env file.")
         sys.exit(1)
+
 
 def generate_alias_key():
     """
@@ -55,7 +57,7 @@ def generate_alias_key():
             - evm_address (str): The derived EVM address to be used as an alias.
     """
     print("\nSTEP 1: Generating a new ECDSA key pair for the account alias...")
-    private_key = PrivateKey.generate('ecdsa')
+    private_key = PrivateKey.generate("ecdsa")
     public_key = private_key.public_key()
     evm_address = public_key.to_evm_address()
     if evm_address is None:
@@ -63,6 +65,7 @@ def generate_alias_key():
         sys.exit(1)
     print(f"✅ Generated new ECDSA key pair. EVM Address (alias): {evm_address}")
     return private_key, public_key, evm_address
+
 
 def create_account_with_alias(client, private_key, public_key, evm_address):
     """
@@ -88,9 +91,11 @@ def create_account_with_alias(client, private_key, public_key, evm_address):
     )
 
     # Sign the transaction with both the new key and the operator key
-    transaction = transaction.freeze_with(client) \
-        .sign(private_key) \
+    transaction = (
+        transaction.freeze_with(client)
+        .sign(private_key)
         .sign(client.operator_private_key)
+    )
 
     # Execute the transaction
     response = transaction.execute(client)
@@ -107,6 +112,7 @@ def create_account_with_alias(client, private_key, public_key, evm_address):
     print(f"✅ Account created with ID: {new_account_id}\n")
     return new_account_id
 
+
 def fetch_account_info(client, account_id):
     """
     Retrieve detailed information for a given account from the Hedera network.
@@ -117,6 +123,7 @@ def fetch_account_info(client, account_id):
         The account information object returned by `AccountInfoQuery.execute(client)`.
     """
     return AccountInfoQuery().set_account_id(account_id).execute(client)
+
 
 def print_account_summary(account_info):
     """
@@ -134,6 +141,7 @@ def print_account_summary(account_info):
     else:
         print("❌ Error: Contract Account ID (alias) does not exist.")
 
+
 def main():
     """
     Orchestrate the example workflow for creating an account using an EVM-style alias.
@@ -148,16 +156,19 @@ def main():
     client = setup_client()
     try:
         private_key, public_key, evm_address = generate_alias_key()
-        
-        new_account_id = create_account_with_alias(client, private_key, public_key, evm_address)
-        
+
+        new_account_id = create_account_with_alias(
+            client, private_key, public_key, evm_address
+        )
+
         account_info = fetch_account_info(client, new_account_id)
-        
+
         print_account_summary(account_info)
 
     except Exception as error:
         print(f"❌ Error: {error}")
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/examples/account/account_create_transaction_with_fallback_alias.py
+++ b/examples/account/account_create_transaction_with_fallback_alias.py
@@ -48,7 +48,8 @@ def setup_client():
         print("Error: Please check OPERATOR_ID and OPERATOR_KEY in your .env file.")
         sys.exit(1)
 
-def generate_fallback_key() -> PrivateKey: 
+
+def generate_fallback_key() -> PrivateKey:
     """Generate an ECDSA key pair and validate its EVM address."""
     print("\nSTEP 1: Generating a single ECDSA key pair for the account...")
     account_private_key = PrivateKey.generate("ecdsa")
@@ -64,16 +65,15 @@ def generate_fallback_key() -> PrivateKey:
     return account_private_key
 
 
-def create_account_with_fallback_alias(client: Client, account_private_key: PrivateKey) -> AccountId:
+def create_account_with_fallback_alias(
+    client: Client, account_private_key: PrivateKey
+) -> AccountId:
     """Create an account whose alias is derived from the provided ECDSA key."""
     print("\nSTEP 2: Creating the account using the fallback alias behaviour...")
-    transaction = (
-        AccountCreateTransaction(
-            initial_balance=Hbar(5),
-            memo="Account with alias derived from main ECDSA key",
-        )
-        .set_key_with_alias(account_private_key)
-    )
+    transaction = AccountCreateTransaction(
+        initial_balance=Hbar(5),
+        memo="Account with alias derived from main ECDSA key",
+    ).set_key_with_alias(account_private_key)
 
     transaction = transaction.freeze_with(client).sign(account_private_key)
 
@@ -106,6 +106,7 @@ def print_account_summary(account_info) -> None:
         f"{account_info.contract_account_id}"
     )
 
+
 def main():
     """Main entry point."""
     client = setup_client()
@@ -117,6 +118,7 @@ def main():
     except Exception as error:
         print(f"❌ Error: {error}")
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/examples/account/account_create_transaction_without_alias.py
+++ b/examples/account/account_create_transaction_without_alias.py
@@ -48,6 +48,7 @@ def setup_client():
         print("Error: Please check OPERATOR_ID and OPERATOR_KEY in your .env file.")
         sys.exit(1)
 
+
 def create_account_without_alias(client: Client) -> None:
     """Create an account explicitly without an alias."""
     try:
@@ -59,18 +60,12 @@ def create_account_without_alias(client: Client) -> None:
 
         print("\nSTEP 2: Creating the account without setting any alias...")
 
-        transaction = (
-            AccountCreateTransaction(
-                initial_balance=Hbar(5),
-                memo="Account created without alias",
-            )
-            .set_key_without_alias(account_private_key)
-        )
+        transaction = AccountCreateTransaction(
+            initial_balance=Hbar(5),
+            memo="Account created without alias",
+        ).set_key_without_alias(account_private_key)
 
-        transaction = (
-            transaction.freeze_with(client)
-            .sign(account_private_key)
-        )
+        transaction = transaction.freeze_with(client).sign(account_private_key)
 
         response = transaction.execute(client)
         new_account_id = response.account_id
@@ -82,11 +77,7 @@ def create_account_without_alias(client: Client) -> None:
 
         print(f"✅ Account created with ID: {new_account_id}\n")
 
-        account_info = (
-            AccountInfoQuery()
-            .set_account_id(new_account_id)
-            .execute(client)
-        )
+        account_info = AccountInfoQuery().set_account_id(new_account_id).execute(client)
 
         out = info_to_dict(account_info)
         print("Account Info:")
@@ -101,10 +92,12 @@ def create_account_without_alias(client: Client) -> None:
         print(f"❌ Error: {error}")
         sys.exit(1)
 
+
 def main():
     """Main entry point."""
     client = setup_client()
     create_account_without_alias(client)
+
 
 if __name__ == "__main__":
     main()

--- a/examples/account/account_delete_transaction.py
+++ b/examples/account/account_delete_transaction.py
@@ -5,15 +5,17 @@ uv run examples/account/account_delete_transaction.py
 python examples/account/account_delete_transaction.py
 
 """
+
 import sys
 from hiero_sdk_python import (
-    Client, 
-    Hbar, 
+    Client,
+    Hbar,
     PrivateKey,
     AccountCreateTransaction,
     AccountDeleteTransaction,
-    ResponseCode
+    ResponseCode,
 )
+
 
 def create_account(client):
     """Create a test account"""

--- a/examples/account/account_id.py
+++ b/examples/account/account_id.py
@@ -79,7 +79,9 @@ def compare_account_ids():
     print(f"\nHash of AccountId 1: {hash(account_id1)}")
     print(f"Hash of AccountId 2: {hash(account_id2)}")
     print(f"Hash of AccountId 3: {hash(account_id3)}")
-    print(f"Are hashes of AccountId 1 and 2 equal? {hash(account_id1) == hash(account_id2)}")
+    print(
+        f"Are hashes of AccountId 1 and 2 equal? {hash(account_id1) == hash(account_id2)}"
+    )
 
 
 def create_account_id_with_alias():

--- a/examples/account/account_info.py
+++ b/examples/account/account_info.py
@@ -12,9 +12,11 @@ from hiero_sdk_python.tokens.token_id import TokenId
 from hiero_sdk_python.tokens.token_relationship import TokenRelationship
 from hiero_sdk_python.account.account_info import AccountInfo
 
+
 def create_mock_account_id() -> AccountId:
     """Create a mock AccountId."""
     return AccountId.from_string("0.0.1234")
+
 
 def create_mock_public_key() -> PublicKey:
     """Generate a random ED25519 public key for demonstration."""
@@ -22,22 +24,27 @@ def create_mock_public_key() -> PublicKey:
     public_key_demo = private_key_demo.public_key()
     return public_key_demo
 
+
 def create_mock_balance() -> Hbar:
     """Return a mock account balance."""
     return Hbar(100)
 
+
 def create_mock_expiration_time() -> Timestamp:
     """Return a sample expiration timestamp (arbitrary future date)."""
-    return Timestamp(seconds=1736539200,nanos=100)
+    return Timestamp(seconds=1736539200, nanos=100)
+
 
 def create_mock_auto_renew_period() -> Duration:
     """Return a 90-day auto-renew period."""
     return Duration(seconds=7776000)
 
+
 def create_mock_token_relationship() -> TokenRelationship:
     """Create a sample token relationship with a mock token."""
     token_id = TokenId.from_string("0.0.9999")
     return TokenRelationship(token_id=token_id, balance=50)
+
 
 def build_mock_account_info() -> AccountInfo:
     """Construct a complete AccountInfo instance manually (no network calls)."""
@@ -51,15 +58,18 @@ def build_mock_account_info() -> AccountInfo:
     info.account_memo = "Mock Account for Example"
     return info
 
+
 def print_account_info(info: AccountInfo) -> None:
     """Pretty-print key AccountInfo fields."""
     print("📜 AccountInfo String Representation:")
     print(info)
 
+
 def main():
     """Run the AccountInfo example."""
     info = build_mock_account_info()
     print_account_info(info)
+
 
 if __name__ == "__main__":
     main()

--- a/examples/account/account_records_query.py
+++ b/examples/account/account_records_query.py
@@ -23,7 +23,8 @@ from hiero_sdk_python.transaction.transfer_transaction import TransferTransactio
 
 load_dotenv()
 
-network_name = os.getenv('NETWORK', 'testnet').lower()
+network_name = os.getenv("NETWORK", "testnet").lower()
+
 
 def setup_client():
     """Initialize and set up the client with operator account"""
@@ -54,7 +55,9 @@ def create_account(client):
     )
 
     if receipt.status != ResponseCode.SUCCESS:
-        print(f"Account creation failed with status: {ResponseCode(receipt.status).name}")
+        print(
+            f"Account creation failed with status: {ResponseCode(receipt.status).name}"
+        )
         sys.exit(1)
 
     account_id = receipt.account_id
@@ -69,27 +72,27 @@ def format_single_record(record, idx):
     lines.append(f"\nRecord #{idx}")
     lines.append("-" * 80)
 
-    transaction_id = getattr(record, 'transaction_id', None)
+    transaction_id = getattr(record, "transaction_id", None)
     if transaction_id:
         lines.append(f"  Transaction ID: {transaction_id}")
 
-    consensus_timestamp = getattr(record, 'consensus_timestamp', None)
+    consensus_timestamp = getattr(record, "consensus_timestamp", None)
     if consensus_timestamp:
         lines.append(f"  Consensus Timestamp: {consensus_timestamp}")
 
-    transaction_fee = getattr(record, 'transaction_fee', None)
+    transaction_fee = getattr(record, "transaction_fee", None)
     if transaction_fee:
         lines.append(f"  Transaction Fee: {transaction_fee} tinybar")
 
-    transaction_hash = getattr(record, 'transaction_hash', None)
+    transaction_hash = getattr(record, "transaction_hash", None)
     if transaction_hash:
         lines.append(f"  Transaction Hash: {transaction_hash.hex()}")
 
-    receipt = getattr(record, 'receipt', None)
+    receipt = getattr(record, "receipt", None)
     if receipt:
         lines.append(f"  Receipt Status: {ResponseCode(receipt.status).name}")
 
-    transfers = getattr(record, 'transfers', None)
+    transfers = getattr(record, "transfers", None)
     if transfers:
         lines.append(f"  Transfers:")
         for account_id, amount_in_tinybar in transfers.items():

--- a/examples/account/account_update_transaction.py
+++ b/examples/account/account_update_transaction.py
@@ -1,6 +1,6 @@
 """
 Example demonstrating account update functionality.
-run with: 
+run with:
 uv run examples/account/account_update_transaction.py
 python examples/account/account_update_transaction.py
 """
@@ -20,7 +20,8 @@ from hiero_sdk_python.timestamp import Timestamp
 
 load_dotenv()
 
-network_name = os.getenv('NETWORK', 'testnet').lower()
+network_name = os.getenv("NETWORK", "testnet").lower()
+
 
 def setup_client():
     """Initialize and set up the client with operator account"""


### PR DESCRIPTION
### Summary

This PR formats all Python examples in `examples/account` using the `black` formatter to ensure a consistent coding style and improve readability across the example codebase.

### Details
- Applied `black` formatting to all files under `examples/account`
- No functional or behavioral changes were introduced
- Improves maintainability and aligns the examples with the project’s formatting standards

### Checklist
- [x] Code formatted using `black`
- [x] Changelog entry added
- [x] Commits are DCO (`-s`) and GPG (`-S`) signed
- [x] No unrelated changes included

Fixes #1301 