### PR TITLE
fix(query): increase query payment max fee from 1 to 2 Hbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 ## [Unreleased]
 
 ### Src
-- fix: increase query payment transaction max fee from 1 to 2 Hbar to match JS SDK and fix intermittent `INSUFFICIENT_TX_FEE` failures (`#1317`)
+- fix: increase query payment transaction max fee from 1 to 2 Hbar and fix intermittent `INSUFFICIENT_TX_FEE` failures (`#1317`)
 
 ### Examples
 

--- a/src/hiero_sdk_python/query/query.py
+++ b/src/hiero_sdk_python/query/query.py
@@ -243,7 +243,7 @@ class Query(_Executable):
         transaction_body = transaction_pb2.TransactionBody(
             transactionID=transaction_id._to_proto(),
             nodeAccountID=node_account_id._to_proto(),
-            transactionFee=200_000_000,  # 2 Hbar default fee (matches JS SDK)
+            transactionFee=200_000_000,  # 2 Hbar default fee
             transactionValidDuration=duration_pb2.Duration(seconds=120),
             cryptoTransfer=crypto_transfer_pb2.CryptoTransferTransactionBody(
                 transfers=basic_types_pb2.TransferList(accountAmounts=account_amounts)

--- a/src/hiero_sdk_python/transaction/query_payment.py
+++ b/src/hiero_sdk_python/transaction/query_payment.py
@@ -21,7 +21,7 @@ def build_query_payment_transaction(
     tx.add_hbar_transfer(payer_account_id, -amount.to_tinybars())
     tx.add_hbar_transfer(node_account_id, amount.to_tinybars())
 
-    tx.transaction_fee = 200_000_000  # 2 Hbar default fee (matches JS SDK)
+    tx.transaction_fee = 200_000_000  # 2 Hbar default fee
     tx.node_account_id = node_account_id
     tx.transaction_id = TransactionId.generate(payer_account_id)
 


### PR DESCRIPTION
## Summary

Fixes #1317

The query payment `CryptoTransfer` transaction had its max fee hardcoded to **100,000,000 tinybars (1 Hbar)** in two locations:
- `src/hiero_sdk_python/query/query.py` — `_build_query_payment_transaction()`
- `src/hiero_sdk_python/transaction/query_payment.py` — `build_query_payment_transaction()`

Under network load, the actual fee for this inner transfer can exceed the 1 Hbar cap, causing the node to reject it with **`INSUFFICIENT_TX_FEE (9)`**. This was observed as an intermittent CI failure in the `AccountRecordsQuery` integration test.

## Changes

- Increased the query payment transaction max fee from `100_000_000` to `200_000_000` tinybars (1 → 2 Hbar) in both files, matching the **JS SDK default**.
- Added a `CHANGELOG.md` entry under `[Unreleased] > Src`.

## Verification

- ✅ All 1495 unit tests pass (`uv run pytest tests/unit/ -x`)
- ✅ No new lint errors introduced (`ruff check` — only pre-existing issues)
- 🔗 The fix is network-dependent; CI integration tests will serve as the ultimate verification

Signed-off-by: Ritesh Kumar <ritesh@ambicuity.com>