### PR TITLE
fix(ci): keep deps-check uv runs on lowest-direct resolution

### DIFF
--- a/.github/workflows/deps-check.yml
+++ b/.github/workflows/deps-check.yml
@@ -69,8 +69,8 @@ jobs:
 
       - name: Generate Proto Files
         run: |
-          uv run python generate_proto.py
+          uv run --resolution=lowest-direct python generate_proto.py
 
       - name: Run unit tests (min deps)
         run: |
-          uv run pytest tests/unit -v
+          uv run --resolution=lowest-direct pytest tests/unit -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### .github
 
+- fix(deps-check): keep `uv run` at `--resolution=lowest-direct` for proto generation and min-deps unit tests (`#1919`)
 - chore: update concurrency group for GFI assignment workflow to prevent race conditions (`#1910`)
 
 ## [0.2.1] - 2026-03-05


### PR DESCRIPTION
## Summary
- add `--resolution=lowest-direct` to both `uv run` commands in `.github/workflows/deps-check.yml`
- keep proto generation and min-deps unit-test steps aligned with the earlier `uv sync --resolution=lowest-direct`
- add an Unreleased changelog entry under `.github`

## Testing
- Ran a Python validation script that parses `.github/workflows/deps-check.yml` and verifies both target steps include `--resolution=lowest-direct`.

## Related
Fixes #1919