### PR TITLE
chore: Added codacy config to exclude the `tests/` directory from Bandit analysis.

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -3,7 +3,7 @@ engines:
   bandit:
     enabled: true
     arguments:
-      - "-lll"
-      - "-ii"
+      - "-s"
+      - "B101"
     exclude_paths:
       - tests/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Added advanced code review prompts for the `src/hiero_sdk_python/file` module in `.coderabbit.yaml` to guide reviewers in verifying proper `FileAppendTransaction` chunking constraints and nuances in memo handling for `FileUpdateTransaction` according to Hiero SDK best practices. (#1697)
 - Added CodeRabbit review instructions for consensus module `src/hiero_sdk_python/consensus/` with critical focus on protobuf alignment `.coderabbit.yaml`.
 - Added CodeRabbit prompt to review the `src/hiero_sdk_python/crypto` module.
-- Added `.codacy.yml` configuration to exclude the `tests/` directory from Bandit analysis.
+- Added `.codacy.yml` configuration to exclude the `tests/` directory from Bandit `assert` analysis.
 
 ### Fixed
 


### PR DESCRIPTION
**Description**:
This PR introduce `.codacy.yml` configuration to exclude the `tests/` directory from Bandit analysis.

**Related issue(s)**:

Fixes #1888

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
