### PR TITLE
chore: enforce assignment limits and show current assignments

### DIFF
--- a/.github/scripts/bot-beginner-assign-on-comment.js
+++ b/.github/scripts/bot-beginner-assign-on-comment.js
@@ -170,9 +170,14 @@ module.exports = async ({ github, context }) => {
           per_page: 100,
         }
       );
-      return issues.length;
+      return issues
+      .filter(issue => !issue.pull_request)
+      .map(issue => ({
+      number: issue.number,
+      title: issue.title,
+      url: issue.html_url,
+      }));
     }
-
     const commenter = comment.user.login;
 
     // Fix 3: Validate comment body
@@ -296,7 +301,11 @@ Please try a GFI first, then come back — we’ll be happy to assign this! 😊
 
       // Enforce Assignment Limits
 
-      const openCount = await getOpenAssignments(commenter);
+      const assignments = await getOpenAssignments(commenter);
+      const openCount = assignments.length;
+      const assignmentList = assignments
+        .map(a => `• #${a.number} – ${a.title}\n${a.url}`)
+        .join('\n');
       const maxAllowed = 2;
 
       console.log("[Beginner Bot] Limit check:", {
@@ -307,7 +316,11 @@ Please try a GFI first, then come back — we’ll be happy to assign this! 😊
       });
 
       if (openCount >= maxAllowed) {
-        const message = `👋 Hi @${commenter}, you already have **2 open assignments**. Please finish one before requesting another.`;
+        const message = `👋 Hi @${commenter}, you already have **${openCount} open assignment${openCount > 1 ? 's' : ''}**:
+
+        ${assignmentList}
+
+        Please finish one before requesting another.`;
 
         try {
           await github.rest.issues.createComment({

--- a/.github/scripts/bot-gfi-assign-on-comment.js
+++ b/.github/scripts/bot-gfi-assign-on-comment.js
@@ -38,7 +38,13 @@ async function getOpenAssignments({ github, owner, repo, username }) {
             per_page: 100,
         }
     );
-    return issues.length;
+    return issues
+      .filter(issue => !issue.pull_request)
+      .map(issue => ({
+        number: issue.number,
+        title: issue.title,
+        url: issue.html_url,
+    }));
 }
 
 /// HELPERS FOR ASSIGNING ///
@@ -328,13 +334,18 @@ module.exports = async ({ github, context }) => {
         // ENFORCE ASSIGNMENT LIMITS
         // -------------------------------
 
-        const openCount = await getOpenAssignments({
+        const assignments = await getOpenAssignments({
             github,
             owner,
             repo,
             username: requesterUsername,
         });
 
+        const openCount = assignments.length;
+        
+        const assignmentList = assignments
+            .map(a => `• #${a.number} – ${a.title}\n${a.url}`)
+            .join('\n');
         const spamUser = isSpamUser(requesterUsername);
         const maxAllowed = spamUser ? 1 : 2;
 
@@ -344,11 +355,15 @@ module.exports = async ({ github, context }) => {
             spamUser,
             maxAllowed,
         });
-
         if (openCount >= maxAllowed) {
+
             const message = spamUser
-                ? `Hi @${requesterUsername}, you are limited to **1 active issue** at a time. Please complete your current assignment before requesting another.`
-                : `Hi @${requesterUsername}, you already have **2 open assignments**. Please finish one before requesting another.`;
+            ? `Hi @${requesterUsername}, you are limited to **1 active issue** at a time. Please complete your current assignment before requesting another.`
+            : `👋 Hi @${requesterUsername}, you already have **${openCount} open assignment${openCount > 1 ? 's' : ''}**:
+
+            ${assignmentList}
+
+            Please finish one before requesting another.`;
 
             await github.rest.issues.createComment({
                 owner,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+﻿# Changelog
 
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org).
@@ -7,6 +7,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 ## [Unreleased]
 
 ### Added
+- Add the assignment limits enforce for Good First Issue and beginner bots and show contributors their current open assignments when the limit is reached(#1724).
 - Added CodeRabbit review instructions in `.coderabbit.yaml` for account module `src/hiero_sdk_python/account/`.
 - Add support for `include_children` to TransactionRecordQuery ([#1512](https://github.com/hiero-ledger/hiero-sdk-python/issues/1512))
 


### PR DESCRIPTION
…ginner bots(#1724)

**Description**:
This PR enforces assignment limits for contributors requesting `/assign` on **Good First Issue** and **beginner** issues.

If a contributor has reached the assignment limit, the bot now prevents additional assignments and displays a list of their current open assignments with links, asking them to complete one before requesting another.

Changes applied to:
- `.github/scripts/bot-gfi_assign_on_comment.js`
- `.github/scripts/bot-beginner-assign-on-comment.js`

**Related issue(s)**:

Fixes #1724 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
