### PR TITLE
chore(account_id): add __repr__ return type hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,8 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Changed
 
+- Add return type hint to `AccountId.__repr__` for type consistency. (#1503)
+
 - Added AI usage guidelines to the Good First Issue and Beginner issue templates to guide contributors on responsible AI use. (#1490)
 - Refactored the advanced issue assignment guard to use a single configurable variable for the required number of completed intermediate issues. (#1479)
 - Align Good First Issue and Good First Issue — Candidate guidelines with the Hiero C++ SDK for clarity and consistency.(#1421)

--- a/src/hiero_sdk_python/account/account_id.py
+++ b/src/hiero_sdk_python/account/account_id.py
@@ -165,7 +165,7 @@ class AccountId:
             client
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Returns the repr representation of the AccountId.
         """


### PR DESCRIPTION
**Description**: Add return type hint to `AccountId.__repr__` for type consistency. issue#1503   **Checklist** - [Done] Documented (Code comments, README, etc.) - [Done] Tested (unit, integration, etc.)  

Fixes #1503