### PR TITLE
fix: make changelog workflow trigger automatically on PRs

### DIFF
--- a/.github/workflows/pr-check-changelog.yml
+++ b/.github/workflows/pr-check-changelog.yml
@@ -1,7 +1,6 @@
 name: 'PR Changelog Check'
 
 on:
-  workflow_dispatch:
   pull_request:
     types: [opened, reopened, edited, synchronize]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Updated `.github/scripts/bot-office-hours.sh` to detect and skip PRs created by bot accounts when posting office hours reminders. (#1384)
 - Refactored `examples/account/account_create_transaction_create_with_alias.py` and `examples/account/account_create_transaction_evm_alias.py` to use the native `AccountInfo.__str__` method for printing account details, replacing manual JSON serialization. ([#1263](https://github.com/hiero-ledger/hiero-sdk-python/issues/1263))
 - Enhance TopicInfo `__str__` method and tests with additional coverage, and update the format_key function in `key_format.py` to handle objects with a _to_proto method.
+- Update changelog workflow to trigger automatically on pull requests instead of manual dispatch (#1567)
 
 ### Fixed
 - Prevented linkbot from commenting on or auto-closing bot-authored pull requests. (#1516)


### PR DESCRIPTION
## Description

This PR updates the changelog workflow to trigger automatically on pull requests instead of requiring manual dispatch. This provides immediate feedback to contributors about changelog issues.

## Changes Made

- Removed `workflow_dispatch` trigger from `.github/workflows/pr-check-changelog.yml`
- Workflow now triggers automatically on `pull_request` events
- Added changelog entry under `[Unreleased]`  `[Changed]`

## Checklist

- [x] I have commented `/assign` on the issue to get assigned
- [x] My code follows the project's style guidelines
- [x] I have added a changelog entry under `[Unreleased]`
- [x] All commits are DCO signed (`-s`)
- [x] All commits are GPG signed (`-S`)
- [x] My commit messages follow conventional commits format
- [x] I only changed what was mentioned in the issue

## Related Issue

Fixes #1567