### PR TITLE
chore: improve mentor assignment message with Discord support link

### DIFF
--- a/.github/scripts/bot-mentor-assignment.js
+++ b/.github/scripts/bot-mentor-assignment.js
@@ -106,6 +106,7 @@ async function isNewContributor(github, owner, repo, login) {
 
 function buildComment({ mentee, mentor, owner, repo }) {
   const repoUrl = `https://github.com/${owner}/${repo}`;
+  const discordDocUrl = `${repoUrl}/blob/main/docs/discord.md`;
 
   return `${COMMENT_MARKER}
 👋 Hi @${mentee}, welcome to the Hiero Python SDK community!
@@ -117,10 +118,13 @@ You've been assigned this Good First Issue, and today’s on-call mentor from ${
 - Share updates early and ask @${mentor} anything right here
 - Keep the feedback loop short so we can support you quickly
 
-Need more backup? ${SUPPORT_TEAM_ALIAS} is also on standby to cheer you on.
+**Need extra help?**
+- The Good First Issue support team (${SUPPORT_TEAM_ALIAS}) is also available if you need additional guidance
+- For real-time help and community support, please see our [Discord setup guide](${discordDocUrl})
 
 **Mentor:** @${mentor}
 **Mentee:** @${mentee}
+**Backup Support:** ${SUPPORT_TEAM_ALIAS}
 
 If you're enjoying the SDK, consider ⭐️ [starring the repository](${repoUrl}) so it's easy to find later.
 
@@ -206,3 +210,4 @@ module.exports = async ({ github, context, assignee: passedAssignee }) => {
     throw error;
   }
 };
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Added technical docstrings and hardening (set -euo pipefail) to the pr-check-test-files.sh script (#1336)
 
 ### Changed
+- Improve Good First Issue mentor assignment message by adding a Discord setup guide link and clarifying mentor and backup support roles (#1395)
 - Renamed `.github/scripts/check_advanced_requirement.sh` to `bot-advanced-check.sh` for workflow consistency (#1341)
 - Added global review instructions to CodeRabbit configuration to limit reviews to issue/PR scope and prevent scope creep [#1373]
 - Archived unused auto draft GitHub workflow to prevent it from running (#1371)


### PR DESCRIPTION
**Description**:  
Improve Good First Issue mentor assignment message to add a Discord setup guide link and clarify mentor vs backup support roles. This makes onboarding new contributors clearer and more supportive.

* Edit `.github/scripts/bot-mentor-assignment.js` to:
  * Include link to `docs/discord.md`
  * Clarify mentor and backup support roles
* Add changelog entry under `[Unreleased] → Changed` (#1395)

**Related issue(s)**:  

Fixes #1395

**Notes for reviewer**:  
* Only the mentor assignment message and changelog were updated  
* Verified Discord link works and message formatting is clean  
* Commit is signed with both `-S` (GPG) and `-s` (DCO)

**Checklist**  

- [x] Documented (changelog entry added)  
- [x] Tested (message output visually validated locally) 