### PR TITLE
feat: add transaction size calculation methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 - Added CodeRabbit review instructions in `.coderabbit.yaml` for account module `src/hiero_sdk_python/account/`.
+- Added transaction size calculation methods: `size()` method and `body_size` property to base `Transaction` class, and `body_size_all_chunks` property to `FileAppendTransaction` and `TopicMessageSubmitTransaction` for multi-chunk transactions (#1794).
 
 ### Changed
 - Changed pytest version to "pytest>=8.3.4,<10" (#1917)

--- a/src/hiero_sdk_python/consensus/topic_message_submit_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_message_submit_transaction.py
@@ -181,10 +181,10 @@ class TopicMessageSubmitTransaction(Transaction):
     def _build_proto_body(self) -> consensus_submit_message_pb2.ConsensusSubmitMessageTransactionBody:
         """
         Returns the protobuf body for the topic message submit transaction.
-        
+
         Returns:
             ConsensusSubmitMessageTransactionBody: The protobuf body for this transaction.
-            
+
         Raises:
             ValueError: If required fields (topic_id, message) are missing.
         """
@@ -207,6 +207,10 @@ class TopicMessageSubmitTransaction(Transaction):
 
         # Multi-chunk metadata
         if self._total_chunks > 1:
+            # Set initial transaction ID if not already set (for freeze() without client)
+            if self._initial_transaction_id is None:
+                self._initial_transaction_id = self.transaction_id
+
             body.chunkInfo.CopyFrom(consensus_submit_message_pb2.ConsensusMessageChunkInfo(
                 initialTransactionID=self._initial_transaction_id._to_proto(),
                 total=self._total_chunks,
@@ -398,9 +402,9 @@ class TopicMessageSubmitTransaction(Transaction):
     def sign(self, private_key: "PrivateKey"):
         """
         Signs the transaction using the provided private key.
-            
+
         For multi-chunk transactions, this stores the signing key for later use.
-        
+
         Args:
             private_key (PrivateKey): The private key to sign the transaction with.
         """
@@ -409,3 +413,42 @@ class TopicMessageSubmitTransaction(Transaction):
 
         super().sign(private_key)
         return self
+
+    @property
+    def body_size_all_chunks(self) -> List[int]:
+        """
+        Returns a list containing the encoded body size of each chunk in multi-chunk transactions.
+
+        For single-chunk transactions, returns a list with one element.
+        The transaction must be frozen before calling this property.
+
+        Returns:
+            List[int]: A list of integers representing the body size of each chunk in bytes.
+
+        Raises:
+            Exception: If the transaction has not been frozen yet.
+        """
+        self._require_frozen()
+
+        chunk_sizes = []
+        required_chunks = self.get_required_chunks()
+
+        # Ensure _initial_transaction_id is set for multi-chunk transactions
+        if required_chunks > 1 and self._initial_transaction_id is None:
+            self._initial_transaction_id = self.transaction_id
+
+        for chunk_index in range(required_chunks):
+            # Save current state
+            saved_index = self._current_index
+
+            # Temporarily set the index to build the body for this chunk
+            self._current_index = chunk_index
+
+            # Build the transaction body for this chunk
+            chunk_body = self.build_transaction_body()
+            chunk_sizes.append(len(chunk_body.SerializeToString()))
+
+            # Restore state
+            self._current_index = saved_index
+
+        return chunk_sizes

--- a/src/hiero_sdk_python/file/file_append_transaction.py
+++ b/src/hiero_sdk_python/file/file_append_transaction.py
@@ -438,9 +438,9 @@ class FileAppendTransaction(Transaction):
     def sign(self, private_key: "PrivateKey") -> FileAppendTransaction:
         """
         Signs the transaction using the provided private key.
-            
+
         For multi-chunk transactions, this stores the signing key for later use.
-        
+
         Args:
             private_key (PrivateKey): The private key to sign the transaction with.
 
@@ -454,3 +454,42 @@ class FileAppendTransaction(Transaction):
         # Call the parent sign method for the current transaction
         super().sign(private_key)
         return self
+
+    @property
+    def body_size_all_chunks(self) -> List[int]:
+        """
+        Returns a list containing the encoded body size of each chunk in multi-chunk transactions.
+
+        For single-chunk transactions, returns a list with one element.
+        The transaction must be frozen before calling this property.
+
+        Returns:
+            List[int]: A list of integers representing the body size of each chunk in bytes.
+
+        Raises:
+            Exception: If the transaction has not been frozen yet.
+        """
+        self._require_frozen()
+
+        chunk_sizes = []
+        required_chunks = self.get_required_chunks()
+
+        for chunk_index in range(required_chunks):
+            # Calculate chunk content size
+            if self.contents is None:
+                chunk_content_size = 0
+            else:
+                start_index = chunk_index * self.chunk_size
+                end_index = min(start_index + self.chunk_size, len(self.contents))
+                chunk_content_size = end_index - start_index
+
+            # Build a protobuf body for this chunk to get its size
+            saved_index = self._current_chunk_index
+            self._current_chunk_index = chunk_index
+
+            chunk_body = self.build_transaction_body()
+            chunk_sizes.append(len(chunk_body.SerializeToString()))
+
+            self._current_chunk_index = saved_index
+
+        return chunk_sizes

--- a/src/hiero_sdk_python/transaction/transaction.py
+++ b/src/hiero_sdk_python/transaction/transaction.py
@@ -649,12 +649,49 @@ class Transaction(_Executable):
             Exception: If the transaction has not been frozen yet.
         """
         self._require_frozen()
-        
+
         # Get the transaction protobuf
         transaction_proto = self._to_proto()
-        
+
         # Serialize to bytes
         return transaction_proto.SerializeToString()
+
+    def size(self) -> int:
+        """
+        Returns the total size in bytes of the fully encoded transaction.
+
+        This includes the transaction body, signatures, and all protobuf overhead.
+        The transaction must be frozen before calling this method.
+
+        Returns:
+            int: The total size of the serialized transaction in bytes.
+
+        Raises:
+            Exception: If the transaction has not been frozen yet.
+        """
+        return len(self.to_bytes())
+
+    @property
+    def body_size(self) -> int:
+        """
+        Returns the size in bytes of the encoded TransactionBody only.
+
+        This excludes signatures and only includes the transaction body bytes.
+        The transaction must be frozen before calling this property.
+
+        Returns:
+            int: The size of the transaction body in bytes.
+
+        Raises:
+            Exception: If the transaction has not been frozen yet.
+        """
+        self._require_frozen()
+
+        body_bytes = self._transaction_body_bytes.get(self.node_account_id)
+        if body_bytes is None:
+            raise ValueError(f"No transaction body found for node {self.node_account_id}")
+
+        return len(body_bytes)
 
     @staticmethod
     def from_bytes(transaction_bytes: bytes):

--- a/tests/unit/transaction_size_test.py
+++ b/tests/unit/transaction_size_test.py
@@ -1,0 +1,154 @@
+"""
+Tests for transaction size calculation methods.
+"""
+
+import pytest
+
+from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.consensus.topic_id import TopicId
+from hiero_sdk_python.consensus.topic_message_submit_transaction import TopicMessageSubmitTransaction
+from hiero_sdk_python.crypto.private_key import PrivateKey
+from hiero_sdk_python.file.file_append_transaction import FileAppendTransaction
+from hiero_sdk_python.file.file_id import FileId
+from hiero_sdk_python.transaction.transaction_id import TransactionId
+from hiero_sdk_python.transaction.transfer_transaction import TransferTransaction
+
+pytestmark = pytest.mark.unit
+
+
+def test_transaction_size_basic():
+    """Test size() method returns the total serialized transaction size."""
+    tx = TransferTransaction()
+    tx.set_transaction_id(TransactionId.generate(AccountId(0, 0, 1)))
+    tx.node_account_id = AccountId(0, 0, 3)
+    tx.freeze()
+
+    # size() should return the same length as to_bytes()
+    tx_bytes = tx.to_bytes()
+    assert tx.size() == len(tx_bytes)
+    assert tx.size() > 0
+
+
+def test_transaction_body_size():
+    """Test body_size property returns the transaction body size only."""
+    tx = TransferTransaction()
+    tx.set_transaction_id(TransactionId.generate(AccountId(0, 0, 1)))
+    tx.node_account_id = AccountId(0, 0, 3)
+    tx.freeze()
+
+    # body_size should be less than or equal to total size (since it excludes signatures and protobuf overhead)
+    assert tx.body_size > 0
+    assert tx.body_size <= tx.size()
+
+
+def test_transaction_size_with_signature():
+    """Test that size() includes signatures when transaction is signed."""
+    private_key = PrivateKey.generate()
+
+    tx = TransferTransaction()
+    tx.set_transaction_id(TransactionId.generate(AccountId(0, 0, 1)))
+    tx.node_account_id = AccountId(0, 0, 3)
+    tx.freeze()
+
+    # Get size before signing
+    size_unsigned = tx.size()
+
+    # Sign the transaction
+    tx.sign(private_key)
+
+    # Size should increase after signing due to signature
+    size_signed = tx.size()
+    assert size_signed > size_unsigned
+
+
+def test_file_append_body_size_all_chunks_single_chunk():
+    """Test body_size_all_chunks for FileAppendTransaction with single chunk."""
+    tx = FileAppendTransaction()
+    tx.set_file_id(FileId(0, 0, 100))
+    tx.set_contents(b"small content")
+    tx.set_transaction_id(TransactionId.generate(AccountId(0, 0, 1)))
+    tx.node_account_id = AccountId(0, 0, 3)
+    tx.freeze()
+
+    chunk_sizes = tx.body_size_all_chunks
+
+    # Should have exactly 1 chunk for small content
+    assert len(chunk_sizes) == 1
+    assert chunk_sizes[0] > 0
+
+
+def test_file_append_body_size_all_chunks_multiple_chunks():
+    """Test body_size_all_chunks for FileAppendTransaction with multiple chunks."""
+    # Create content that requires multiple chunks (default chunk_size is 4096)
+    large_content = b"x" * 10000
+
+    tx = FileAppendTransaction()
+    tx.set_file_id(FileId(0, 0, 100))
+    tx.set_contents(large_content)
+    tx.set_transaction_id(TransactionId.generate(AccountId(0, 0, 1)))
+    tx.node_account_id = AccountId(0, 0, 3)
+    tx.freeze()
+
+    chunk_sizes = tx.body_size_all_chunks
+
+    # Should have 3 chunks: 4096 + 4096 + 1808 = 10000 bytes
+    assert len(chunk_sizes) == 3
+    assert all(size > 0 for size in chunk_sizes)
+
+
+def test_topic_message_body_size_all_chunks_single_chunk():
+    """Test body_size_all_chunks for TopicMessageSubmitTransaction with single chunk."""
+    tx = TopicMessageSubmitTransaction()
+    tx.set_topic_id(TopicId(0, 0, 100))
+    tx.set_message("small message")
+    tx.set_transaction_id(TransactionId.generate(AccountId(0, 0, 1)))
+    tx.node_account_id = AccountId(0, 0, 3)
+    tx.freeze()
+
+    chunk_sizes = tx.body_size_all_chunks
+
+    # Should have exactly 1 chunk for small message
+    assert len(chunk_sizes) == 1
+    assert chunk_sizes[0] > 0
+
+
+def test_topic_message_body_size_all_chunks_multiple_chunks():
+    """Test body_size_all_chunks for TopicMessageSubmitTransaction with multiple chunks."""
+    # Create message that requires multiple chunks (default chunk_size is 1024)
+    large_message = "x" * 3000
+
+    tx = TopicMessageSubmitTransaction()
+    tx.set_topic_id(TopicId(0, 0, 100))
+    tx.set_message(large_message)
+    tx.set_transaction_id(TransactionId.generate(AccountId(0, 0, 1)))
+    tx.node_account_id = AccountId(0, 0, 3)
+    tx.freeze()
+
+    chunk_sizes = tx.body_size_all_chunks
+
+    # Should have 3 chunks: 1024 + 1024 + 952 = 3000 bytes
+    assert len(chunk_sizes) == 3
+    assert all(size > 0 for size in chunk_sizes)
+
+
+def test_transaction_size_requires_frozen():
+    """Test that size() and body_size require transaction to be frozen."""
+    tx = TransferTransaction()
+
+    # Should raise exception when not frozen
+    with pytest.raises(Exception, match="Transaction is not frozen"):
+        tx.size()
+
+    with pytest.raises(Exception, match="Transaction is not frozen"):
+        _ = tx.body_size
+
+
+def test_chunked_transaction_body_size_all_chunks_requires_frozen():
+    """Test that body_size_all_chunks requires transaction to be frozen."""
+    tx = FileAppendTransaction()
+    tx.set_file_id(FileId(0, 0, 100))
+    tx.set_contents(b"content")
+
+    # Should raise exception when not frozen
+    with pytest.raises(Exception, match="Transaction is not frozen"):
+        _ = tx.body_size_all_chunks


### PR DESCRIPTION
## Description

Add transaction size calculation methods to the Python SDK, aligning it with the Java and JavaScript SDK implementations.

### Changes

- **`Transaction.size()`** - Returns the total serialized transaction size in bytes, including all protobuf overhead and signatures
- **`Transaction.body_size`** - Returns the transaction body size only, excluding signatures  
- **`FileAppendTransaction.body_size_all_chunks`** - Returns a list of body sizes for each chunk in multi-chunk file append transactions
- **`TopicMessageSubmitTransaction.body_size_all_chunks`** - Returns a list of body sizes for each chunk in multi-chunk topic message submissions

### Motivation

These methods enable developers to:
- Validate transaction sizes before submission
- Optimize transaction batching
- Plan multi-chunk transactions effectively
- Debug size-related transaction failures

### Testing

- Added comprehensive test suite (`tests/unit/transaction_size_test.py`) with 9 tests
- Tests cover single-chunk, multi-chunk, signed, unsigned, and frozen transaction scenarios
- All existing tests continue to pass

### Files Changed

- `src/hiero_sdk_python/transaction/transaction.py` - Added `size()` and `body_size`
- `src/hiero_sdk_python/file/file_append_transaction.py` - Added `body_size_all_chunks`
- `src/hiero_sdk_python/consensus/topic_message_submit_transaction.py` - Added `body_size_all_chunks`
- `tests/unit/transaction_size_test.py` - New test file
- `CHANGELOG.md` - Added feature entry

Fixes #1794

---

> **AI Disclosure:** This contribution was authored with assistance from an AI coding assistant (Claude). The implementation, tests, and PR description were generated with AI support. All code changes have been validated against the project's conventions and test suite.

Co-Authored-By: AI Assistant (Claude) <ai-assistant@contributor-bot.dev>