### PR TITLE
chore: bump astral-sh/setup-uv from v7.2.1 to v7.3.1

### DIFF
--- a/.github/workflows/deps-check.yml
+++ b/.github/workflows/deps-check.yml
@@ -37,7 +37,7 @@ jobs:
           cache: "pip"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
 
       - name: Create virtual environment
         run: uv venv

--- a/.github/workflows/pr-check-codecov.yml
+++ b/.github/workflows/pr-check-codecov.yml
@@ -24,7 +24,7 @@ jobs:
                   python-version: "3.11"
 
             - name: Install uv
-              uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
+              uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
 
             - name: Install dependencies
               run: |

--- a/.github/workflows/pr-check-examples.yml
+++ b/.github/workflows/pr-check-examples.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
           
       - name: Install uv
-        uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
 
       - name: Install dependencies
         run: uv sync --all-extras

--- a/.github/workflows/pr-check-test.yml
+++ b/.github/workflows/pr-check-test.yml
@@ -36,7 +36,7 @@ jobs:
           cache: "pip"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
 
       - name: Install setuptools wheel
         run: pip install --upgrade pip setuptools wheel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - updated spam list users (`#1894`)
 - trigger spam list updates every hour (`#1864`)
 - close unlinked pull requests after 12 hours rather than 3 days (`#1863`)
+- Bumped `astral-sh/setup-uv` from v7.2.1 to v7.3.1 in workflow files (#1900)
 
 ## [0.2.0] - 2026-11-02
 


### PR DESCRIPTION
Fixes #1900

## Changes
Updated astral-sh/setup-uv GitHub Action from v7.2.1 to v7.3.1 in 4 workflow files:
- .github/workflows/deps-check.yml
- .github/workflows/pr-check-codecov.yml
- .github/workflows/pr-check-examples.yml
- .github/workflows/pr-check-test.yml

## Checklist
- [x] Changes match issue requirements
- [x] Changelog entry added
- [x] Commit signed with GPG (verified)