### PR TITLE
chore: format tests/unit/crypto_utils_test.py with Black

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 
 ### Tests
+- Format `tests/unit/crypto_utils_test.py` with Black for code style consistency (#1524)
 - Formatted `tests/unit/get_receipt_query_test.py` with black for code style consistency. (#1537)
 - format black `tests/unit/hbar*.py`.(#1538)
 - Formatted `tests/unit/conftest.py` with black for code style consistency. (#1522)

--- a/tests/unit/crypto_utils_test.py
+++ b/tests/unit/crypto_utils_test.py
@@ -1,4 +1,5 @@
 """Unit tests for crypto_utils module."""
+
 from cryptography.hazmat.primitives.asymmetric import ec
 import pytest
 
@@ -15,13 +16,22 @@ pytestmark = pytest.mark.unit
 def test_keccak256():
     """Test keccak256 hashing."""
     # Known vector: empty string -> c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
-    assert keccak256(b"").hex() == "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+    assert (
+        keccak256(b"").hex()
+        == "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+    )
 
     # "hello" -> 1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8
-    assert keccak256(b"hello").hex() == "1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8"
+    assert (
+        keccak256(b"hello").hex()
+        == "1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8"
+    )
 
     # "Transfer" -> 461a29a8a7db848c0827103038dd4776114eb182e0717208d0a793574936353d
-    assert keccak256(b"Transfer").hex() == "f099cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+    assert (
+        keccak256(b"Transfer").hex()
+        == "f099cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+    )
 
 
 def test_compress_point_unchecked():
@@ -57,19 +67,19 @@ def test_decompress_point():
     assert y == nums.y
 
     # Test uncompressed 65-byte format (0x04 + x + y)
-    uncompressed = b'\x04' + nums.x.to_bytes(32, 'big') + nums.y.to_bytes(32, 'big')
+    uncompressed = b"\x04" + nums.x.to_bytes(32, "big") + nums.y.to_bytes(32, "big")
     x2, y2 = decompress_point(uncompressed)
     assert x2 == nums.x
     assert y2 == nums.y
 
     # Test invalid length
     with pytest.raises(ValueError, match="Not recognized"):
-        decompress_point(b'\x04' * 10)
+        decompress_point(b"\x04" * 10)
 
     # Test invalid prefix
     with pytest.raises(ValueError, match="Not recognized"):
         # 0x05 is invalid prefix for 33-byte point
-        invalid_point = b'\x05' + nums.x.to_bytes(32, 'big')
+        invalid_point = b"\x05" + nums.x.to_bytes(32, "big")
         decompress_point(invalid_point)
 
 
@@ -80,7 +90,7 @@ def test_compress_with_cryptography():
     nums = pub.public_numbers()
 
     # Create uncompressed
-    uncompressed = b'\x04' + nums.x.to_bytes(32, 'big') + nums.y.to_bytes(32, 'big')
+    uncompressed = b"\x04" + nums.x.to_bytes(32, "big") + nums.y.to_bytes(32, "big")
 
     compressed_via_lib = compress_with_cryptography(uncompressed)
     compressed_manual = compress_point_unchecked(nums.x, nums.y)


### PR DESCRIPTION
## Summary
- Apply Black code formatter to `tests/unit/crypto_utils_test.py` for consistent code style

## Changes
- Standardized string quotes (single to double quotes per Black's default)
- Added blank line after module docstring
- Wrapped long lines to comply with Black's line length limit (88 characters)

## Related Issue
Closes #1524

## Test Plan
- [x] Run `black --check tests/unit/crypto_utils_test.py` to verify formatting
- [x] Ensure no functional changes were made (formatting only)

---

Generated with [Claude Code](https://claude.ai/claude-code)