### PR TITLE
chore: remove unused commented issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,16 +1,5 @@
 blank_issues_enabled: true
 
-# Only show specific issue templates
-# issue_templates:
-#   - name: Good First Issue
-#     filename: 01-good_first_issue.yml
-#- name: Bug Report
-#    filename: 02_bug_report.yml
-
-#  - name: Feature Request
-#    filename: 03_feature_request.yml
-
-# Test contact links
 contact_links:
   - name: Hiero Discord
     url: https://github.com/hiero-ledger/hiero-sdk-python/blob/main/docs/discord.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Added prompt for coderabbit to review `Query` and it's sub-classes.
 
 ### Changed
+- Remove the commented out blocks in config.yml (#1435)
 - Renamed `.github/scripts/check_advanced_requirement.sh` to `bot-advanced-check.sh` for workflow consistency (#1341)
 - Added global review instructions to CodeRabbit configuration to limit reviews to issue/PR scope and prevent scope creep [#1373]
 - Archived unused auto draft GitHub workflow to prevent it from running (#1371)


### PR DESCRIPTION
**Description**:
fixes #1435 
removes the commented out blocks in config.yml

- [x] Documented (Code comments, README, etc.)