### PR TITLE
docs: add Chocolatey to Windows setup prerequisites

### DIFF
--- a/docs/sdk_developers/setup_windows.md
+++ b/docs/sdk_developers/setup_windows.md
@@ -25,6 +25,7 @@ Before you begin, ensure you have the following installed on your system:
 1.  **Git for Windows**: [Download and install Git](https://gitforwindows.org/).
 2.  **Python 3.10+**: [Download and install Python](https://www.python.org/downloads/windows/). Ensure "Add Python to PATH" is checked during installation.
 3.  **GitHub Account**: You will need a GitHub account to fork the repository.
+4.  **Chocolatey**: For Windows 10 users, you must install Chocolatey. A link for install can be found here [Chocolatey Install](https://chocolatey.org/install). Make sure Chocolatey is added to PATH.
 
 ---
 


### PR DESCRIPTION
## Summary
Add Chocolatey as a prerequisite for Windows 10 users in the setup instructions.

## Changes
Added a new prerequisite item (item #4) to the Windows Setup Guide:
> 4. **Chocolatey**: For Windows 10 users, you must install Chocolatey. A link for install can be found here [Chocolatey Install](https://chocolatey.org/install). Make sure Chocolatey is added to PATH.

This helps Windows 10 users set up the SDK locally more easily as described in issue #1961.