### PR TITLE
chore: update bot-community-calls workflow to use self-hosted runner

### DIFF
--- a/.github/workflows/bot-community-calls.yml
+++ b/.github/workflows/bot-community-calls.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
     office-hour-reminder:
-        runs-on: ubuntu-latest
+        runs-on: hl-sdk-py-lin-md
         steps:
             - name: Harden the runner
               uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc #2.15.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Require contributors to complete 1 beginner issue before they can be assigned an intermediate issue (#1939)
 - Expand spam list (#1933)
 - chore: add ndpvt-web to spam list (#1945)
+- chore: update bot-community-calls workflow to use self hosted runner (#1942)
 
 
 ## [0.2.1] - 2026-03-05


### PR DESCRIPTION
Fixes #1942

## Summary
Updated .github/workflows/bot-community-calls.yml to use self hosted runner hl-sdk-py-lin-md instead of ubuntu-latest.

## Changes Made
- Changed runs-on: ubuntu-latest to runs-on: hl-sdk-py-lin-md
- Added CHANGELOG.md entry under [Unreleased] > ### .github

## Testing
No functional changes, configuration update only