### PR TITLE
chore: format tests/unit/executable_test.py with black (#1530)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 
 ### Tests
+- Format `tests/unit/executable_test.py` with Black.(#1530)
 - Format `tests/unit/hedera_trust_manager_test.py` with Black for consistent code style (#1539)
 - Format tests/unit/logger_test.py with black for code style consistency (#1541)
 - Format `tests/unit/batch_transaction_test.py` with Black.(`#1520`)


### PR DESCRIPTION
this PR formats `tests/unit/executable_test.py` with Black to standardize the code style.

Fixes #1530

### Changes
- Ran `black tests/unit/executable_test.py`
- Added a changelog entry under the "Tests" section.
- Verified that all unit tests still pass.