### PR TITLE
chore: improve keccak256 docstring and update changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Added comprehensive docstring to `compress_with_cryptography` function (#1626)
 
 ### Changed
+- Improve `keccak256` docstring formatting for better readability and consistency (#1624)
 - Removed outdated "Common Issues" section from CONTRIBUTING.md that referenced non-existent docs/common_issues.md (`#1665`)
 - Hide the commit verification bot marker in pull request comments.
 - Added missing type hints to sign method in Transaction class (#1630)

--- a/src/hiero_sdk_python/utils/crypto_utils.py
+++ b/src/hiero_sdk_python/utils/crypto_utils.py
@@ -17,8 +17,20 @@ SECP256K1_CURVE = ec.SECP256K1()
 
 def keccak256(data: bytes) -> bytes:
     """
-    Mirroring the Java code's `Crypto.calcKeccak256`.
+    Compute the Keccak-256 hash of the input data.
+
+    This mirrors the Java SDK's `Crypto.calcKeccak256` function.
+
+    Args:
+        data: The bytes to hash.
+
+    Returns:
+        bytes: The 32-byte Keccak-256 hash digest.
+
+    Raises:
+        RuntimeError: If pycryptodome or similar keccak library is not installed.
     """
+
     global keccak
     if keccak is None:
         raise RuntimeError("Keccak not available. Install pycryptodome or similar.")


### PR DESCRIPTION
**Description**:
Expand the keccak256 function docstring to follow Google-style documentation standards and update the project changelog.

- Update the keccak256 docstring with Args, Returns, and Raises sections.
- Add entry to CHANGELOG.md documenting the improvement.

Fixes #1624 

**Notes for reviewer**:
The docstring was previously a single line. Now it follows the Google Python Style Guide, including Args, Returns, and Raises sections.

**Checklist**

- [x] I have followed the Google-style docstring format.
- [x] Tested (pytest test/)
