### PR TITLE
refactor: simplify account examples using Client.from_env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,10 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Updated `.github/scripts/bot-office-hours.sh` to detect and skip PRs created by bot accounts when posting office hours reminders. (#1384)
 - Refactored `examples/account/account_create_transaction_create_with_alias.py` and `examples/account/account_create_transaction_evm_alias.py` to use the native `AccountInfo.__str__` method for printing account details, replacing manual JSON serialization. ([#1263](https://github.com/hiero-ledger/hiero-sdk-python/issues/1263))
 
+- Refactored account example client setup to use Client.from_env()
+
+
+
 ### Fixed
 
 - Improved filename-related error handling with clearer and more descriptive error messages.(#1413)
@@ -762,5 +766,8 @@ contract_call_local_pb2.ContractLoginfo -> contract_types_pb2.ContractLoginfo
 - N/A
 
 ### Removed
+
+
+
 
 - N/A

--- a/examples/account/account_allowance_approve_transaction_hbar.py
+++ b/examples/account/account_allowance_approve_transaction_hbar.py
@@ -29,12 +29,9 @@ Notes:
     allowances and does not demonstrate revoking allowances or token/NFT usage.
 """
 
-import os
 import sys
 
-from dotenv import load_dotenv
-
-from hiero_sdk_python import AccountId, Client, Hbar, Network, PrivateKey, TransactionId
+from hiero_sdk_python import AccountId, Client, Hbar, PrivateKey, TransactionId
 from hiero_sdk_python.account.account_allowance_approve_transaction import (
     AccountAllowanceApproveTransaction,
 )
@@ -42,22 +39,9 @@ from hiero_sdk_python.account.account_create_transaction import AccountCreateTra
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.transaction.transfer_transaction import TransferTransaction
 
-load_dotenv()
-network_name = os.getenv("NETWORK", "testnet").lower()
-
 
 def setup_client() -> Client:
-    """Initialize and set up the client with operator account using env vars."""
-    network = Network(network_name)
-    print(f"Connecting to Hedera {network_name} network!")
-    client = Client(network)
-
-    operator_id = AccountId.from_string(os.getenv("OPERATOR_ID", ""))
-    operator_key = PrivateKey.from_string(os.getenv("OPERATOR_KEY", ""))
-    client.set_operator(operator_id, operator_key)
-    print(f"Client set up with operator id {client.operator_account_id}")
-
-    return client
+    return Client.from_env()
 
 
 def create_account(client: Client):

--- a/examples/account/account_allowance_approve_transaction_nft.py
+++ b/examples/account/account_allowance_approve_transaction_nft.py
@@ -27,15 +27,12 @@ Usage:
     uv run examples/account/account_allowance_approve_transaction_nft.py
 """
 
-import os
 import sys
-from dotenv import load_dotenv
 
 from hiero_sdk_python import (
     Client,
     AccountId,
     PrivateKey,
-    Network,
     Hbar,
     ResponseCode,
     TokenCreateTransaction,
@@ -49,31 +46,11 @@ from hiero_sdk_python import (
 )
 from hiero_sdk_python.account.account_create_transaction import AccountCreateTransaction
 
-load_dotenv()
 
-network_name = os.getenv("NETWORK", "testnet").lower()
-
-
-def setup_client():
-    """Initialize and set up the client with operator account"""
-    if os.getenv("OPERATOR_ID") is None or os.getenv("OPERATOR_KEY") is None:
-        print("Environment variables OPERATOR_ID and OPERATOR_KEY must be set")
-        sys.exit(1)
-
-    network = Network(network_name)
-    print(f"Connecting to Hedera {network_name} network!")
-    client = Client(network)
-
-    operator_id_str = os.getenv("OPERATOR_ID")
-    operator_key_str = os.getenv("OPERATOR_KEY")
-    assert operator_id_str is not None and operator_key_str is not None
-
-    operator_id = AccountId.from_string(operator_id_str)
-    operator_key = PrivateKey.from_string(operator_key_str)
-
-    client.set_operator(operator_id, operator_key)
-    print(f"Client setup for NFT Owner (Operator): {client.operator_account_id}")
-    return client, operator_id, operator_key
+def setup_client() -> tuple[Client, AccountId, PrivateKey]:
+    """Initialize client from environment variables."""
+    client = Client.from_env()
+    return client, client.operator_account_id, client.operator_private_key
 
 
 def create_account(client, memo="Test Account"):

--- a/examples/account/account_allowance_delete_transaction_hbar.py
+++ b/examples/account/account_allowance_delete_transaction_hbar.py
@@ -2,12 +2,9 @@
 Example demonstrating hbar allowance approval, deletion, and failure after deletion.
 """
 
-import os
 import sys
 
-from dotenv import load_dotenv
-
-from hiero_sdk_python import AccountId, Client, Hbar, Network, PrivateKey, TransactionId
+from hiero_sdk_python import AccountId, Client, Hbar, PrivateKey, TransactionId
 from hiero_sdk_python.account.account_allowance_approve_transaction import (
     AccountAllowanceApproveTransaction,
 )
@@ -15,22 +12,9 @@ from hiero_sdk_python.account.account_create_transaction import AccountCreateTra
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.transaction.transfer_transaction import TransferTransaction
 
-load_dotenv()
-network_name = os.getenv("NETWORK", "testnet").lower()
-
 
 def setup_client() -> Client:
-    """Initialize and set up the client with operator account using env vars."""
-    network = Network(network_name)
-    print(f"Connecting to Hedera {network_name} network!")
-    client = Client(network)
-
-    operator_id = AccountId.from_string(os.getenv("OPERATOR_ID", ""))
-    operator_key = PrivateKey.from_string(os.getenv("OPERATOR_KEY", ""))
-    client.set_operator(operator_id, operator_key)
-    print(f"Client set up with operator id {client.operator_account_id}")
-
-    return client
+    return Client.from_env()
 
 
 def create_account(client: Client):

--- a/examples/account/account_allowance_delete_transaction_nft.py
+++ b/examples/account/account_allowance_delete_transaction_nft.py
@@ -12,15 +12,12 @@ Usage:
     uv run examples/account/account_allowance_delete_transaction_nft.py
 """
 
-import os
 import sys
-from dotenv import load_dotenv
 
 from hiero_sdk_python import (
     Client,
     AccountId,
     PrivateKey,
-    Network,
     Hbar,
     ResponseCode,
     TokenCreateTransaction,
@@ -35,32 +32,11 @@ from hiero_sdk_python import (
 )
 from hiero_sdk_python.account.account_create_transaction import AccountCreateTransaction
 
-load_dotenv()
-network_name = os.getenv("NETWORK", "testnet").lower()
 
-
-def setup_client():
-    """Initialize and set up the client with operator account"""
-    if os.getenv("OPERATOR_ID") is None or os.getenv("OPERATOR_KEY") is None:
-        print("Environment variables OPERATOR_ID and OPERATOR_KEY must be set")
-        sys.exit(1)
-
-    network = Network(network_name)
-    print(f"Connecting to Hedera {network_name} network!")
-    client = Client(network)
-
-    operator_id_str = os.getenv("OPERATOR_ID")
-    operator_key_str = os.getenv("OPERATOR_KEY")
-
-    assert operator_id_str is not None and operator_key_str is not None
-
-    operator_id = AccountId.from_string(operator_id_str)
-    operator_key = PrivateKey.from_string(operator_key_str)
-
-    client.set_operator(operator_id, operator_key)
-    print(f"Client setup for NFT Owner (Operator): {client.operator_account_id}")
-
-    return client, operator_id, operator_key
+def setup_client() -> tuple[Client, AccountId, PrivateKey]:
+    """Initialize client from environment variables."""
+    client = Client.from_env()
+    return client, client.operator_account_id, client.operator_private_key
 
 
 def create_account(client, memo="Test Account"):
@@ -261,7 +237,7 @@ def verify_allowance_removed(
                 "Verification SUCCEEDED: Transfer failed with SPENDER_DOES_NOT_HAVE_ALLOWANCE as expected."
             )
         elif receipt.status == ResponseCode.SUCCESS:
-            print(f"Verification FAILED: Transfer succeeded unexpectedly!")
+            print("Verification FAILED: Transfer succeeded unexpectedly!")
             sys.exit(1)
         else:
             print(

--- a/examples/account/account_records_query.py
+++ b/examples/account/account_records_query.py
@@ -4,40 +4,22 @@ uv run examples/account/account_records_query.py
 python examples/account/account_records_query.py
 """
 
-import os
 import sys
-
-from dotenv import load_dotenv
 
 from hiero_sdk_python import (
     AccountCreateTransaction,
     AccountId,
     Client,
     Hbar,
-    Network,
     PrivateKey,
     ResponseCode,
 )
 from hiero_sdk_python.account.account_records_query import AccountRecordsQuery
 from hiero_sdk_python.transaction.transfer_transaction import TransferTransaction
 
-load_dotenv()
 
-network_name = os.getenv("NETWORK", "testnet").lower()
-
-
-def setup_client():
-    """Initialize and set up the client with operator account"""
-    network = Network(network_name)
-    print(f"Connecting to Hedera {network_name} network!")
-    client = Client(network)
-
-    operator_id = AccountId.from_string(os.getenv("OPERATOR_ID", ""))
-    operator_key = PrivateKey.from_string(os.getenv("OPERATOR_KEY", ""))
-    client.set_operator(operator_id, operator_key)
-    print(f"Client set up with operator id {client.operator_account_id}")
-
-    return client
+def setup_client() -> Client:
+    return Client.from_env()
 
 
 def create_account(client):

--- a/examples/account/account_update_transaction.py
+++ b/examples/account/account_update_transaction.py
@@ -6,35 +6,18 @@ python examples/account/account_update_transaction.py
 """
 
 import datetime
-import os
 import sys
 
-from dotenv import load_dotenv
-
-from hiero_sdk_python import AccountId, Client, Duration, Hbar, Network, PrivateKey
+from hiero_sdk_python import Client, Duration, Hbar, PrivateKey
 from hiero_sdk_python.account.account_create_transaction import AccountCreateTransaction
 from hiero_sdk_python.account.account_update_transaction import AccountUpdateTransaction
 from hiero_sdk_python.query.account_info_query import AccountInfoQuery
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.timestamp import Timestamp
 
-load_dotenv()
 
-network_name = os.getenv("NETWORK", "testnet").lower()
-
-
-def setup_client():
-    """Initialize and set up the client with operator account"""
-    network = Network(network_name)
-    print(f"Connecting to Hedera {network_name} network!")
-    client = Client(network)
-
-    operator_id = AccountId.from_string(os.getenv("OPERATOR_ID", ""))
-    operator_key = PrivateKey.from_string(os.getenv("OPERATOR_KEY", ""))
-    client.set_operator(operator_id, operator_key)
-    print(f"Client set up with operator id {client.operator_account_id}")
-
-    return client
+def setup_client() -> Client:
+    return Client.from_env()
 
 
 def create_account(client):


### PR DESCRIPTION
Refactors account example client setup to use Client.from_env().

- Removes duplicate setup_client logic
- Simplifies environment-based configuration
- Preserves existing example behavior
- Cleans up unused imports

Fixes #1471