### PR TITLE
Update pytest version constraint to allow pytest 9.x (#1797)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ tck = ["flask>=3.0.0,<4"]
 [dependency-groups]
 dev = [
     "grpcio-tools>=1.76.0,<2",
-    "pytest>=8.3.4,<9",
+    "pytest>=8.3.4,<10",
     "pytest-cov>=7.0.0,<8",
 ]
 


### PR DESCRIPTION
## 📋 Summary

Fixes #1797

## ✅ Changes

- Updated `pytest` version constraint from `<9` to `<10`
- Enables support for pytest 9.0.2 and forward compatibility

## 📝 Change Details

```diff
-    "pytest>=8.3.4,<9",
+    "pytest>=8.3.4,<10",
```

## 🎯 Why This Matters

- ✅ Unlocks pytest 9.0.2 features for users
- ✅ Maintains backward compatibility with pytest 8.x
- ✅ Future-proof for upcoming pytest releases

## 📝 Files Changed

- `pyproject.toml` (1 line)

---

Built with ❤️ by [Halbot100](https://github.com/Halbot100) 🤖