### PR TITLE
fix: prevent LinkBot from posting duplicate missing-issue comments 

### DIFF
--- a/.github/scripts/bot-pr-missing-linked-issue.js
+++ b/.github/scripts/bot-pr-missing-linked-issue.js
@@ -53,8 +53,9 @@ module.exports = async ({ github, context }) => {
     }
 
     if (!regex.test(body)) {
+      const safeAuthor = authorLogin ?? 'there' ;
       const commentBody = [ `${LINKBOT_MARKER}` +
-        `Hi @${prData.user.login}, this is **LinkBot** 👋`,
+        `Hi @${safeAuthor}, this is **LinkBot** 👋`,
         ``,
         `Linking pull requests to issues helps us significantly with reviewing pull requests and keeping the repository healthy.`,
         ``,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,7 +173,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Enhance TopicInfo `__str__` method and tests with additional coverage, and update the format_key function in `key_format.py` to handle objects with a _to_proto method.
 
 ### Fixed
-- Prevent LinkBot from posting duplicate “missing linked issue” comments on pull requests.
+- Prevent LinkBot from posting duplicate “missing linked issue” comments on pull requests. (#1475)
 - Refined intermediate assignment guard to validate Beginner issue completion with improved logging and GraphQL-based counting. (#1424)
 - Improved filename-related error handling with clearer and more descriptive error messages.(#1413)
 - Good First Issue bot no longer posts `/assign` reminders for repository collaborators. (#1367)


### PR DESCRIPTION
### Changes
- Added a hidden HTML marker to LinkBot comments
- The bot now checks for this marker before posting
- Ensures only one reminder comment per PR
- Fixed an issue where workflow_dispatch runs could fail due to a missing pull_request payload
- PR number is now resolved safely for both pull_request_target and manual runs

### Dry-run tests
- PR already has a linked issue
https://github.com/parvninama/hiero-sdk-python/actions/runs/20971924882/job/60277198451

- PR missing a linked issue
https://github.com/parvninama/hiero-sdk-python/actions/runs/20970206898/job/60271268287

-  Linkbot already commented once
https://github.com/parvninama/hiero-sdk-python/actions/runs/20971735868/job/60276557424


Fixes #1463 