### PR TITLE
chore: allow pytest version up to 10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ eth = [
 [dependency-groups]
 dev = [
     "grpcio-tools>=1.76.0,<2",
-    "pytest>=8.3.4,<9",
+    "pytest>=8.3.4,<10",
     "pytest-cov>=7.0.0,<8",
 ]
 


### PR DESCRIPTION
## Summary

Update pyproject.toml to allow pytest 9.x versions.

## Changes

Changed:
- "pytest>=8.3.4,<9"
+ "pytest>=8.3.4,<10"

This enables forward compatibility with pytest 9.x.

## Issue

Closes #1797
