### PR TITLE
fix: skip inactivity close for PRs with discussion label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,7 +137,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Added `/working` command to reset the inactivity timer on issues and PRs. ([#1552](https://github.com/hiero-ledger/hiero-sdk-python/issues/1552))
 
 ### Changed
-- Inactivity bot now skips closing pull requests labeled `discussion`(#1583)
+- Inactivity bot now skips closing pull requests labeled `discussion` (#1583)
 
 ### Documentation
 - Added comprehensive docstring to `compress_with_cryptography` function (#1626)


### PR DESCRIPTION
Adds a check in bot-inactivity-unassign.sh to skip closing and unassigning pull requests that contain the `discussion` label.
This prevents valid PRs that are parked for discussion from being auto-closed by the inactivity bot.
Fixes #1583
