### PR TITLE
docs: fix MAINTAINERS link in bug guide (#1666)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Improved Google-style docstring for `compress_point_unchecked` in `crypto_utils.py`. (#1625)
 - chore: update office hours and community calls to use direct links (`#1804`)
 - docs: create workflow best practices guide (`docs/workflows/03-workflow-best-practices.md`) (`#1743`)
+- Fixed broken `MAINTAINERS.md` relative link in `docs/sdk_developers/bug.md` by using the repository-root GitHub URL. (#1666)
 
 ### Tests
 - Format `tests/unit/endpoint_test.py` using black. (`#1792`)

--- a/docs/sdk_developers/bug.md
+++ b/docs/sdk_developers/bug.md
@@ -9,7 +9,7 @@
    ```
 3. **Report it:**
    - **Regular bugs** → [Create Issue](https://github.com/hiero-ledger/hiero-sdk-python/issues/new)
-   - **Security bugs** → Contact [maintainers](MAINTAINERS.md) on [Discord](https://discord.gg/hyperledger) privately
+   - **Security bugs** → Contact [maintainers](https://github.com/hiero-ledger/hiero-sdk-python/blob/main/MAINTAINERS.md) on [Discord](https://discord.gg/hyperledger) privately
 
 **Include:**
 - Clear description


### PR DESCRIPTION
**Description**:                                                                                        
  Fix broken maintainer contact link in the bug reporting guide so it correctly points to `MAINTAINERS.md`
  at repo root.                                                                                           
                                                                                                          
  * Update `docs/sdk_developers/bug.md` to use an absolute GitHub URL for the maintainers link            
  * Add an unreleased docs changelog entry in `CHANGELOG.md` for issue #1666                              
                                                                                                          
  **Related issue(s)**:                                                                                   
                                                                                                          
  Fixes #1666                                                                                             
                                                                                                          
  **Notes for reviewer**:                                                                                 
  Validated links in `docs/sdk_developers/bug.md` return HTTP 200:                                        
  - `https://github.com/hiero-ledger/hiero-sdk-python/issues/new`                                         
  - `https://github.com/hiero-ledger/hiero-sdk-python/blob/main/MAINTAINERS.md`                           
  - `https://discord.gg/hyperledger`                                                                      
                                                                                                          
  **Checklist**                                                                                           
                                                                                                          
  - [x] Documented (Code comments, README, etc.)                                                          
  - [x] Tested (unit, integration, etc.)    