### PR TITLE
docs: add Chocolatey as prerequisite for Windows 10 users

### DIFF
--- a/docs/sdk_developers/training/setup/setup_windows.md
+++ b/docs/sdk_developers/training/setup/setup_windows.md
@@ -21,6 +21,7 @@ Before you begin, ensure you have the following installed on your system:
 1.  **Git for Windows**: [Download and install Git](https://gitforwindows.org/).
 2.  **Python 3.10+**: [Download and install Python](https://www.python.org/downloads/windows/). Ensure "Add Python to PATH" is checked during installation.
 3.  **GitHub Account**: You will need a GitHub account to fork the repository.
+4.  **Chocolatey** (Windows 10 users only): [Install Chocolatey](https://chocolatey.org/install). Ensure Chocolatey is added to your PATH during installation.
 
 ---
 


### PR DESCRIPTION
This PR adds Chocolatey as a prerequisite for Windows 10 users in the setup documentation.

## Changes
- Added Chocolatey installation requirement to the Windows setup guide
- Included link to Chocolatey installation instructions
- Added note about ensuring Chocolatey is added to PATH

## Related Issue
Fixes #1961

## Testing
This is a documentation-only change. No code modifications were made.