### PR TITLE
chore: format logger_test.py with black

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 ## [Unreleased]
 
 ### Tests
+- Format tests/unit/logger_test.py with black for code style consistency (#1541)
 - Style: formatted `tests/unit/prng_transaction_test.py` with black (#1546)
 - Formatted contract unit tests with black for consistent style. (#1523)
 - Format account test files with Black (#1519)

--- a/tests/unit/logger_test.py
+++ b/tests/unit/logger_test.py
@@ -5,6 +5,7 @@ from src.hiero_sdk_python.logger.log_level import LogLevel
 
 pytestmark = pytest.mark.unit
 
+
 def test_set_level():
     """Test that changing log level affects what will be logged."""
     logger = Logger(LogLevel.DEBUG, "test_logger")
@@ -16,7 +17,7 @@ def test_get_level():
     """Test getting the current log level."""
     logger = Logger(level=LogLevel.DEBUG)
     assert logger.get_level() == LogLevel.DEBUG
-    
+
     logger.set_level(LogLevel.ERROR)
     assert logger.get_level() == LogLevel.ERROR
 
@@ -25,7 +26,7 @@ def test_logger_creation():
     logger = Logger(LogLevel.DEBUG, "test_logger")
     assert logger.name == "test_logger"
     assert logger.level == LogLevel.DEBUG
-    
+
 
 def test_logger_creation_from_env():
     os.environ["LOG_LEVEL"] = "CRITICAL"
@@ -35,23 +36,23 @@ def test_logger_creation_from_env():
 
 def test_logger_output(capsys):
     """Test that logger outputs the expected messages to stdout.
-    
+
     This test uses pytest's capsys fixture to capture the actual log output,
     allowing verification of the exact content written to stdout by the logger.
     """
     # Create a logger that logs to the captured stdout with UNIQUE name
     logger = Logger(LogLevel.TRACE, "test_logger_output")
-    
+
     # Log messages at different levels with key-value pairs
     logger.trace("trace message", "traceKey", "traceValue")
     logger.debug("debug message", "debugKey", "debugValue")
     logger.info("info message", "infoKey", "infoValue")
     logger.warning("warning message", "warningKey", "warningValue")
     logger.error("error message", "errorKey", "errorValue")
-    
+
     # Get the captured output
     captured = capsys.readouterr()
-    
+
     # Verify that each message appears in the output
     assert "trace message: traceKey = traceValue" in captured.out
     assert "debug message: debugKey = debugValue" in captured.out
@@ -63,7 +64,7 @@ def test_logger_output(capsys):
     logger.error("this should not appear")
     captured = capsys.readouterr()
     assert captured.out == ""
-    
+
     # Test re-enabling logging
     logger.set_silent(False)
     logger.info("this should appear")
@@ -73,27 +74,27 @@ def test_logger_output(capsys):
 
 def test_logger_respects_level(capsys):
     """Test that logger only outputs messages at or above its level.
-    
+
     Uses pytest's capsys fixture to verify that log filtering works correctly
     by examining which messages actually appear in the captured output based on
     the configured log level.
     """
     # Create a logger that logs to the captured stdout with UNIQUE name
     logger = Logger(LogLevel.INFO, "test_logger_respects_level")
-    
+
     # These should not be logged
     logger.trace("trace message")
     logger.debug("debug message")
-    
+
     # These should be logged
     logger.info("info message")
     logger.warning("warning message")
     logger.error("error message")
-    
+
     # Get the captured output
     captured = capsys.readouterr()
     logger.info(captured.out)
-    
+
     # Check that appropriate messages were logged or not logged
     assert "trace message" not in captured.out
     assert "debug message" not in captured.out


### PR DESCRIPTION
---

**Description:**

Format `tests/unit/logger_test.py` using the Black formatter to ensure consistent code style across unit tests.
This change is limited to formatting only and does not affect test logic or behavior.

**Changes:**

* Apply Black formatting to `tests/unit/logger_test.py`
* No functional or logical changes
* Changelog entry added

---

**Related issue(s):**[[Good First Issue]: format black tests/unit/logger_test.py](https://github.com/hiero-ledger/hiero-sdk-python/issues/1541#top)
#1541

Fixes #1541

> Replace `<ISSUE_NUMBER>` with the actual issue number.

---

**Notes for reviewer:**

* Formatting-only change
* No runtime behavior changes
* All tests pass locally

---

**Checklist**

* [x] Documented (Code comments, README, etc.)
* [x] Tested (unit, integration, etc.)

---