### PR TITLE
chore: add PR draft explainer workflow (#1723)

### DIFF
--- a/.github/scripts/pr-draft-explainer.js
+++ b/.github/scripts/pr-draft-explainer.js
@@ -1,0 +1,84 @@
+const COMMENT_MARKER = "<!-- pr-draft-explainer -->";
+
+module.exports = async ({ github, context, core }) => {
+  const pr = context.payload.pull_request;
+  const { owner, repo } = context.repo;
+
+  if (!pr) {
+    core.info("No pull request found in payload. Exiting.");
+    return;
+  }
+
+  const prNumber = pr.number;
+  const authorLogin = pr.user && pr.user.login ? pr.user.login : null;
+  const greetingTarget = authorLogin ? `@${authorLogin}` : "there";
+
+  core.info(
+    `PR #${prNumber} was converted to draft. Checking if explanation is needed.`,
+  );
+
+  let comments = [];
+  try {
+    comments = await github.paginate(github.rest.issues.listComments, {
+      owner,
+      repo,
+      issue_number: prNumber,
+      per_page: 100,
+    });
+  } catch (error) {
+    core.info(
+      `Failed to list comments for PR #${prNumber}: ${error.message}. Skipping comment to avoid duplicates.`,
+    );
+    return;
+  }
+
+  const alreadyExplained = comments.some((comment) =>
+    comment.body ? comment.body.includes(COMMENT_MARKER) : false,
+  );
+
+  if (alreadyExplained) {
+    core.info("Draft explanation comment already exists. Skipping.");
+    return;
+  }
+
+  try {
+    const reviews = await github.rest.pulls.listReviews({
+      owner,
+      repo,
+      pull_number: prNumber,
+    });
+
+    const hasChangeRequest = reviews.data.some(
+      (review) => review.state === "CHANGES_REQUESTED",
+    );
+
+    if (!hasChangeRequest) {
+      core.info("No change-request review found. Skipping explanation comment.");
+      return;
+    }
+  } catch (error) {
+    core.info(
+      `Review lookup failed (${error.message}). Posting explanation anyway.`,
+    );
+  }
+
+  const message = `${COMMENT_MARKER}
+Hi ${greetingTarget}!
+
+We suggested a few updates and moved this PR to **draft** while you apply the feedback. This keeps it out of the review queue until it is ready again.
+
+### What happens next?
+- Make the requested changes.
+- When you are ready, click **"Ready for review"** at the top of the PR or comment \`/ready\`.
+
+Thanks again for your contribution!`;
+
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: prNumber,
+    body: message,
+  });
+
+  core.info(`Posted draft explanation comment on PR #${prNumber}.`);
+};

--- a/.github/workflows/pr-draft-explainer.yml
+++ b/.github/workflows/pr-draft-explainer.yml
@@ -1,0 +1,34 @@
+name: PR Draft Explainer
+
+on:
+  pull_request:
+    types: [converted_to_draft]
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  explain:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          sparse-checkout: |
+            .github/scripts/pr-draft-explainer.js
+          sparse-checkout-cone-mode: false
+
+      - name: Post draft explanation
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const explain = require('./.github/scripts/pr-draft-explainer.js');
+            await explain({ github, context, core });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Format `tests/unit/endpoint_test.py` using black. (`#1792`)
 
 ### .github
+- Added PR draft explainer workflow to comment when PRs are converted to draft after changes are requested. (#1723)
 - Fixed bot workflow runtime failure caused by strict `FAILED_WORKFLOW_NAME` validation. (`#1690`)
 - Reverted PR #1739 checking assignment counts
 - chore: update step-security/harden-runner from 2.14.1 to 2.14.2 in a workflow


### PR DESCRIPTION
**Description**:
Add a workflow that explains why PRs are moved to draft after changes are requested.

- Add PR draft explainer workflow
- Add script to post a single friendly comment
- Add changelog entry for the workflow

 **Related issue(s)**:

Fixes #1723 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**
