### PR TITLE
feat: add __repr__ to TokenId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Formatted client_test.py using Black.
 
 ### Added
+- Add developer-friendly `__repr__` for `TokenId` (#1653)
 - Added guide for resolving CHANGELOG.md conflicts using GitHub's web editor (`#1591`)
 
 - Added Windows setup guide for SDK developers (`docs/sdk_developers/training/setup/setup_windows.md`) with PowerShell installation instructions. (#1570)

--- a/src/hiero_sdk_python/tokens/token_id.py
+++ b/src/hiero_sdk_python/tokens/token_id.py
@@ -178,3 +178,12 @@ class TokenId:
             int: A hash of the TokenId instance.
         """
         return hash((self.shard, self.realm, self.num))
+
+    def __repr__(self) -> str:
+        """
+        Returns a detailed representation of the TokenId suitable for debugging.
+
+        Returns:
+            str: A string in constructor format 'TokenId(shard=X, realm=Y, num=Z)'.
+        """
+        return f"TokenId(shard={self.shard}, realm={self.realm}, num={self.num})"

--- a/tests/unit/token_id_test.py
+++ b/tests/unit/token_id_test.py
@@ -69,3 +69,12 @@ def test_validate_checksum_failure(mock_client):
 
     with pytest.raises(ValueError):
         token_id.validate_checksum(client)
+
+def test_token_id_repr():
+    """Should return constructor-style representation without checksum."""
+    token_id = TokenId(0, 0, 123)
+    assert repr(token_id) == "TokenId(shard=0, realm=0, num=123)"
+
+    # Test with different values
+    token_id2 = TokenId(1, 2, 456)
+    assert repr(token_id2) == "TokenId(shard=1, realm=2, num=456)"


### PR DESCRIPTION
## Summary
- Implement custom `__repr__()` method for `TokenId` class
- Returns constructor-style representation showing only shard, realm, and num (excludes internal checksum field)
- Add unit tests to verify the `__repr__()` behavior

## Rationale
- Addresses issue #1653 requesting a cleaner `__repr__` for better debugging experience
- Default dataclass `__repr__` was showing `checksum=None` which is an internal implementation detail
- New implementation provides clean output: `TokenId(shard=0, realm=0, num=123)`

## Changes
- `src/hiero_sdk_python/tokens/token_id.py`: implement `__repr__()` method
- `tests/unit/token_id_test.py`: add `test_token_id_repr()` with multiple test cases
- `CHANGELOG.md`: add entry under Unreleased → Added

## Test Plan
- Unit test added: `test_token_id_repr()` verifies correct output format
- All existing tests continue to pass
- CI checks passing

Fixes #1653