### PR TITLE
chore: update pytest version constraint to allow pytest 9.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ eth = [
 [dependency-groups]
 dev = [
     "grpcio-tools>=1.76.0,<2",
-    "pytest>=8.3.4,<9",
+    "pytest>=8.3.4,<10",
     "pytest-cov>=7.0.0,<8",
 ]
 


### PR DESCRIPTION
## Description
Updates the pytest version constraint in pyproject.toml from  to  to allow users to use the latest pytest version (9.0.2).

## Related Issue
Fixes #1797

## Changes Made
- Changed  to  in pyproject.toml

## Checklist
- [x] I have read the contribution guidelines
- [x] My code follows the project's style guidelines
- [x] I have signed the DCO (if applicable)

Signed-off-by: Mehul <mehulr2801@gmail.com>