### PR TITLE
chore: format tests/unit/mock_server.py with black

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Added dry-run support and refactored `.github/workflows/bot-workflows.yml` to use dedicated script `.github/scripts/bot-workflows.js` for improved maintainability and testability. (`#1288`)
 
 ### Changed
+- chore: format tests/unit/mock_server.py with black (#1542)
 - Updated actions/checkout to v6.0.1 and actions/github-script v8.0.0 in bot-next-issue-recommendation workflow (#1586)
 - Expanded inactivity bot messages to include `/unassign` command information for contributors (#1555)
 - Update the acceptance criteria wording in the issue templates to improve clarity and consistency for contributors (#1491)

--- a/tests/unit/mock_server.py
+++ b/tests/unit/mock_server.py
@@ -20,13 +20,14 @@ from hiero_sdk_python.hapi.services import (
 )
 from hiero_sdk_python.logger.log_level import LogLevel
 
+
 class MockServer:
     """Mock gRPC server that returns predetermined responses."""
-    
+
     def __init__(self, responses):
         """
         Initialize a mock gRPC server with predetermined responses.
-        
+
         Args:
             responses (list): List of response objects to return in sequence
         """
@@ -34,75 +35,91 @@ class MockServer:
         self.server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
         self.port = _find_free_port()
         self.address = f"localhost:{self.port}"
-        
+
         self._register_services()
-        
+
         # Start the server
         self.server.add_insecure_port(self.address)
         self.server.start()
-        
+
     def _register_services(self):
         """Register all necessary gRPC services."""
         # Create and register all servicers
         services = [
-            (crypto_service_pb2_grpc.CryptoServiceServicer, 
-             crypto_service_pb2_grpc.add_CryptoServiceServicer_to_server),
-            (token_service_pb2_grpc.TokenServiceServicer,
-             token_service_pb2_grpc.add_TokenServiceServicer_to_server),
-            (consensus_service_pb2_grpc.ConsensusServiceServicer,
-             consensus_service_pb2_grpc.add_ConsensusServiceServicer_to_server),
-            (network_service_pb2_grpc.NetworkServiceServicer,
-             network_service_pb2_grpc.add_NetworkServiceServicer_to_server),
-            (file_service_pb2_grpc.FileServiceServicer,
-             file_service_pb2_grpc.add_FileServiceServicer_to_server),
-            (smart_contract_service_pb2_grpc.SmartContractServiceServicer,
-             smart_contract_service_pb2_grpc.add_SmartContractServiceServicer_to_server),
-            (schedule_service_pb2_grpc.ScheduleServiceServicer,
-             schedule_service_pb2_grpc.add_ScheduleServiceServicer_to_server),
-            (util_service_pb2_grpc.UtilServiceServicer,
-             util_service_pb2_grpc.add_UtilServiceServicer_to_server),
+            (
+                crypto_service_pb2_grpc.CryptoServiceServicer,
+                crypto_service_pb2_grpc.add_CryptoServiceServicer_to_server,
+            ),
+            (
+                token_service_pb2_grpc.TokenServiceServicer,
+                token_service_pb2_grpc.add_TokenServiceServicer_to_server,
+            ),
+            (
+                consensus_service_pb2_grpc.ConsensusServiceServicer,
+                consensus_service_pb2_grpc.add_ConsensusServiceServicer_to_server,
+            ),
+            (
+                network_service_pb2_grpc.NetworkServiceServicer,
+                network_service_pb2_grpc.add_NetworkServiceServicer_to_server,
+            ),
+            (
+                file_service_pb2_grpc.FileServiceServicer,
+                file_service_pb2_grpc.add_FileServiceServicer_to_server,
+            ),
+            (
+                smart_contract_service_pb2_grpc.SmartContractServiceServicer,
+                smart_contract_service_pb2_grpc.add_SmartContractServiceServicer_to_server,
+            ),
+            (
+                schedule_service_pb2_grpc.ScheduleServiceServicer,
+                schedule_service_pb2_grpc.add_ScheduleServiceServicer_to_server,
+            ),
+            (
+                util_service_pb2_grpc.UtilServiceServicer,
+                util_service_pb2_grpc.add_UtilServiceServicer_to_server,
+            ),
         ]
-        
+
         for servicer_class, add_servicer_fn in services:
             servicer = self._create_mock_servicer(servicer_class)
             add_servicer_fn(servicer, self.server)
-    
+
     def _create_mock_servicer(self, servicer_class):
         """
         Create a mock servicer that returns predetermined responses.
-        
+
         Args:
             servicer_class: The gRPC servicer class to mock
-        
+
         Returns:
             A mock servicer object
         """
         responses = self.responses
-        
+
         class MockServicer(servicer_class):
             def __getattribute__(self, name):
                 # Get special attributes normally
-                if name in ('_next_response', '__class__'):
+                if name in ("_next_response", "__class__"):
                     return super().__getattribute__(name)
-            
+
                 def method_wrapper(request, context):
                     nonlocal responses
                     if not responses:
                         # If no more responses are available, return None
                         return None
-                    
+
                     response = responses.pop(0)
-                    
+
                     if isinstance(response, RealRpcError):
                         # Abort with custom error
                         context.abort(response.code(), response.details())
-                    
+
                     return response
-                
+
                 return method_wrapper
-                
+
         return MockServicer()
-    
+
     def close(self):
         """Stop the server."""
         self.server.stop(0)
@@ -111,21 +128,21 @@ class MockServer:
 def _find_free_port():
     """Find a free port on localhost."""
     with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-        s.bind(('', 0))
+        s.bind(("", 0))
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         return s.getsockname()[1]
 
 
 class RealRpcError(grpc.RpcError):
     """A more realistic gRPC error for testing."""
-    
+
     def __init__(self, status_code, details):
         self._status_code = status_code
         self._details = details
-        
+
     def code(self):
         return self._status_code
-        
+
     def details(self):
         return self._details
 
@@ -134,29 +151,28 @@ class RealRpcError(grpc.RpcError):
 def mock_hedera_servers(response_sequences):
     """
     Context manager that creates mock Hedera servers and a client.
-    
+
     Args:
         response_sequences: List of response sequences, one for each mock server
-        
+
     Yields:
         Client: The configured client
     """
     # Create mock servers
     servers = [MockServer(responses) for responses in response_sequences]
-    
+
     try:
         # Configure the network with mock servers
         nodes = []
         for i, server in enumerate(servers):
             node = _Node(AccountId(0, 0, 3 + i), server.address, None)
-            
+
             # force insecure transport
             node._apply_transport_security(False)
             node._set_verify_certificates(False)
-            
+
             nodes.append(node)
 
-        
         # Create network and client
         network = Network(nodes=nodes)
         client = Client(network)
@@ -165,7 +181,7 @@ def mock_hedera_servers(response_sequences):
         key = PrivateKey.generate()
         client.set_operator(AccountId(0, 0, 1800), key)
         client.max_attempts = 4  # Configure for testing
-        
+
         yield client
     finally:
         # Clean up the servers


### PR DESCRIPTION
**Description**:
Standardizes the formatting of `tests/unit/mock_server.py` using the `black` formatter to improve code consistency.

* Format `tests/unit/mock_server.py` with black
* Add changelog entry

**Related issue(s)**:

Fixes #1542

**Notes for reviewer**:
This is a "Good First Issue" contribution. I have signed the commits and added a changelog entry as requested.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)