### PR TITLE
chore: update pytest version constraint to allow pytest 9.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ eth = [
 [dependency-groups]
 dev = [
     "grpcio-tools>=1.76.0,<2",
-    "pytest>=8.3.4,<9",
+    "pytest>=8.3.4,<10",
     "pytest-cov>=7.0.0,<8",
 ]
 


### PR DESCRIPTION
Fixes #1797

Updated pytest version constraint from `<9` to `<10` in pyproject.toml to allow pytest 9.x versions.

Note: This PR needs GPG signing to be verified. The commit is currently unsigned - please let me know if there is another way to verify.