### PR TITLE
chore: update pytest version constraint to allow 9.x versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ eth = [
 [dependency-groups]
 dev = [
     "grpcio-tools>=1.76.0,<2",
-    "pytest>=8.3.4,<9",
+    "pytest>=8.3.4,<10",
     "pytest-cov>=7.0.0,<8",
 ]
 


### PR DESCRIPTION
This PR addresses issue #1797 by updating the pytest version constraint in pyproject.toml.

**Changes:**
- Updated pytest version constraint from `>=8.3.4,<9` to `>=8.3.4,<10`
- This enables forward compatibility with pytest 9.x releases (current latest is 9.0.2)

**Reason:**
The original constraint was limiting users from using the most recent pytest version. This change allows pytest 9.x while maintaining an upper bound for stability.

Fixes #1797