### PR TITLE
Update spam-list.txt with new spam accounts

### DIFF
--- a/.github/spam-list.txt
+++ b/.github/spam-list.txt
@@ -2,3 +2,5 @@ KubanjaElijahEldred
 by22Jy
 CODEAbhinav-art
 zhanglinqian
+Halbot100
+roberthallers


### PR DESCRIPTION
Fixes #1933

Added the following spam accounts to `.github/spam-list.txt`:
- Halbot100
- roberthallers