### PR TITLE
feat: Expose all missing protobuf fields in TransactionRecord 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+﻿# Changelog
 
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org).
@@ -7,7 +7,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 ## [Unreleased]
 
 ### Src
-- Exposed all missing `TransactionRecord` protobuf fields (`consensusTimestamp`, `scheduleRef`, `assessed_custom_fees`, `automatic_token_associations`, `parent_consensus_timestamp`, `alias`, `ethereum_hash`, `paid_staking_rewards`, `evm_address`, `contractCreateResult`) with proper `None` handling (#1636)
+- Exposed all missing `TransactionRecord` protobuf fields `consensusTimestamp`, `scheduleRef`, `assessed_custom_fees`, `automatic_token_associations`, `parent_consensus_timestamp`, `alias`, `ethereum_hash`, `paid_staking_rewards`, `evm_address`, `contractCreateResult` with proper `None` handling, PRNG oneof handling with unset values return `None` instead of default values 0 / b"" (#1636)
 
 ### Tests
 - Refactor `mock_server` setup for network level TLS handling and added thread safety

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 ## [Unreleased]
 
 ### Src
-- 
+- Exposed all missing `TransactionRecord` protobuf fields (`consensusTimestamp`, `scheduleRef`, `assessed_custom_fees`, `automatic_token_associations`, `parent_consensus_timestamp`, `alias`, `ethereum_hash`, `paid_staking_rewards`, `evm_address`, `contractCreateResult`) with proper `None` handling (#1636)
 
 ### Tests
 - Refactor `mock_server` setup for network level TLS handling and added thread safety
@@ -36,6 +36,8 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Fix the TransactionGetReceiptQuery to raise ReceiptStatusError for the non-retryable and non success receipt status
 - Refactor `AccountInfo` to use the existing `StakingInfo` wrapper class instead of flattened staking fields. Access is now via `info.staking_info.staked_account_id`, `info.staking_info.staked_node_id`, and `info.staking_info.decline_reward`. The old flat accessors (`info.staked_account_id`, `info.staked_node_id`, `info.decline_staking_reward`) are still available as deprecated properties and will emit a `DeprecationWarning`. (#1366)
 - Added abstract `Key` supper class to handle various proto Keys.
+
+
 ### Examples
 
 ### Tests

--- a/examples/transaction/transaction_record.py
+++ b/examples/transaction/transaction_record.py
@@ -1,0 +1,159 @@
+"""
+Simple example: Exploring TransactionRecord fields
+
+This example creates a mock TransactionRecord with sample data and prints all fields
+in a readable format.
+
+No network or client needed — just run the file!
+
+Run:
+    python examples/transaction/transaction_record.py
+"""
+
+from collections import defaultdict
+
+from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.contract.contract_function_result import ContractFunctionResult
+from hiero_sdk_python.contract.contract_id import ContractId
+from hiero_sdk_python.schedule.schedule_id import ScheduleId
+from hiero_sdk_python.timestamp import Timestamp
+from hiero_sdk_python.tokens.assessed_custom_fee import AssessedCustomFee
+from hiero_sdk_python.tokens.token_association import TokenAssociation
+from hiero_sdk_python.tokens.token_id import TokenId
+from hiero_sdk_python.transaction.transaction_id import TransactionId
+from hiero_sdk_python.transaction.transaction_receipt import TransactionReceipt
+from hiero_sdk_python.transaction.transaction_record import TransactionRecord
+
+from hiero_sdk_python.hapi.services import transaction_receipt_pb2
+from hiero_sdk_python.response_code import ResponseCode
+
+def create_mock_record():
+    """Create a mock TransactionRecord with sample values for all fields."""
+    # Basic setup
+    tx_id = TransactionId.from_string("0.0.1234@1698765432.000000000")
+
+    receipt_proto = transaction_receipt_pb2.TransactionReceipt()
+    receipt_proto.status = ResponseCode.SUCCESS.value  
+
+    receipt = TransactionReceipt(
+        receipt_proto=receipt_proto,
+        transaction_id=tx_id
+    )
+
+    ts = Timestamp(seconds=1698765432, nanos=123456789)
+    sched = ScheduleId(0, 0, 9999)
+
+    record = TransactionRecord(
+        transaction_id=tx_id,
+        transaction_hash=b'\x01\x02\x03\x04' * 12,
+        transaction_memo="Hello from example!",
+        transaction_fee=50000,
+        receipt=receipt,
+        token_transfers=defaultdict(lambda: defaultdict(int)),
+        nft_transfers=defaultdict(list),
+        transfers=defaultdict(int),
+        new_pending_airdrops=[],
+        prng_number=42,
+        prng_bytes=None,  # mutually exclusive with prng_number
+        duplicates=[],
+        children=[],
+        consensus_timestamp=ts,
+        schedule_ref=sched,
+        assessed_custom_fees=[
+            AssessedCustomFee(
+                amount=1000000,
+                fee_collector_account_id=AccountId(shard=0, realm=0, num=98),
+                effective_payer_account_ids=[AccountId(shard=0, realm=0, num=100)]
+            )
+        ],
+        automatic_token_associations=[
+            TokenAssociation(
+                token_id=TokenId(shard=0, realm=0, num=5678),
+                account_id=AccountId(shard=0, realm=0, num=1234)
+            )
+        ],
+        parent_consensus_timestamp=ts,
+        alias=b'\x12\x34\x56\x78\x9a\xbc',
+        ethereum_hash=b'\xab' * 32,
+        paid_staking_rewards=[
+            (AccountId(shard=0, realm=0, num=456), 500000),
+            (AccountId(shard=0, realm=0, num=789), 250000)
+        ],
+        evm_address=b'\xef' * 20,
+        contract_create_result=ContractFunctionResult(
+            contract_id=ContractId(shard=0, realm=0, contract=1000),
+            contract_call_result=b"Contract created successfully!"
+        ),
+    )
+
+    record.transfers[AccountId(shard=0, realm=0, num=100)] = -10000
+    record.transfers[AccountId(shard=0, realm=0, num=200)] = 10000
+
+    return record
+
+def _print_basic_fields(record):
+    print("Basic:")
+    print(f"  Transaction ID: {record.transaction_id}")
+    print(f"  Memo: {record.transaction_memo}")
+    print(f"  Fee: {record.transaction_fee} tinybars")
+    print(f"  Hash: {record.transaction_hash.hex() if record.transaction_hash else 'None'}")
+    if record.receipt:
+        try:
+            status = ResponseCode(record.receipt.status).name
+        except ValueError:
+            status = str(record.receipt.status)
+    else:
+        status = "None"
+    print(f"  Receipt Status: {status}")
+    print(f"  PRNG Number: {record.prng_number}")
+    print(f"  PRNG Bytes (hex): {record.prng_bytes.hex() if record.prng_bytes else 'None'}")
+
+
+def _print_transfer_fields(record):
+    print(f"  HBAR Transfers: {dict(record.transfers) if record.transfers else 'None'}")
+    print(f"  Token Transfers: {dict(record.token_transfers) if record.token_transfers else 'None'}")
+    print(f"  NFT Transfers: { {k: len(v) for k, v in record.nft_transfers.items()} if record.nft_transfers else 'None'}")
+    print(f"  Pending Airdrops: {len(record.new_pending_airdrops)}")
+
+
+def _print_new_fields(record):
+    print(f"  Consensus Timestamp: {record.consensus_timestamp}")
+    print(f"  Parent Consensus Timestamp: {record.parent_consensus_timestamp}")
+    print(f"  Schedule Ref: {record.schedule_ref}")
+    print(f"  Assessed Custom Fees ({len(record.assessed_custom_fees)}):")
+    for fee in record.assessed_custom_fees:
+        token = fee.token_id if fee.token_id else "HBAR"
+        payers = ", ".join(str(p) for p in fee.effective_payer_account_ids) if fee.effective_payer_account_ids else "N/A"
+        print(f"    - {fee.amount} {token} → Collector: {fee.fee_collector_account_id}, Payers: {payers}")
+    print(f"  Automatic Token Associations ({len(record.automatic_token_associations)}):")
+    for assoc in record.automatic_token_associations:
+        print(f"    - Token {assoc.token_id} → Account {assoc.account_id}")
+    print(f"  Alias (hex): {record.alias.hex() if record.alias else 'None'}")
+    print(f"  Ethereum Hash (hex): {record.ethereum_hash.hex() if record.ethereum_hash else 'None'}")
+    print(f"  Paid Staking Rewards ({len(record.paid_staking_rewards)}):")
+    for account, amount in record.paid_staking_rewards:
+        print(f"    - {account}: {amount} tinybars")
+    print(f"  EVM Address (hex): {record.evm_address.hex() if record.evm_address else 'None'}")
+    if record.contract_create_result:
+        print(f"  Contract Create Result: {record.contract_create_result.contract_id}")
+        print(f"    Result bytes (first 32): {record.contract_create_result.contract_call_result[:32].hex() if record.contract_create_result.contract_call_result else 'None'}...")
+    else:
+        print("  Contract Create Result: None")
+
+
+def print_all_fields(record):
+    """Print all fields of TransactionRecord in a simple, readable way."""
+    print("=== TransactionRecord Example ===")
+    _print_basic_fields(record)
+    _print_transfer_fields(record)
+    _print_new_fields(record)
+    
+def main():
+    print("Creating mock TransactionRecord...\n")
+    record = create_mock_record()
+    print_all_fields(record)
+
+
+if __name__ == "__main__":
+    main()
+    

--- a/examples/transaction/transaction_record.py
+++ b/examples/transaction/transaction_record.py
@@ -1,5 +1,5 @@
 """
-Simple example: Exploring TransactionRecord fields
+Simple example: Exploring TransactionRecord fields.
 
 This example creates a mock TransactionRecord with sample data and prints all fields
 in a readable format.
@@ -15,6 +15,8 @@ from collections import defaultdict
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.contract.contract_function_result import ContractFunctionResult
 from hiero_sdk_python.contract.contract_id import ContractId
+from hiero_sdk_python.hapi.services import transaction_receipt_pb2
+from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.schedule.schedule_id import ScheduleId
 from hiero_sdk_python.timestamp import Timestamp
 from hiero_sdk_python.tokens.assessed_custom_fee import AssessedCustomFee
@@ -24,8 +26,6 @@ from hiero_sdk_python.transaction.transaction_id import TransactionId
 from hiero_sdk_python.transaction.transaction_receipt import TransactionReceipt
 from hiero_sdk_python.transaction.transaction_record import TransactionRecord
 
-from hiero_sdk_python.hapi.services import transaction_receipt_pb2
-from hiero_sdk_python.response_code import ResponseCode
 
 def create_mock_record():
     """Create a mock TransactionRecord with sample values for all fields."""
@@ -149,6 +149,7 @@ def print_all_fields(record):
     _print_new_fields(record)
     
 def main():
+    """Run the TransactionRecord example."""
     print("Creating mock TransactionRecord...\n")
     record = create_mock_record()
     print_all_fields(record)

--- a/src/hiero_sdk_python/__init__.py
+++ b/src/hiero_sdk_python/__init__.py
@@ -52,6 +52,7 @@ from .tokens.token_unpause_transaction import TokenUnpauseTransaction
 from .tokens.token_pause_transaction import TokenPauseTransaction
 from .tokens.token_airdrop_claim import TokenClaimAirdropTransaction
 from .tokens.assessed_custom_fee import AssessedCustomFee
+from .tokens.token_association import TokenAssociation
 
 # Transaction
 from .transaction.transaction import Transaction
@@ -193,6 +194,7 @@ __all__ = [
     "TokenBurnTransaction",
     "TokenGrantKycTransaction",
     "TokenRelationship",
+    "TokenAssociation",
     "TokenUpdateTransaction",
     "TokenAirdropTransaction",
     "TokenCancelAirdropTransaction",

--- a/src/hiero_sdk_python/tokens/token_association.py
+++ b/src/hiero_sdk_python/tokens/token_association.py
@@ -1,13 +1,14 @@
+"""Dataclass for automatic token associations in Hedera transaction records."""
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Optional
 
 from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenAssociation as TokenAssociationProto
 from hiero_sdk_python.tokens.token_id import TokenId
-from hiero_sdk_python.hapi.services.basic_types_pb2 import (
-    TokenAssociation as TokenAssociationProto,
-)
 
-@dataclass
+
+@dataclass(frozen=True)
 class TokenAssociation:
     """Represents an automatic token association between a token and an account.
 
@@ -19,14 +20,14 @@ class TokenAssociation:
     on the ledger — use TokenAssociateTransaction for that.
     """
 
-    token_id: Optional[TokenId] = None
+    token_id: TokenId | None = None
     """The ID of the token that was automatically associated."""
 
-    account_id: Optional[AccountId] = None
+    account_id: AccountId | None = None
     """The ID of the account that received the automatic association."""
 
     @classmethod
-    def _from_proto(cls, proto: TokenAssociationProto) -> "TokenAssociation":
+    def _from_proto(cls, proto: TokenAssociationProto) -> TokenAssociation:
         """Create a TokenAssociation instance from the protobuf message."""
         return cls(
             token_id=(
@@ -58,18 +59,17 @@ class TokenAssociation:
         return self._to_proto().SerializeToString()
 
     @classmethod
-    def from_bytes(cls, data: bytes) -> "TokenAssociation":
+    def from_bytes(cls, data: bytes) -> TokenAssociation:
         """Deserialize a TokenAssociation from raw protobuf bytes."""
         proto = TokenAssociationProto()
         proto.ParseFromString(data)
         return cls._from_proto(proto)
     
+    def __repr__(self) -> str:
+        """Returns an unambiguous string representation for debugging."""
+        return f"TokenAssociation(token_id={self.token_id!r}, account_id={self.account_id!r})"
+
     def __str__(self) -> str:
         """Returns a human-readable string representation."""
-        return (
-            f"TokenAssociation("
-            f"token_id={self.token_id}, "
-            f"account_id={self.account_id}"
-            f")"
-        )
+        return self.__repr__()
     

--- a/src/hiero_sdk_python/tokens/token_association.py
+++ b/src/hiero_sdk_python/tokens/token_association.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.tokens.token_id import TokenId
+from hiero_sdk_python.hapi.services.basic_types_pb2 import (
+    TokenAssociation as TokenAssociationProto,
+)
+
+@dataclass
+class TokenAssociation:
+    """Represents an automatic token association between a token and an account.
+
+    This class appears in `TransactionRecord.automatic_token_associations` (repeated field)
+    when the network creates associations automatically (e.g., during token transfers
+    or airdrops to unassociated accounts).
+
+    These associations are informational only and cannot be used to create new associations
+    on the ledger — use TokenAssociateTransaction for that.
+    """
+
+    token_id: Optional[TokenId] = None
+    """The ID of the token that was automatically associated."""
+
+    account_id: Optional[AccountId] = None
+    """The ID of the account that received the automatic association."""
+
+    @classmethod
+    def _from_proto(cls, proto: TokenAssociationProto) -> "TokenAssociation":
+        """Create a TokenAssociation instance from the protobuf message."""
+        return cls(
+            token_id=(
+                TokenId._from_proto(proto.token_id)
+                if proto.HasField("token_id")
+                else None
+            ),
+            account_id=(
+                AccountId._from_proto(proto.account_id)
+                if proto.HasField("account_id")
+                else None
+            ),
+        )
+
+    def _to_proto(self) -> TokenAssociationProto:
+        """Convert this TokenAssociation instance back to a protobuf message."""
+        proto = TokenAssociationProto()
+
+        if self.token_id is not None:
+            proto.token_id.CopyFrom(self.token_id._to_proto())
+
+        if self.account_id is not None:
+            proto.account_id.CopyFrom(self.account_id._to_proto())
+
+        return proto
+
+    def to_bytes(self) -> bytes:
+        """Serialize this TokenAssociation to raw protobuf bytes."""
+        return self._to_proto().SerializeToString()
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> "TokenAssociation":
+        """Deserialize a TokenAssociation from raw protobuf bytes."""
+        proto = TokenAssociationProto()
+        proto.ParseFromString(data)
+        return cls._from_proto(proto)
+    
+    def __str__(self) -> str:
+        """Returns a human-readable string representation."""
+        return (
+            f"TokenAssociation("
+            f"token_id={self.token_id}, "
+            f"account_id={self.account_id}"
+            f")"
+        )
+    

--- a/src/hiero_sdk_python/transaction/transaction_record.py
+++ b/src/hiero_sdk_python/transaction/transaction_record.py
@@ -28,6 +28,10 @@ from hiero_sdk_python.tokens.token_id import TokenId
 from hiero_sdk_python.tokens.token_nft_transfer import TokenNftTransfer
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 from hiero_sdk_python.transaction.transaction_receipt import TransactionReceipt
+from hiero_sdk_python.timestamp import Timestamp
+from hiero_sdk_python.schedule.schedule_id import ScheduleId
+from hiero_sdk_python.tokens.assessed_custom_fee import AssessedCustomFee
+from hiero_sdk_python.tokens.token_association import TokenAssociation
 
 
 @dataclass
@@ -60,7 +64,20 @@ class TransactionRecord:
                                                           with include_duplicates=True. Empty by default.
 
         children (list[TransactionRecord]):               A list of children transaction records returned when queried
-                                                          with include_children=True. Empty by default.
+                                                          with include_children=True. Empty by default.       
+        consensus_timestamp (Optional[Timestamp]):        Network-assigned consensus timestamp when the transaction was finalized.
+        schedule_ref (Optional[ScheduleId]):              Schedule ID if this transaction was executed via a schedule.
+        assessed_custom_fees (list[AssessedCustomFee]):   Custom fees that were assessed and charged during execution.
+        automatic_token_associations (list[TokenAssociation]): 
+                                                          Automatic token-account associations created by the network.
+        parent_consensus_timestamp (Optional[Timestamp]): Consensus timestamp of the parent transaction (for child records).
+        alias (Optional[bytes]):                          New account alias created (e.g., during account creation with alias).
+        ethereum_hash (Optional[bytes]):                  Keccak-256 hash of the Ethereum-compatible transaction data.
+        paid_staking_rewards (list[tuple[AccountId, int]]): 
+                                                          Staking rewards paid out (account ID → amount in tinybars).
+        evm_address (Optional[bytes]):                    EVM address created or associated with the account.
+        contract_create_result (Optional[ContractFunctionResult]): 
+                                                          Result of a contract creation transaction (if applicable)                                           
     """
 
     transaction_id: Optional[TransactionId] = None
@@ -79,13 +96,26 @@ class TransactionRecord:
     prng_bytes: Optional[bytes] = None
     duplicates: list['TransactionRecord'] = field(default_factory=list)
     children: list['TransactionRecord'] = field(default_factory=list)
+    
+    consensus_timestamp: Optional[Timestamp] = None
+    schedule_ref: Optional[ScheduleId] = None
+    assessed_custom_fees: list[AssessedCustomFee] = field(default_factory=list)
+    automatic_token_associations: list[TokenAssociation] = field(default_factory=list)
+    parent_consensus_timestamp: Optional[Timestamp] = None
+    alias: Optional[bytes] = None
+    ethereum_hash: Optional[bytes] = None
+    paid_staking_rewards: list[tuple[AccountId, int]] = field(default_factory=list)
+    evm_address: Optional[bytes] = None
+    contract_create_result: Optional[ContractFunctionResult] = None
 
     def __repr__(self) -> str:
         """Returns a human-readable string representation of the TransactionRecord.
         
         This method constructs a detailed string containing all significant fields of the 
-        transaction record including transaction ID, hash, memo, fees, status, transfers,
-        and PRNG results. For the receipt status, it attempts to resolve the numeric status
+        transaction record including transaction ID, hash, memo, fees, status, transfers, 
+        PRNG results, consensus timestamp, schedule ref, custom fees, automatic associations, 
+        parent timestamp, alias, Ethereum hash, staking rewards, EVM address, contract create result. 
+        For the receipt status, it attempts to resolve the numeric status
         to a human-readable ResponseCode name.
         
         Returns:
@@ -112,8 +142,18 @@ class TransactionRecord:
                 f"prng_number={self.prng_number}, "
                 f"prng_bytes={self.prng_bytes}, "
                 f"duplicates_count={len(self.duplicates)}, "
-                f"children_count={len(self.children)})")
-
+                f"children_count={len(self.children)}, "
+                f"consensus_timestamp={self.consensus_timestamp}, "
+                f"schedule_ref={self.schedule_ref}, "
+                f"assessed_custom_fees={self.assessed_custom_fees}, "
+                f"automatic_token_associations={self.automatic_token_associations}, "
+                f"parent_consensus_timestamp={self.parent_consensus_timestamp}, "
+                f"alias={self.alias}, "
+                f"ethereum_hash={self.ethereum_hash}, "
+                f"paid_staking_rewards={self.paid_staking_rewards}, "
+                f"evm_address={self.evm_address}, "
+                f"contract_create_result={self.contract_create_result})")
+    
     @classmethod
     def _from_proto(
         cls,
@@ -132,6 +172,11 @@ class TransactionRecord:
         - Contract execution results
         - Airdrop records
         - PRNG (pseudo-random number generation) results
+        - Other protobuf fields: consensus timestamp, schedule reference,
+        assessed custom fees, automatic token associations, parent consensus
+        timestamp, alias, ethereum hash, paid staking rewards, EVM address,
+        and contract create result
+        
         The method maps all nested transfer data from the raw protobuf message into
         the structured format used by the TransactionRecord class & organizing them
 
@@ -157,6 +202,46 @@ class TransactionRecord:
         new_pending_airdrops = cls._parse_pending_airdrops(proto)
         call_result = cls._parse_contract_call_result(proto)
 
+        consensus_timestamp = (
+            Timestamp._from_protobuf(proto.consensusTimestamp)
+            if proto.HasField("consensusTimestamp") else None
+        )
+        parent_consensus_timestamp = (
+            Timestamp._from_protobuf(proto.parent_consensus_timestamp)
+            if proto.HasField("parent_consensus_timestamp") else None
+        )
+        schedule_ref = (
+            ScheduleId._from_proto(proto.scheduleRef)
+            if proto.HasField("scheduleRef") else None
+        )
+        assessed_custom_fees = [
+            AssessedCustomFee._from_proto(fee) for fee in proto.assessed_custom_fees
+        ]
+        automatic_token_associations = [
+            TokenAssociation._from_proto(assoc) for assoc in proto.automatic_token_associations
+        ]
+        paid_staking_rewards = [
+            (AccountId._from_proto(r.accountID), r.amount)
+            for r in proto.paid_staking_rewards
+        ]
+        contract_create_result = (
+            ContractFunctionResult._from_proto(proto.contractCreateResult)
+            if proto.HasField("contractCreateResult") else None
+        )
+        alias = proto.alias if proto.alias else None
+        ethereum_hash = proto.ethereum_hash if proto.ethereum_hash else None
+        evm_address = proto.evm_address if proto.evm_address else None
+        
+        entropy_case = proto.WhichOneof("entropy")
+
+        prng_number = None
+        prng_bytes  = None
+
+        if entropy_case == "prng_number":
+            prng_number = proto.prng_number
+        elif entropy_case == "prng_bytes":
+            prng_bytes = proto.prng_bytes
+
         return cls(
             transaction_id=tx_id,
             transaction_hash=proto.transactionHash,
@@ -168,10 +253,20 @@ class TransactionRecord:
             transfers=transfers,
             new_pending_airdrops=new_pending_airdrops,
             call_result=call_result,
-            prng_number=proto.prng_number,
-            prng_bytes=proto.prng_bytes,
+            prng_number=prng_number,
+            prng_bytes=prng_bytes,
             duplicates=duplicates,
             children=children,
+            consensus_timestamp=consensus_timestamp,
+            schedule_ref=schedule_ref,
+            assessed_custom_fees=assessed_custom_fees,
+            automatic_token_associations=automatic_token_associations,
+            parent_consensus_timestamp=parent_consensus_timestamp,
+            alias=alias,
+            ethereum_hash=ethereum_hash,
+            paid_staking_rewards=paid_staking_rewards,
+            evm_address=evm_address,
+            contract_create_result=contract_create_result,
         )
 
     @staticmethod
@@ -256,6 +351,10 @@ class TransactionRecord:
         - Contract execution results
         - Airdrop records
         - PRNG (pseudo-random number generation) results
+        - Other protobuf fields: consensus timestamp, schedule reference,
+        assessed custom fees, automatic token associations, parent consensus
+        timestamp, alias, ethereum hash, paid staking rewards, EVM address,
+        and contract create result
 
         The method performs a deep conversion of all nested objects (token transfers,
         NFT transfers, account transfers, and pending airdrops) to their respective
@@ -266,6 +365,18 @@ class TransactionRecord:
             all the transaction record data in a format suitable for network transmission
             or storage.
         """
+        if self.call_result is not None and self.contract_create_result is not None:
+            raise ValueError(
+                "contractCallResult and contractCreateResult are mutually exclusive "
+                "proto oneof fields and cannot both be set simultaneously."
+            )
+        
+        if self.prng_number is not None and self.prng_bytes is not None:
+            raise ValueError(
+                "prng_number and prng_bytes are mutually exclusive "
+                "proto oneof fields (entropy) and cannot both be set simultaneously."
+            )
+        
         record_proto = transaction_record_pb2.TransactionRecord(
             transactionHash=self.transaction_hash,
             memo=self.transaction_memo,
@@ -274,9 +385,12 @@ class TransactionRecord:
             contractCallResult=(
                 self.call_result._to_proto() if self.call_result else None
             ),
-            prng_number=self.prng_number,
-            prng_bytes=self.prng_bytes,
         )
+        
+        if self.prng_number is not None:
+                record_proto.prng_number = self.prng_number
+        if self.prng_bytes is not None:
+            record_proto.prng_bytes = self.prng_bytes
 
         if self.transaction_id is not None:
             record_proto.transactionID.CopyFrom(self.transaction_id._to_proto())
@@ -302,6 +416,39 @@ class TransactionRecord:
 
         for pending_airdrop in self.new_pending_airdrops:
             record_proto.new_pending_airdrops.add().CopyFrom(pending_airdrop._to_proto())
+        if self.consensus_timestamp is not None:
+            record_proto.consensusTimestamp.CopyFrom(self.consensus_timestamp._to_protobuf())
+
+        if self.schedule_ref is not None:
+            record_proto.scheduleRef.CopyFrom(self.schedule_ref._to_proto())
+
+        record_proto.assessed_custom_fees.extend(
+            fee._to_proto() for fee in self.assessed_custom_fees
+        )
+
+        record_proto.automatic_token_associations.extend(
+            assoc._to_proto() for assoc in self.automatic_token_associations
+        )
+
+        if self.parent_consensus_timestamp is not None:
+            record_proto.parent_consensus_timestamp.CopyFrom(self.parent_consensus_timestamp._to_protobuf())
+
+        if self.alias is not None:
+            record_proto.alias = self.alias
+
+        if self.ethereum_hash is not None:
+            record_proto.ethereum_hash = self.ethereum_hash
+
+        for account_id, amount in self.paid_staking_rewards:
+            aa = record_proto.paid_staking_rewards.add()
+            aa.accountID.CopyFrom(account_id._to_proto())
+            aa.amount = amount
+
+        if self.evm_address is not None:
+            record_proto.evm_address = self.evm_address
+
+        if self.contract_create_result is not None:
+            record_proto.contractCreateResult.CopyFrom(self.contract_create_result._to_proto())
 
         return record_proto
-    
+

--- a/src/hiero_sdk_python/transaction/transaction_record.py
+++ b/src/hiero_sdk_python/transaction/transaction_record.py
@@ -1,4 +1,6 @@
 """
+Module for the TransactionRecord class.
+
 This module implements the TransactionRecord class which represents a complete record
 of a transaction executed on the Hiero network. It serves as a comprehensive data
 structure that captures all aspects of a transaction's execution and its effects.
@@ -16,28 +18,29 @@ The module provides functionality to:
 
 """
 
+from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Optional
 
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.contract.contract_function_result import ContractFunctionResult
 from hiero_sdk_python.hapi.services import transaction_record_pb2
+from hiero_sdk_python.schedule.schedule_id import ScheduleId
+from hiero_sdk_python.timestamp import Timestamp
+from hiero_sdk_python.tokens.assessed_custom_fee import AssessedCustomFee
 from hiero_sdk_python.tokens.token_airdrop_pending_record import PendingAirdropRecord
+from hiero_sdk_python.tokens.token_association import TokenAssociation
 from hiero_sdk_python.tokens.token_id import TokenId
 from hiero_sdk_python.tokens.token_nft_transfer import TokenNftTransfer
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 from hiero_sdk_python.transaction.transaction_receipt import TransactionReceipt
-from hiero_sdk_python.timestamp import Timestamp
-from hiero_sdk_python.schedule.schedule_id import ScheduleId
-from hiero_sdk_python.tokens.assessed_custom_fee import AssessedCustomFee
-from hiero_sdk_python.tokens.token_association import TokenAssociation
 
 
 @dataclass
 class TransactionRecord:
     """
     Represents a record of a completed transaction on the Hiero network.
+    
     This class combines detailed information about the a transaction including the
     transaction ID, receipt, token and NFT transfers, fees & other
     metadata such as pseudo-random number generation(PRNG) results and 
@@ -80,33 +83,33 @@ class TransactionRecord:
                                                           Result of a contract creation transaction (if applicable)                                           
     """
 
-    transaction_id: Optional[TransactionId] = None
-    transaction_hash: Optional[bytes] = None
-    transaction_memo: Optional[str] = None
-    transaction_fee: Optional[int] = None
-    receipt: Optional[TransactionReceipt] = None
-    call_result: Optional[ContractFunctionResult] = None
+    transaction_id: TransactionId | None = None
+    transaction_hash: bytes | None = None
+    transaction_memo: str | None = None
+    transaction_fee: int | None = None
+    receipt: TransactionReceipt | None = None
+    call_result: ContractFunctionResult | None = None
 
     token_transfers: defaultdict[TokenId, defaultdict[AccountId, int]] = field(default_factory=lambda: defaultdict(lambda: defaultdict(int)))
     nft_transfers: defaultdict[TokenId, list[TokenNftTransfer]] = field(default_factory=lambda: defaultdict(list[TokenNftTransfer]))
     transfers: defaultdict[AccountId, int] = field(default_factory=lambda: defaultdict(int))
     new_pending_airdrops: list[PendingAirdropRecord] = field(default_factory=list)
 
-    prng_number: Optional[int] = None
-    prng_bytes: Optional[bytes] = None
-    duplicates: list['TransactionRecord'] = field(default_factory=list)
-    children: list['TransactionRecord'] = field(default_factory=list)
+    prng_number: int | None = None
+    prng_bytes: bytes | None = None
+    duplicates: list[TransactionRecord] = field(default_factory=list)
+    children: list[TransactionRecord] = field(default_factory=list)
     
-    consensus_timestamp: Optional[Timestamp] = None
-    schedule_ref: Optional[ScheduleId] = None
+    consensus_timestamp: Timestamp | None = None
+    schedule_ref: ScheduleId | None = None
     assessed_custom_fees: list[AssessedCustomFee] = field(default_factory=list)
     automatic_token_associations: list[TokenAssociation] = field(default_factory=list)
-    parent_consensus_timestamp: Optional[Timestamp] = None
-    alias: Optional[bytes] = None
-    ethereum_hash: Optional[bytes] = None
+    parent_consensus_timestamp: Timestamp | None = None
+    alias: bytes | None = None
+    ethereum_hash: bytes | None = None
     paid_staking_rewards: list[tuple[AccountId, int]] = field(default_factory=list)
-    evm_address: Optional[bytes] = None
-    contract_create_result: Optional[ContractFunctionResult] = None
+    evm_address: bytes | None = None
+    contract_create_result: ContractFunctionResult | None = None
 
     def __repr__(self) -> str:
         """Returns a human-readable string representation of the TransactionRecord.
@@ -158,10 +161,10 @@ class TransactionRecord:
     def _from_proto(
         cls,
         proto: transaction_record_pb2.TransactionRecord,
-        transaction_id: Optional[TransactionId] = None,
-        duplicates: Optional[list['TransactionRecord']] = None,
-        children: Optional[list['TransactionRecord']] = None,
-    ) -> 'TransactionRecord':
+        transaction_id: TransactionId | None = None,
+        duplicates: list[TransactionRecord] | None = None,
+        children: list[TransactionRecord] | None = None,
+    ) -> TransactionRecord:
         """Creates a TransactionRecord instance from a protobuf transaction record.
 
         This method performs complex data aggregation from the protobuf message,
@@ -200,7 +203,14 @@ class TransactionRecord:
         token_transfers, nft_transfers = cls._parse_token_transfers(proto)
         transfers = cls._parse_hbar_transfers(proto)
         new_pending_airdrops = cls._parse_pending_airdrops(proto)
-        call_result = cls._parse_contract_call_result(proto)
+        call_result = None
+        contract_create_result = None
+
+        body_case = proto.WhichOneof("body")
+        if body_case == "contractCallResult":
+            call_result = ContractFunctionResult._from_proto(proto.contractCallResult)
+        elif body_case == "contractCreateResult":
+            contract_create_result = ContractFunctionResult._from_proto(proto.contractCreateResult)
 
         consensus_timestamp = (
             Timestamp._from_protobuf(proto.consensusTimestamp)
@@ -272,7 +282,7 @@ class TransactionRecord:
     @staticmethod
     def _resolve_transaction_id(
         proto: transaction_record_pb2.TransactionRecord,
-        transaction_id: Optional[TransactionId],
+        transaction_id: TransactionId | None,
     ) -> TransactionId:
         """Resolves the transaction ID from proto or raises error if not available."""
         if proto.HasField("transactionID"):
@@ -330,7 +340,7 @@ class TransactionRecord:
     @staticmethod
     def _parse_contract_call_result(
         proto: transaction_record_pb2.TransactionRecord,
-    ) -> Optional[ContractFunctionResult]:
+    ) -> ContractFunctionResult | None:
         """Parses contract call result from proto if present."""
         if proto.HasField("contractCallResult"):
             return ContractFunctionResult._from_proto(proto.contractCallResult)
@@ -382,11 +392,12 @@ class TransactionRecord:
             memo=self.transaction_memo,
             transactionFee=self.transaction_fee,
             receipt=self.receipt._to_proto() if self.receipt else None,
-            contractCallResult=(
-                self.call_result._to_proto() if self.call_result else None
-            ),
         )
         
+        if self.call_result is not None:
+            record_proto.contractCallResult.CopyFrom(self.call_result._to_proto())
+        elif self.contract_create_result is not None:
+            record_proto.contractCreateResult.CopyFrom(self.contract_create_result._to_proto())
         if self.prng_number is not None:
                 record_proto.prng_number = self.prng_number
         if self.prng_bytes is not None:
@@ -451,4 +462,3 @@ class TransactionRecord:
             record_proto.contractCreateResult.CopyFrom(self.contract_create_result._to_proto())
 
         return record_proto
-

--- a/tests/integration/prng_transaction_e2e_test.py
+++ b/tests/integration/prng_transaction_e2e_test.py
@@ -24,7 +24,7 @@ def test_integration_prng_transaction_can_execute(env):
     assert (
         record.prng_number >= 0 and record.prng_number <= 100
     ), "PRNG number should be between 0 and 100"
-    assert record.prng_bytes == b"", "PRNG bytes should be empty bytes"
+    assert record.prng_bytes is None, "PRNG bytes should be None"
 
 
 @pytest.mark.integration
@@ -37,10 +37,9 @@ def test_integration_prng_transaction_can_execute_without_range(env):
 
     record = TransactionRecordQuery(receipt.transaction_id).execute(env.client)
 
-    assert record.prng_number == 0, "PRNG number should be 0"
-    assert len(record.prng_bytes) == 48, "PRNG bytes should be 48 bytes"
+    assert record.prng_number is None, "PRNG number should be None"
     assert record.prng_bytes is not None, "PRNG bytes should not be None"
-
+    assert len(record.prng_bytes) == 48, "PRNG bytes should be 48 bytes"
 
 @pytest.mark.integration
 def test_integration_prng_transaction_can_execute_with_zero_range(env):
@@ -52,6 +51,6 @@ def test_integration_prng_transaction_can_execute_with_zero_range(env):
 
     record = TransactionRecordQuery(receipt.transaction_id).execute(env.client)
 
-    assert record.prng_number == 0, "PRNG number should be 0"
-    assert len(record.prng_bytes) == 48, "PRNG bytes should be 48 bytes"
+    assert record.prng_number is None, "PRNG number should be None"
     assert record.prng_bytes is not None, "PRNG bytes should not be None"
+    assert len(record.prng_bytes) == 48, "PRNG bytes should be 48 bytes"

--- a/tests/integration/transaction_record_query_e2e_test.py
+++ b/tests/integration/transaction_record_query_e2e_test.py
@@ -1,11 +1,16 @@
-import pytest
+"""Integration tests for TransactionRecordQuery end-to-end functionality."""
+
 import os
-from hiero_sdk_python import AccountId, Client, TransactionRecord
+
+import pytest
+
+from hiero_sdk_python import AccountId, Timestamp, TransactionRecord
+from hiero_sdk_python.account.account_create_transaction import AccountCreateTransaction
 from hiero_sdk_python.crypto.private_key import PrivateKey
 from hiero_sdk_python.hbar import Hbar
-from hiero_sdk_python.account.account_create_transaction import AccountCreateTransaction
 from hiero_sdk_python.query.transaction_record_query import TransactionRecordQuery
 from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.schedule.schedule_id import ScheduleId
 from hiero_sdk_python.tokens.nft_id import NftId
 from hiero_sdk_python.tokens.token_associate_transaction import (
     TokenAssociateTransaction,
@@ -16,7 +21,6 @@ from tests.integration.utils import (
     IntegrationTestEnv,
     create_fungible_token,
     create_nft_token,
-    env,
 )
 
 
@@ -41,6 +45,7 @@ def _submit_alias_auto_create_transfer(env: IntegrationTestEnv):
 
 @pytest.mark.integration
 def test_transaction_record_query_can_execute():
+    """Test that a basic transaction record query can execute successfully."""
     env = IntegrationTestEnv()
 
     try:
@@ -75,41 +80,46 @@ def test_transaction_record_query_can_execute():
 
 
 @pytest.mark.integration
-def test_transaction_record_query_include_children_returns_child_records(env):
+def test_transaction_record_query_include_children_returns_child_records():
     """Querying an alias auto-create parent record should return parsed child records."""
-    parent_transaction_id = _submit_alias_auto_create_transfer(env)
-    parent_account_id = parent_transaction_id.account_id
+    env = IntegrationTestEnv()
+    try:
+        parent_transaction_id = _submit_alias_auto_create_transfer(env)
+        parent_account_id = parent_transaction_id.account_id
 
-    parent_record = (
-        TransactionRecordQuery()
-        .set_transaction_id(parent_transaction_id)
-        .set_include_children(True)
-        .execute(env.client)
-    )
+        parent_record = (
+            TransactionRecordQuery()
+            .set_transaction_id(parent_transaction_id)
+            .set_include_children(True)
+            .execute(env.client)
+        )
 
-    assert parent_record.transaction_id == parent_transaction_id
-    assert parent_record.receipt.status == ResponseCode.SUCCESS
-    assert len(parent_record.children) > 0
-    assert parent_record.transfers[parent_account_id] < 0
+        assert parent_record.transaction_id == parent_transaction_id
+        assert parent_record.receipt.status == ResponseCode.SUCCESS
+        assert len(parent_record.children) > 0
+        assert parent_record.transfers[parent_account_id] < 0
 
-    child_record = parent_record.children[0]
-    created_account_id = child_record.receipt.account_id
+        child_record = parent_record.children[0]
+        created_account_id = child_record.receipt.account_id
 
-    assert isinstance(child_record, TransactionRecord)
-    assert child_record.receipt.status == ResponseCode.SUCCESS
-    assert child_record.transaction_id == parent_transaction_id
-    assert created_account_id is not None
-    assert created_account_id.shard == 0
-    assert created_account_id.realm == 0
-    assert created_account_id.num > 0
-    assert child_record.transaction_hash != parent_record.transaction_hash
-    assert child_record.transaction_memo == ""
-    assert child_record.children == []
-    assert child_record.duplicates == []
+        assert isinstance(child_record, TransactionRecord)
+        assert child_record.receipt.status == ResponseCode.SUCCESS
+        assert child_record.transaction_id == parent_transaction_id
+        assert created_account_id is not None
+        assert created_account_id.shard == 0
+        assert created_account_id.realm == 0
+        assert created_account_id.num > 0
+        assert child_record.transaction_hash != parent_record.transaction_hash
+        assert child_record.transaction_memo == ""
+        assert child_record.children == []
+        assert child_record.duplicates == []
+    finally:
+        env.close()
 
 
 @pytest.mark.integration
 def test_transaction_record_query_can_execute_nft_transfer():
+    """Test that NFT transfers are correctly captured in the transaction record."""
     env = IntegrationTestEnv()
 
     try:
@@ -196,6 +206,7 @@ def test_transaction_record_query_can_execute_nft_transfer():
 
 @pytest.mark.integration
 def test_transaction_record_query_can_execute_fungible_transfer():
+    """Test that fungible token transfers are correctly captured in the record."""
     env = IntegrationTestEnv()
 
     try:
@@ -265,6 +276,7 @@ def test_transaction_record_query_can_execute_fungible_transfer():
     ),
 )
 def test_query_with_include_duplicates():
+    """Verify that duplicate records are returned when the flag is enabled."""
     env = IntegrationTestEnv()
     try:
         # Use a fresh keypair for isolation
@@ -329,3 +341,83 @@ def test_query_with_include_duplicates():
     finally:
         env.close()
         
+@pytest.mark.integration
+def test_transaction_record_new_fields():
+    """Simple test to verify some fields in TransactionRecord.
+    
+    consensus_timestamp, automatic_token_associations, paid_staking_rewards,
+    evm_address, alias, ethereum_hash, parent_consensus_timestamp,
+    assessed_custom_fees, schedule_ref, and PRNG oneof handling.
+    """
+    env = IntegrationTestEnv()
+    try:
+        new_account_private_key = PrivateKey.generate_ed25519()
+        new_account_public_key = new_account_private_key.public_key()
+
+        receipt = (
+            AccountCreateTransaction()
+            .set_key_without_alias(new_account_public_key)
+            .set_initial_balance(Hbar(1))
+            .execute(env.client)
+        )
+        assert receipt.status == ResponseCode.SUCCESS
+
+        record: TransactionRecord = TransactionRecordQuery(
+            receipt.transaction_id
+        ).execute(env.client)
+
+        _assert_basic_record_fields(record, receipt)
+        _assert_fields(record)
+    finally:
+        env.close()
+
+def _assert_basic_record_fields(record: TransactionRecord, receipt) -> None:
+    """Assert basic fields that existed before this PR."""
+    assert record.transaction_id == receipt.transaction_id
+    assert record.transaction_fee > 0
+    assert record.consensus_timestamp is not None
+    assert record.transaction_hash is not None and len(record.transaction_hash) > 0
+
+def _assert_fields(record: TransactionRecord) -> None:
+    """Assert all newly exposed fields from this PR."""
+    _assert_list_fields(record)
+    _assert_optional_bytes_fields(record)
+    _assert_timestamp_and_schedule_fields(record)
+    _assert_prng_fields(record)
+    _assert_token_associations(record)
+
+def _assert_list_fields(record: TransactionRecord) -> None:
+    """Assert list fields are properly initialized."""
+    assert isinstance(record.automatic_token_associations, list)
+    assert isinstance(record.paid_staking_rewards, list)
+    assert isinstance(record.assessed_custom_fees, list)
+
+def _assert_optional_bytes_fields(record: TransactionRecord) -> None:
+    """Assert optional bytes fields."""
+    assert record.evm_address is None or isinstance(record.evm_address, bytes)
+    assert record.alias is None or isinstance(record.alias, bytes)
+    assert record.ethereum_hash is None or isinstance(record.ethereum_hash, bytes)
+
+def _assert_timestamp_and_schedule_fields(record: TransactionRecord) -> None:
+    """Assert timestamp and schedule related fields."""
+    assert record.parent_consensus_timestamp is None or isinstance(
+        record.parent_consensus_timestamp, Timestamp
+    )
+    assert record.schedule_ref is None or isinstance(record.schedule_ref, ScheduleId)
+
+def _assert_prng_fields(record: TransactionRecord) -> None:
+    """Assert PRNG oneof handling."""
+    assert not (record.prng_number is not None and record.prng_bytes is not None), \
+        "prng_number and prng_bytes are mutually exclusive"
+
+    if record.prng_number is not None:
+        assert isinstance(record.prng_number, int)
+    if record.prng_bytes is not None:
+        assert isinstance(record.prng_bytes, bytes)
+
+def _assert_token_associations(record: TransactionRecord) -> None:
+    """Assert TokenAssociation model fields."""
+    for assoc in record.automatic_token_associations:
+        assert hasattr(assoc, "token_id")
+        assert hasattr(assoc, "account_id")
+    

--- a/tests/unit/token_association_test.py
+++ b/tests/unit/token_association_test.py
@@ -1,3 +1,4 @@
+"""Unit tests for the TokenAssociation class."""
 import pytest
 
 from hiero_sdk_python.account.account_id import AccountId
@@ -5,17 +6,18 @@ from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenAssociation as T
 from hiero_sdk_python.tokens.token_association import TokenAssociation
 from hiero_sdk_python.tokens.token_id import TokenId
 
-
 pytestmark = pytest.mark.unit
 
 
 @pytest.fixture
 def sample_token_id() -> TokenId:
+    """Return a sample TokenId for testing."""
     return TokenId(shard=0, realm=0, num=5678)
 
 
 @pytest.fixture
 def sample_account_id() -> AccountId:
+    """Return a sample AccountId for testing."""
     return AccountId(shard=0, realm=0, num=1234)
 
 
@@ -216,31 +218,25 @@ def test_bytes_round_trip_empty():
     assert reconstructed.token_id is None
     assert reconstructed.account_id is None
 
-def test_str_representation(sample_token_id: TokenId, sample_account_id: AccountId):
-    """Test that __str__ contains expected field information."""
+def test_repr_representation(sample_token_id: TokenId, sample_account_id: AccountId):
+    """Test __repr__ output for TokenAssociation."""
     assoc = TokenAssociation(
         token_id=sample_token_id,
         account_id=sample_account_id
     )
-    repr_s = str(assoc)
-    assert "TokenAssociation" in repr_s
-    assert str(sample_token_id) in repr_s
-    assert str(sample_account_id) in repr_s
+    repr_str = repr(assoc)
+
+    assert "TokenAssociation" in repr_str
+    assert "token_id=" in repr_str
+    assert "account_id=" in repr_str
 
 
-def test_str_with_none_fields():
-    """Test __str__ with one or both fields None."""
-    assoc_token_only = TokenAssociation(token_id=TokenId(shard=0, realm=0, num=5678))
-    s_token = str(assoc_token_only)
-    assert "token_id=0.0.5678" in s_token
-    assert "account_id=None" in s_token
+def test_repr_with_none_fields():
+    """Test __repr__ when some fields are None."""
+    assoc = TokenAssociation(token_id=TokenId(shard=0, realm=0, num=5678))
+    repr_str = repr(assoc)
+    assert "token_id=TokenId" in repr_str
+    assert "account_id=None" in repr_str
 
-    assoc_account_only = TokenAssociation(account_id=AccountId(shard=0, realm=0, num=1234))
-    s_account = str(assoc_account_only)
-    assert "token_id=None" in s_account
-    assert "account_id=0.0.1234" in s_account
-
-    assoc_empty = TokenAssociation()
-    s_empty = str(assoc_empty)
-    assert "token_id=None" in s_empty
-    assert "account_id=None" in s_empty
+    empty = TokenAssociation()
+    assert "TokenAssociation(token_id=None, account_id=None)" in repr(empty)

--- a/tests/unit/token_association_test.py
+++ b/tests/unit/token_association_test.py
@@ -1,0 +1,246 @@
+import pytest
+
+from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.hapi.services.basic_types_pb2 import TokenAssociation as TokenAssociationProto
+from hiero_sdk_python.tokens.token_association import TokenAssociation
+from hiero_sdk_python.tokens.token_id import TokenId
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def sample_token_id() -> TokenId:
+    return TokenId(shard=0, realm=0, num=5678)
+
+
+@pytest.fixture
+def sample_account_id() -> AccountId:
+    return AccountId(shard=0, realm=0, num=1234)
+
+
+def test_default_initialization():
+    """Test default initialization of TokenAssociation (both fields None)."""
+    assoc = TokenAssociation()
+
+    assert assoc.token_id is None
+    assert assoc.account_id is None
+
+
+def test_initialization_both_fields(sample_token_id: TokenId, sample_account_id: AccountId):
+    """Test initialization with both token_id and account_id provided."""
+    assoc = TokenAssociation(
+        token_id=sample_token_id,
+        account_id=sample_account_id
+    )
+
+    assert assoc.token_id == sample_token_id
+    assert assoc.account_id == sample_account_id
+
+
+def test_initialization_token_only(sample_token_id: TokenId):
+    """Test initialization with only token_id (account_id None)."""
+    assoc = TokenAssociation(token_id=sample_token_id)
+
+    assert assoc.token_id == sample_token_id
+    assert assoc.account_id is None
+
+
+def test_initialization_account_only(sample_account_id: AccountId):
+    """Test initialization with only account_id (token_id None)."""
+    assoc = TokenAssociation(account_id=sample_account_id)
+
+    assert assoc.token_id is None
+    assert assoc.account_id == sample_account_id
+
+
+def test_from_proto_both_fields(sample_token_id: TokenId, sample_account_id: AccountId):
+    """Test _from_proto with both token_id and account_id present in proto."""
+    proto = TokenAssociationProto()
+    proto.token_id.shardNum = sample_token_id.shard
+    proto.token_id.realmNum = sample_token_id.realm
+    proto.token_id.tokenNum = sample_token_id.num
+    proto.account_id.shardNum = sample_account_id.shard
+    proto.account_id.realmNum = sample_account_id.realm
+    proto.account_id.accountNum = sample_account_id.num
+
+    assoc = TokenAssociation._from_proto(proto)
+
+    assert assoc.token_id == sample_token_id
+    assert assoc.account_id == sample_account_id
+
+
+def test_from_proto_token_only(sample_token_id: TokenId):
+    """Test _from_proto with only token_id present (account_id absent)."""
+    proto = TokenAssociationProto()
+    proto.token_id.shardNum = sample_token_id.shard
+    proto.token_id.realmNum = sample_token_id.realm
+    proto.token_id.tokenNum = sample_token_id.num
+
+    assoc = TokenAssociation._from_proto(proto)
+
+    assert assoc.token_id == sample_token_id
+    assert assoc.account_id is None
+
+
+def test_from_proto_account_only(sample_account_id: AccountId):
+    """Test _from_proto with only account_id present (token_id absent)."""
+    proto = TokenAssociationProto()
+    proto.account_id.shardNum = sample_account_id.shard
+    proto.account_id.realmNum = sample_account_id.realm
+    proto.account_id.accountNum = sample_account_id.num
+
+    assoc = TokenAssociation._from_proto(proto)
+
+    assert assoc.token_id is None
+    assert assoc.account_id == sample_account_id
+
+
+def test_from_proto_empty():
+    """Test _from_proto with completely empty protobuf message."""
+    proto = TokenAssociationProto()
+    assoc = TokenAssociation._from_proto(proto)
+
+    assert assoc.token_id is None
+    assert assoc.account_id is None
+
+
+def test_to_proto_both_fields(sample_token_id: TokenId, sample_account_id: AccountId):
+    """Test _to_proto serializes both fields correctly."""
+    assoc = TokenAssociation(
+        token_id=sample_token_id,
+        account_id=sample_account_id
+    )
+
+    proto = assoc._to_proto()
+
+    assert proto.HasField("token_id")
+    assert proto.token_id.shardNum == sample_token_id.shard
+    assert proto.token_id.realmNum == sample_token_id.realm
+    assert proto.token_id.tokenNum == sample_token_id.num
+
+    assert proto.HasField("account_id")
+    assert proto.account_id.shardNum == sample_account_id.shard
+    assert proto.account_id.realmNum == sample_account_id.realm
+    assert proto.account_id.accountNum == sample_account_id.num
+
+
+def test_to_proto_token_only(sample_token_id: TokenId):
+    """Test _to_proto with only token_id (account_id None)."""
+    assoc = TokenAssociation(token_id=sample_token_id)
+    proto = assoc._to_proto()
+
+    assert proto.HasField("token_id")
+    assert not proto.HasField("account_id")
+
+
+def test_to_proto_account_only(sample_account_id: AccountId):
+    """Test _to_proto with only account_id (token_id None)."""
+    assoc = TokenAssociation(account_id=sample_account_id)
+    proto = assoc._to_proto()
+
+    assert not proto.HasField("token_id")
+    assert proto.HasField("account_id")
+
+
+def test_to_proto_empty():
+    """Test _to_proto with empty/default instance."""
+    assoc = TokenAssociation()
+    proto = assoc._to_proto()
+
+    assert not proto.HasField("token_id")
+    assert not proto.HasField("account_id")
+
+
+def test_round_trip_both_fields(sample_token_id: TokenId, sample_account_id: AccountId):
+    """Test full round-trip conversion preserves both fields."""
+    original = TokenAssociation(
+        token_id=sample_token_id,
+        account_id=sample_account_id
+    )
+
+    proto = original._to_proto()
+    reconstructed = TokenAssociation._from_proto(proto)
+
+    assert reconstructed.token_id == original.token_id
+    assert reconstructed.account_id == original.account_id
+
+
+def test_round_trip_token_only(sample_token_id: TokenId):
+    """Test round-trip with only token_id."""
+    original = TokenAssociation(token_id=sample_token_id)
+    proto = original._to_proto()
+    reconstructed = TokenAssociation._from_proto(proto)
+
+    assert reconstructed.token_id == original.token_id
+    assert reconstructed.account_id is None
+
+
+def test_round_trip_account_only(sample_account_id: AccountId):
+    """Test round-trip with only account_id."""
+    original = TokenAssociation(account_id=sample_account_id)
+    proto = original._to_proto()
+    reconstructed = TokenAssociation._from_proto(proto)
+
+    assert reconstructed.token_id is None
+    assert reconstructed.account_id == original.account_id
+
+def test_round_trip_empty():
+    """Test round-trip with empty/default instance."""
+    original = TokenAssociation()
+    proto = original._to_proto()
+    reconstructed = TokenAssociation._from_proto(proto)
+
+    assert reconstructed.token_id is None
+    assert reconstructed.account_id is None
+
+def test_bytes_round_trip_both_fields(
+    sample_token_id: TokenId,
+    sample_account_id: AccountId,
+    ):
+    """Test round-trip via public to_bytes() / from_bytes() preserves both fields."""
+    original = TokenAssociation(
+        token_id=sample_token_id,
+        account_id=sample_account_id,
+    )
+
+    reconstructed = TokenAssociation.from_bytes(original.to_bytes())
+
+    assert reconstructed == original
+
+def test_bytes_round_trip_empty():
+    """Test round-trip via to_bytes()/from_bytes() with empty/default instance."""
+    original = TokenAssociation()
+    reconstructed = TokenAssociation.from_bytes(original.to_bytes())
+    assert reconstructed == original
+    assert reconstructed.token_id is None
+    assert reconstructed.account_id is None
+
+def test_str_representation(sample_token_id: TokenId, sample_account_id: AccountId):
+    """Test that __str__ contains expected field information."""
+    assoc = TokenAssociation(
+        token_id=sample_token_id,
+        account_id=sample_account_id
+    )
+    repr_s = str(assoc)
+    assert "TokenAssociation" in repr_s
+    assert str(sample_token_id) in repr_s
+    assert str(sample_account_id) in repr_s
+
+
+def test_str_with_none_fields():
+    """Test __str__ with one or both fields None."""
+    assoc_token_only = TokenAssociation(token_id=TokenId(shard=0, realm=0, num=5678))
+    s_token = str(assoc_token_only)
+    assert "token_id=0.0.5678" in s_token
+    assert "account_id=None" in s_token
+
+    assoc_account_only = TokenAssociation(account_id=AccountId(shard=0, realm=0, num=1234))
+    s_account = str(assoc_account_only)
+    assert "token_id=None" in s_account
+    assert "account_id=0.0.1234" in s_account
+
+    assoc_empty = TokenAssociation()
+    s_empty = str(assoc_empty)
+    assert "token_id=None" in s_empty
+    assert "account_id=None" in s_empty

--- a/tests/unit/transaction_record_test.py
+++ b/tests/unit/transaction_record_test.py
@@ -14,6 +14,11 @@ from hiero_sdk_python.hapi.services import (
 )
 from hiero_sdk_python.contract.contract_function_result import ContractFunctionResult
 from hiero_sdk_python.contract.contract_id import ContractId
+from hiero_sdk_python.schedule.schedule_id import ScheduleId
+from hiero_sdk_python.timestamp import Timestamp
+from hiero_sdk_python.tokens.assessed_custom_fee import AssessedCustomFee
+from hiero_sdk_python.tokens.token_association import TokenAssociation
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 pytestmark = pytest.mark.unit
 
@@ -27,7 +32,10 @@ def transaction_record(transaction_id):
         ),
         transaction_id=transaction_id
     )
-    
+
+    ts = Timestamp(seconds=1234567890, nanos=500000000)
+    sched = ScheduleId(0, 0, 9999)
+
     return TransactionRecord(
         transaction_id=transaction_id,
         transaction_hash=b'\x01\x02\x03\x04' * 12,
@@ -41,6 +49,31 @@ def transaction_record(transaction_id):
         prng_number=100,
         prng_bytes=None,
         children=[],
+        consensus_timestamp=ts,
+        schedule_ref=sched,
+        assessed_custom_fees=[
+            AssessedCustomFee(
+                amount=500000000,
+                fee_collector_account_id=AccountId(shard=0, realm=0, num=98)
+            )
+        ],
+        automatic_token_associations=[
+            TokenAssociation(
+                token_id=TokenId(shard=0, realm=0, num=5678),
+                account_id=AccountId(shard=0, realm=0, num=1234)
+            )
+        ],
+        parent_consensus_timestamp=ts,
+        alias=b'\x12\x34\x56\x78',
+        ethereum_hash=b'\xab' * 32,
+        paid_staking_rewards=[
+            (AccountId(shard=0, realm=0, num=456), 1000000)
+        ],
+        evm_address=b'\x12' * 20,
+        contract_create_result=ContractFunctionResult(
+            contract_id=ContractId(shard=0, realm=0, contract=789),
+            contract_call_result=b"Mock result"
+        ),
     )
 
 @pytest.fixture
@@ -89,6 +122,17 @@ def test_transaction_record_default_initialization():
     assert record.duplicates == []
     assert record.children == []
 
+    assert record.consensus_timestamp is None
+    assert record.schedule_ref is None
+    assert record.assessed_custom_fees == []
+    assert record.automatic_token_associations == []
+    assert record.parent_consensus_timestamp is None
+    assert record.alias is None
+    assert record.ethereum_hash is None
+    assert record.paid_staking_rewards == []
+    assert record.evm_address is None
+    assert record.contract_create_result is None
+
 def test_from_proto(proto_transaction_record, transaction_id):
     """Test the from_proto method of the TransactionRecord class"""
     record = TransactionRecord._from_proto(proto_transaction_record, transaction_id)
@@ -100,7 +144,18 @@ def test_from_proto(proto_transaction_record, transaction_id):
     assert isinstance(record.receipt, TransactionReceipt)
     assert record.receipt.status == ResponseCode.SUCCESS
     assert record.prng_number == 100
-    assert record.prng_bytes == b""
+    assert record.prng_bytes is None
+
+    assert record.consensus_timestamp is None
+    assert record.schedule_ref is None
+    assert record.assessed_custom_fees == []
+    assert record.automatic_token_associations == []
+    assert record.parent_consensus_timestamp is None
+    assert record.alias is None
+    assert record.ethereum_hash is None
+    assert record.paid_staking_rewards == []
+    assert record.evm_address is None
+    assert record.contract_create_result is None
 
 def test_from_proto_with_transfers(transaction_id):
     """Test from_proto with HBAR transfers"""
@@ -172,7 +227,7 @@ def test_from_proto_with_prng_number(transaction_id):
 
     record = TransactionRecord._from_proto(proto, transaction_id)
     assert record.prng_number == 42
-    assert record.prng_bytes == b""
+    assert record.prng_bytes is None
 
 
 def test_from_proto_with_prng_bytes(transaction_id):
@@ -182,8 +237,136 @@ def test_from_proto_with_prng_bytes(transaction_id):
 
     record = TransactionRecord._from_proto(proto, transaction_id)
     assert record.prng_bytes == b"123"
-    assert record.prng_number == 0
+    assert record.prng_number is None
 
+def test_from_proto_with_consensus_timestamp(transaction_id):
+    """Test parsing consensus_timestamp from proto."""
+    proto = transaction_record_pb2.TransactionRecord()
+    proto.consensusTimestamp.seconds = 1234567890
+    proto.consensusTimestamp.nanos = 500000000
+
+    record = TransactionRecord._from_proto(proto, transaction_id)
+    assert record.consensus_timestamp is not None
+    assert record.consensus_timestamp.seconds == 1234567890
+    assert record.consensus_timestamp.nanos == 500000000
+
+
+def test_from_proto_with_schedule_ref(transaction_id):
+    """Test parsing schedule_ref from proto."""
+    proto = transaction_record_pb2.TransactionRecord()
+    proto.scheduleRef.shardNum = 0
+    proto.scheduleRef.realmNum = 0
+    proto.scheduleRef.scheduleNum = 9999
+
+    record = TransactionRecord._from_proto(proto, transaction_id)
+    assert record.schedule_ref is not None
+    assert record.schedule_ref.shard == 0
+    assert record.schedule_ref.realm == 0
+    assert record.schedule_ref.schedule == 9999
+
+
+def test_from_proto_with_assessed_custom_fees(transaction_id):
+    """Test parsing assessed_custom_fees from proto."""
+    proto = transaction_record_pb2.TransactionRecord()
+    fee = proto.assessed_custom_fees.add()
+    fee.amount = 500000000
+    fee.fee_collector_account_id.shardNum = 0
+    fee.fee_collector_account_id.realmNum = 0
+    fee.fee_collector_account_id.accountNum = 98
+
+    record = TransactionRecord._from_proto(proto, transaction_id)
+    assert len(record.assessed_custom_fees) == 1
+    f = record.assessed_custom_fees[0]
+    assert isinstance(f, AssessedCustomFee)
+    assert f.amount == 500000000
+    assert f.fee_collector_account_id.num == 98
+
+
+def test_from_proto_with_automatic_token_associations(transaction_id):
+    """Test parsing automatic_token_associations from proto."""
+    proto = transaction_record_pb2.TransactionRecord()
+    assoc = proto.automatic_token_associations.add()
+    assoc.token_id.shardNum = 0
+    assoc.token_id.realmNum = 0
+    assoc.token_id.tokenNum = 5678
+    assoc.account_id.shardNum = 0
+    assoc.account_id.realmNum = 0
+    assoc.account_id.accountNum = 1234
+
+    record = TransactionRecord._from_proto(proto, transaction_id)
+    assert len(record.automatic_token_associations) == 1
+    a = record.automatic_token_associations[0]
+    assert isinstance(a, TokenAssociation)
+    assert a.token_id.num == 5678
+    assert a.account_id.num == 1234
+
+
+def test_from_proto_with_parent_consensus_timestamp(transaction_id):
+    """Test parsing parent_consensus_timestamp from proto."""
+    proto = transaction_record_pb2.TransactionRecord()
+    proto.parent_consensus_timestamp.seconds = 9876543210
+    proto.parent_consensus_timestamp.nanos = 0
+
+    record = TransactionRecord._from_proto(proto, transaction_id)
+    assert record.parent_consensus_timestamp is not None
+    assert record.parent_consensus_timestamp.seconds == 9876543210
+
+
+def test_from_proto_with_alias(transaction_id):
+    """Test parsing alias bytes from proto."""
+    proto = transaction_record_pb2.TransactionRecord()
+    proto.alias = b'\x12\x34\x56\x78'
+
+    record = TransactionRecord._from_proto(proto, transaction_id)
+    assert record.alias == b'\x12\x34\x56\x78'
+
+
+def test_from_proto_with_ethereum_hash(transaction_id):
+    """Test parsing ethereum_hash from proto."""
+    proto = transaction_record_pb2.TransactionRecord()
+    proto.ethereum_hash = b'\xab' * 32
+
+    record = TransactionRecord._from_proto(proto, transaction_id)
+    assert record.ethereum_hash == b'\xab' * 32
+
+
+def test_from_proto_with_paid_staking_rewards(transaction_id):
+    """Test parsing paid_staking_rewards from proto."""
+    proto = transaction_record_pb2.TransactionRecord()
+    reward = proto.paid_staking_rewards.add()
+    reward.accountID.shardNum = 0
+    reward.accountID.realmNum = 0
+    reward.accountID.accountNum = 456
+    reward.amount = 1000000
+
+    record = TransactionRecord._from_proto(proto, transaction_id)
+    assert len(record.paid_staking_rewards) == 1
+    account, amount = record.paid_staking_rewards[0]
+    assert account.num == 456
+    assert amount == 1000000
+
+
+def test_from_proto_with_evm_address(transaction_id):
+    """Test parsing evm_address from proto."""
+    proto = transaction_record_pb2.TransactionRecord()
+    proto.evm_address = b'\x12' * 20
+
+    record = TransactionRecord._from_proto(proto, transaction_id)
+    assert record.evm_address == b'\x12' * 20
+
+
+def test_from_proto_with_contract_create_result(transaction_id):
+    """Test parsing contract_create_result from proto."""
+    proto = transaction_record_pb2.TransactionRecord()
+    proto.contractCreateResult.contractID.shardNum = 0
+    proto.contractCreateResult.contractID.realmNum = 0
+    proto.contractCreateResult.contractID.contractNum = 789
+    proto.contractCreateResult.contractCallResult = b"Created!"
+
+    record = TransactionRecord._from_proto(proto, transaction_id)
+    assert record.contract_create_result is not None
+    assert record.contract_create_result.contract_id.contract == 789
+    assert record.contract_create_result.contract_call_result == b"Created!"
 
 def test_to_proto(transaction_record, transaction_id):
     """Test the to_proto method of the TransactionRecord class"""
@@ -208,7 +391,7 @@ def test_proto_conversion(transaction_record):
     assert converted.transaction_fee == transaction_record.transaction_fee
     assert converted.receipt.status == transaction_record.receipt.status
     assert converted.prng_number == transaction_record.prng_number
-    assert converted.prng_bytes == b""
+    assert converted.prng_bytes is None
 
 def test_proto_conversion_with_transfers(transaction_id):
     """Test proto conversion preserves transfer data"""
@@ -304,7 +487,17 @@ def test_repr_method(transaction_id):
         "prng_number=None, "
         "prng_bytes=None, "
         "duplicates_count=0, "
-        "children_count=0)"
+        "children_count=0, "
+        "consensus_timestamp=None, "
+        "schedule_ref=None, "
+        "assessed_custom_fees=[], "
+        "automatic_token_associations=[], "
+        "parent_consensus_timestamp=None, "
+        "alias=None, "
+        "ethereum_hash=None, "
+        "paid_staking_rewards=[], "
+        "evm_address=None, "
+        "contract_create_result=None)"
     )
     assert repr(record_default) == expected_repr_default
     
@@ -336,40 +529,63 @@ def test_repr_method(transaction_id):
         f"prng_number=None, "
         f"prng_bytes=None, "
         f"duplicates_count=0, "
-        f"children_count=0)"
+        f"children_count=0, "
+        f"consensus_timestamp=None, "
+        f"schedule_ref=None, "
+        f"assessed_custom_fees=[], "
+        f"automatic_token_associations=[], "
+        f"parent_consensus_timestamp=None, "
+        f"alias=None, "
+        f"ethereum_hash=None, "
+        f"paid_staking_rewards=[], "
+        f"evm_address=None, "
+        f"contract_create_result=None)"
     )
     assert repr(record_with_receipt) == expected_repr_with_receipt
 
     # Test with all parameters set
+    ts = Timestamp(1234567890, 0)
+    sched = ScheduleId(0, 0, 9999)
     record_full = TransactionRecord(
         transaction_id=transaction_id,
         transaction_hash=b'\x01\x02\x03\x04',
         transaction_memo="Test memo",
         transaction_fee=100000,
         receipt=receipt,
+        consensus_timestamp=ts,
+        schedule_ref=sched,
+        assessed_custom_fees=[AssessedCustomFee(
+            amount=500000000,
+            fee_collector_account_id=AccountId(0, 0, 98)
+        )],
+        automatic_token_associations=[TokenAssociation(token_id=TokenId(0, 0, 5678), account_id=AccountId(0, 0, 1234))],
+        parent_consensus_timestamp=ts,
+        alias=b'\x12\x34',
+        ethereum_hash=b'\xab' * 32,
+        paid_staking_rewards=[(AccountId(0, 0, 456), 1000000)],
+        evm_address=b'\x12' * 20,
+        contract_create_result=ContractFunctionResult(contract_id=ContractId(0, 0, 789)),
     )
+    
     repr_full = repr(record_full)
-    assert "duplicates_count=0" in repr_full
     assert f"transaction_id='{transaction_id}'" in repr_full
     assert "transaction_hash=b'\\x01\\x02\\x03\\x04'" in repr_full
     assert "transaction_memo='Test memo'" in repr_full
     assert "transaction_fee=100000" in repr_full
     assert "receipt_status='SUCCESS'" in repr_full
-    expected_repr_full = (f"TransactionRecord(transaction_id='{transaction_id}', "
-                         f"transaction_hash=b'\\x01\\x02\\x03\\x04', "
-                         f"transaction_memo='Test memo', "
-                         f"transaction_fee=100000, "
-                         f"receipt_status='SUCCESS', "
-                         f"token_transfers={{}}, "
-                         f"nft_transfers={{}}, "
-                         f"transfers={{}}, "
-                         f"new_pending_airdrops={[]}, "
-                         f"call_result=None, "
-                         f"prng_number=None, "
-                         f"prng_bytes=None, "
-                         f"duplicates_count=0, "
-                         f"children_count=0)")
-    assert repr(record_full) == expected_repr_full
+    assert "consensus_timestamp=" in repr_full
+    assert f"schedule_ref={sched}" in repr_full
+    assert "assessed_custom_fees=" in repr_full
+    assert "automatic_token_associations=" in repr_full
+    assert "parent_consensus_timestamp=" in repr_full
+    assert "alias=b'\\x124'" in repr_full
+    assert "ethereum_hash=" in repr_full
+    assert "paid_staking_rewards=" in repr_full
+    assert "evm_address=" in repr_full
+    assert "contract_create_result=" in repr_full
+    assert "duplicates_count=0" in repr_full
+    assert "children_count=0" in repr_full
+
     # Test with transfers
     record_with_transfers = TransactionRecord(
         transaction_id=transaction_id, receipt=receipt
@@ -393,7 +609,17 @@ def test_repr_method(transaction_id):
                                   f"prng_number=None, "
                                   f"prng_bytes=None, "
                                   f"duplicates_count=0, "
-                                  f"children_count=0)")
+                                  f"children_count=0, "
+                                  f"consensus_timestamp=None, "
+                                  f"schedule_ref=None, "
+                                  f"assessed_custom_fees=[], "
+                                  f"automatic_token_associations=[], "
+                                  f"parent_consensus_timestamp=None, "
+                                  f"alias=None, "
+                                  f"ethereum_hash=None, "
+                                  f"paid_staking_rewards=[], "
+                                  f"evm_address=None, "
+                                  f"contract_create_result=None)")
     assert repr(record_with_transfers) == expected_repr_with_transfers
 
 def test_proto_conversion_with_call_result(transaction_id):
@@ -441,7 +667,6 @@ def test_from_proto_without_duplicates_param_backward_compat(transaction_id):
     proto = transaction_record_pb2.TransactionRecord()
     proto.memo = "Test"
 
-    # Call without duplicates parameter - should not raise
     record = TransactionRecord._from_proto(proto, transaction_id)
 
     assert record.duplicates == [], "Duplicates should default to empty list when omitted"
@@ -503,12 +728,11 @@ def test_repr_includes_duplicates_count(transaction_id):
     record.duplicates = [dup, dup]
 
     assert "duplicates_count=2" in repr(record), "duplicates_count should reflect list length"
-    
+
 def test_from_proto_raises_when_no_transaction_id_available():
     """Verify error is raised when neither transaction_id param nor proto.transactionID is present."""
     proto = transaction_record_pb2.TransactionRecord()
     
-    # Force-clear the field (works in protobuf 3 & 4)
     proto.ClearField("transactionID")
     
     assert not proto.HasField("transactionID"), "Field should be absent after ClearField"
@@ -526,3 +750,118 @@ def test_transaction_record_children_not_shared_between_instances():
 
     assert len(r1.children) == 1
     assert len(r2.children) == 0
+
+def test_round_trip_consensus_timestamp(transaction_id):
+    ts = Timestamp(1234567890, 500000000)
+    original = TransactionRecord(consensus_timestamp=ts)
+    proto = original._to_proto()
+    round_tripped = TransactionRecord._from_proto(proto, transaction_id)
+    assert round_tripped.consensus_timestamp == ts
+
+
+def test_round_trip_schedule_ref(transaction_id):
+    sched = ScheduleId(0, 0, 9999)
+    original = TransactionRecord(schedule_ref=sched)
+    proto = original._to_proto()
+    round_tripped = TransactionRecord._from_proto(proto, transaction_id)
+    assert round_tripped.schedule_ref == sched
+
+
+def test_round_trip_assessed_custom_fees(transaction_id):
+    fee = AssessedCustomFee(
+        amount=500000000,
+        fee_collector_account_id=AccountId(0, 0, 98)
+    )
+    original = TransactionRecord(assessed_custom_fees=[fee])
+    proto = original._to_proto()
+    round_tripped = TransactionRecord._from_proto(proto, transaction_id)
+    assert len(round_tripped.assessed_custom_fees) == 1
+    assert round_tripped.assessed_custom_fees[0].amount == 500000000
+
+
+def test_round_trip_automatic_token_associations(transaction_id):
+    assoc = TokenAssociation(
+        token_id=TokenId(0, 0, 5678),
+        account_id=AccountId(0, 0, 1234)
+    )
+    original = TransactionRecord(automatic_token_associations=[assoc])
+    proto = original._to_proto()
+    round_tripped = TransactionRecord._from_proto(proto, transaction_id)
+    assert len(round_tripped.automatic_token_associations) == 1
+    assert round_tripped.automatic_token_associations[0].token_id.num == 5678
+
+
+def test_round_trip_parent_consensus_timestamp(transaction_id):
+    ts = Timestamp(9876543210, 0)
+    original = TransactionRecord(parent_consensus_timestamp=ts)
+    proto = original._to_proto()
+    round_tripped = TransactionRecord._from_proto(proto, transaction_id)
+    assert round_tripped.parent_consensus_timestamp == ts
+
+
+def test_round_trip_alias(transaction_id):
+    original = TransactionRecord(alias=b'\x12\x34')
+    proto = original._to_proto()
+    round_tripped = TransactionRecord._from_proto(proto, transaction_id)
+    assert round_tripped.alias == b'\x12\x34'
+
+
+def test_round_trip_ethereum_hash(transaction_id):
+    original = TransactionRecord(ethereum_hash=b'\xab' * 32)
+    proto = original._to_proto()
+    round_tripped = TransactionRecord._from_proto(proto, transaction_id)
+    assert round_tripped.ethereum_hash == b'\xab' * 32
+
+
+def test_round_trip_paid_staking_rewards(transaction_id):
+    rewards = [(AccountId(0, 0, 456), 1000000)]
+    original = TransactionRecord(paid_staking_rewards=rewards)
+    proto = original._to_proto()
+    round_tripped = TransactionRecord._from_proto(proto, transaction_id)
+    assert round_tripped.paid_staking_rewards == rewards
+
+
+def test_round_trip_evm_address(transaction_id):
+    original = TransactionRecord(evm_address=b'\x12' * 20)
+    proto = original._to_proto()
+    round_tripped = TransactionRecord._from_proto(proto, transaction_id)
+    assert round_tripped.evm_address == b'\x12' * 20
+
+
+def test_round_trip_contract_create_result(transaction_id):
+    result = ContractFunctionResult(
+        contract_id=ContractId(0, 0, 789),
+        contract_call_result=b"Created!"
+    )
+    original = TransactionRecord(contract_create_result=result)
+    proto = original._to_proto()
+    round_tripped = TransactionRecord._from_proto(proto, transaction_id)
+    assert round_tripped.contract_create_result.contract_id == result.contract_id
+    assert round_tripped.contract_create_result.contract_call_result == b"Created!"
+
+def test_to_proto_raises_when_both_call_and_create_result_set(transaction_id):
+    """Setting both call_result and contract_create_result must raise (protobuf oneof)."""
+    record = TransactionRecord(
+        transaction_id=transaction_id,
+        call_result=ContractFunctionResult(
+            contract_id=ContractId(0, 0, 100),
+        ),
+        contract_create_result=ContractFunctionResult(
+            contract_id=ContractId(0, 0, 200),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        record._to_proto()
+
+def test_to_proto_raises_when_both_prng_fields_set(transaction_id):
+    """Setting both prng_number and prng_bytes must raise (entropy oneof)."""
+    record = TransactionRecord(
+        transaction_id=transaction_id,
+        prng_number=1,
+        prng_bytes=b"\x01",
+    )
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        record._to_proto()
+        

--- a/tests/unit/transaction_record_test.py
+++ b/tests/unit/transaction_record_test.py
@@ -1,24 +1,28 @@
-from hiero_sdk_python.tokens.token_airdrop_pending_id import PendingAirdropId
-from hiero_sdk_python.tokens.token_airdrop_pending_record import PendingAirdropRecord
-import pytest
+"""Unit tests for the TransactionRecord class functionality."""
+
 from collections import defaultdict
+
+import pytest
+
 from hiero_sdk_python.account.account_id import AccountId
-from hiero_sdk_python.tokens.token_id import TokenId
-from hiero_sdk_python.tokens.token_nft_transfer import TokenNftTransfer
-from hiero_sdk_python.transaction.transaction_record import TransactionRecord
-from hiero_sdk_python.transaction.transaction_receipt import TransactionReceipt
-from hiero_sdk_python.response_code import ResponseCode
-from hiero_sdk_python.hapi.services import (
-    transaction_record_pb2,
-    transaction_receipt_pb2,
-)
 from hiero_sdk_python.contract.contract_function_result import ContractFunctionResult
 from hiero_sdk_python.contract.contract_id import ContractId
+from hiero_sdk_python.hapi.services import (
+    transaction_receipt_pb2,
+    transaction_record_pb2,
+)
+from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.schedule.schedule_id import ScheduleId
 from hiero_sdk_python.timestamp import Timestamp
 from hiero_sdk_python.tokens.assessed_custom_fee import AssessedCustomFee
+from hiero_sdk_python.tokens.token_airdrop_pending_id import PendingAirdropId
+from hiero_sdk_python.tokens.token_airdrop_pending_record import PendingAirdropRecord
 from hiero_sdk_python.tokens.token_association import TokenAssociation
-from hiero_sdk_python.transaction.transaction_id import TransactionId
+from hiero_sdk_python.tokens.token_id import TokenId
+from hiero_sdk_python.tokens.token_nft_transfer import TokenNftTransfer
+from hiero_sdk_python.transaction.transaction_id import TransactionId  # noqa: F401
+from hiero_sdk_python.transaction.transaction_receipt import TransactionReceipt
+from hiero_sdk_python.transaction.transaction_record import TransactionRecord
 
 pytestmark = pytest.mark.unit
 
@@ -79,7 +83,7 @@ def transaction_record(transaction_id):
 @pytest.fixture
 def proto_transaction_record(transaction_id):
     """Create a mock transaction record protobuf."""
-    proto = transaction_record_pb2.TransactionRecord(
+    return transaction_record_pb2.TransactionRecord(
         transactionHash=b'\x01\x02\x03\x04' * 12,
         memo="Test transaction memo",
         transactionFee=100000,
@@ -87,10 +91,9 @@ def proto_transaction_record(transaction_id):
         transactionID=transaction_id._to_proto(),
         prng_number=100,
     )
-    return proto
 
 def test_transaction_record_initialization(transaction_record, transaction_id):
-    """Test the initialization of the TransactionRecord class"""
+    """Test the initialization of the TransactionRecord class."""
     assert transaction_record.transaction_id == transaction_id
     assert transaction_record.transaction_hash == b'\x01\x02\x03\x04' * 12
     assert transaction_record.transaction_memo == "Test transaction memo"
@@ -103,7 +106,7 @@ def test_transaction_record_initialization(transaction_record, transaction_id):
 
 
 def test_transaction_record_default_initialization():
-    """Test the default initialization of the TransactionRecord class"""
+    """Test the default initialization of the TransactionRecord class."""
     record = TransactionRecord()
     assert record.transaction_id is None
     assert record.transaction_hash is None
@@ -134,7 +137,7 @@ def test_transaction_record_default_initialization():
     assert record.contract_create_result is None
 
 def test_from_proto(proto_transaction_record, transaction_id):
-    """Test the from_proto method of the TransactionRecord class"""
+    """Test the from_proto method of the TransactionRecord class."""
     record = TransactionRecord._from_proto(proto_transaction_record, transaction_id)
 
     assert record.transaction_id == transaction_id
@@ -158,7 +161,7 @@ def test_from_proto(proto_transaction_record, transaction_id):
     assert record.contract_create_result is None
 
 def test_from_proto_with_transfers(transaction_id):
-    """Test from_proto with HBAR transfers"""
+    """Test from_proto with HBAR transfers."""
     proto = transaction_record_pb2.TransactionRecord()
     transfer = proto.transferList.accountAmounts.add()
     transfer.accountID.CopyFrom(AccountId(0, 0, 200)._to_proto())
@@ -168,7 +171,7 @@ def test_from_proto_with_transfers(transaction_id):
     assert record.transfers[AccountId(0, 0, 200)] == 1000
 
 def test_from_proto_with_token_transfers(transaction_id):
-    """Test from_proto with token transfers"""
+    """Test from_proto with token transfers."""
     proto = transaction_record_pb2.TransactionRecord()
     token_list = proto.tokenTransferLists.add()
     token_list.token.CopyFrom(TokenId(0, 0, 300)._to_proto())
@@ -181,7 +184,7 @@ def test_from_proto_with_token_transfers(transaction_id):
     assert record.token_transfers[TokenId(0, 0, 300)][AccountId(0, 0, 200)] == 500
 
 def test_from_proto_with_nft_transfers(transaction_id):
-    """Test from_proto with NFT transfers"""
+    """Test from_proto with NFT transfers."""
     proto = transaction_record_pb2.TransactionRecord()
     token_list = proto.tokenTransferLists.add()
     token_list.token.CopyFrom(TokenId(0, 0, 300)._to_proto())
@@ -198,10 +201,10 @@ def test_from_proto_with_nft_transfers(transaction_id):
     assert transfer.sender_id == AccountId(0, 0, 100)
     assert transfer.receiver_id == AccountId(0, 0, 200)
     assert transfer.serial_number == 1
-    assert transfer.is_approved == False
+    assert transfer.is_approved is False
 
 def test_from_proto_with_new_pending_airdrops(transaction_id):
-    """Test from_proto with Pending Airdrops"""
+    """Test from_proto with Pending Airdrops."""
     sender = AccountId(0,0,100)
     receiver = AccountId(0,0,200)
     token_id = TokenId(0,0,1)
@@ -221,7 +224,7 @@ def test_from_proto_with_new_pending_airdrops(transaction_id):
 
 
 def test_from_proto_with_prng_number(transaction_id):
-    """Test from_proto with prng_number set"""
+    """Test from_proto with prng_number set."""
     proto = transaction_record_pb2.TransactionRecord()
     proto.prng_number = 42
 
@@ -231,7 +234,7 @@ def test_from_proto_with_prng_number(transaction_id):
 
 
 def test_from_proto_with_prng_bytes(transaction_id):
-    """Test from_proto with prng_bytes set"""
+    """Test from_proto with prng_bytes set."""
     proto = transaction_record_pb2.TransactionRecord()
     proto.prng_bytes = b"123"
 
@@ -369,7 +372,7 @@ def test_from_proto_with_contract_create_result(transaction_id):
     assert record.contract_create_result.contract_call_result == b"Created!"
 
 def test_to_proto(transaction_record, transaction_id):
-    """Test the to_proto method of the TransactionRecord class"""
+    """Test the to_proto method of the TransactionRecord class."""
     proto = transaction_record._to_proto()
 
     assert proto.transactionHash == b'\x01\x02\x03\x04' * 12
@@ -381,7 +384,7 @@ def test_to_proto(transaction_record, transaction_id):
     assert proto.prng_bytes == b""
 
 def test_proto_conversion(transaction_record):
-    """Test converting TransactionRecord to proto and back preserves data"""
+    """Test converting TransactionRecord to proto and back preserves data."""
     proto = transaction_record._to_proto()
     converted = TransactionRecord._from_proto(proto, transaction_record.transaction_id)
 
@@ -394,7 +397,7 @@ def test_proto_conversion(transaction_record):
     assert converted.prng_bytes is None
 
 def test_proto_conversion_with_transfers(transaction_id):
-    """Test proto conversion preserves transfer data"""
+    """Test proto conversion preserves transfer data."""
     record = TransactionRecord()
     record.transfers = defaultdict(int)
     record.transfers[AccountId(0, 0, 100)] = -1000
@@ -407,7 +410,7 @@ def test_proto_conversion_with_transfers(transaction_id):
     assert converted.transfers[AccountId(0, 0, 200)] == 1000
 
 def test_proto_conversion_with_token_transfers(transaction_id):
-    """Test proto conversion preserves token transfer data"""
+    """Test proto conversion preserves token transfer data."""
     record = TransactionRecord()
     token_id = TokenId(0, 0, 300)
     record.token_transfers = defaultdict(lambda: defaultdict(int))
@@ -421,7 +424,7 @@ def test_proto_conversion_with_token_transfers(transaction_id):
     assert converted.token_transfers[token_id][AccountId(0, 0, 200)] == 500
 
 def test_proto_conversion_with_nft_transfers(transaction_id):
-    """Test proto conversion preserves NFT transfer data"""
+    """Test proto conversion preserves NFT transfer data."""
     record = TransactionRecord()
     token_id = TokenId(0, 0, 300)
     nft_transfer = TokenNftTransfer(
@@ -442,10 +445,10 @@ def test_proto_conversion_with_nft_transfers(transaction_id):
     assert transfer.sender_id == AccountId(0, 0, 100)
     assert transfer.receiver_id == AccountId(0, 0, 200)
     assert transfer.serial_number == 1
-    assert transfer.is_approved == False
+    assert not transfer.is_approved
 
 def test_proto_conversion_with_new_pending_airdrops(transaction_id):
-    """Test proto conversion preserves PendingAirdropsRecord"""
+    """Test proto conversion preserves PendingAirdropsRecord."""
     sender = AccountId(0,0,100)
     receiver = AccountId(0,0,200)
     token_id = TokenId(0,0,1)
@@ -742,7 +745,7 @@ def test_from_proto_raises_when_no_transaction_id_available():
 
 
 def test_transaction_record_children_not_shared_between_instances():
-    """children not shared between two different instances"""
+    """Children not shared between two different instances."""
     r1 = TransactionRecord()
     r2 = TransactionRecord()
 
@@ -752,6 +755,7 @@ def test_transaction_record_children_not_shared_between_instances():
     assert len(r2.children) == 0
 
 def test_round_trip_consensus_timestamp(transaction_id):
+    """Test consensus timestamp survives protobuf round-trip."""
     ts = Timestamp(1234567890, 500000000)
     original = TransactionRecord(consensus_timestamp=ts)
     proto = original._to_proto()
@@ -760,6 +764,7 @@ def test_round_trip_consensus_timestamp(transaction_id):
 
 
 def test_round_trip_schedule_ref(transaction_id):
+    """Test schedule reference survives protobuf round-trip."""
     sched = ScheduleId(0, 0, 9999)
     original = TransactionRecord(schedule_ref=sched)
     proto = original._to_proto()
@@ -768,6 +773,7 @@ def test_round_trip_schedule_ref(transaction_id):
 
 
 def test_round_trip_assessed_custom_fees(transaction_id):
+    """Test custom fees survive protobuf round-trip."""
     fee = AssessedCustomFee(
         amount=500000000,
         fee_collector_account_id=AccountId(0, 0, 98)
@@ -780,6 +786,7 @@ def test_round_trip_assessed_custom_fees(transaction_id):
 
 
 def test_round_trip_automatic_token_associations(transaction_id):
+    """Test token associations survive protobuf round-trip."""
     assoc = TokenAssociation(
         token_id=TokenId(0, 0, 5678),
         account_id=AccountId(0, 0, 1234)
@@ -792,6 +799,7 @@ def test_round_trip_automatic_token_associations(transaction_id):
 
 
 def test_round_trip_parent_consensus_timestamp(transaction_id):
+    """Test parent timestamp survives protobuf round-trip."""
     ts = Timestamp(9876543210, 0)
     original = TransactionRecord(parent_consensus_timestamp=ts)
     proto = original._to_proto()
@@ -800,6 +808,7 @@ def test_round_trip_parent_consensus_timestamp(transaction_id):
 
 
 def test_round_trip_alias(transaction_id):
+    """Test alias bytes survive protobuf round-trip."""
     original = TransactionRecord(alias=b'\x12\x34')
     proto = original._to_proto()
     round_tripped = TransactionRecord._from_proto(proto, transaction_id)
@@ -807,6 +816,7 @@ def test_round_trip_alias(transaction_id):
 
 
 def test_round_trip_ethereum_hash(transaction_id):
+    """Test ethereum hash survives protobuf round-trip."""
     original = TransactionRecord(ethereum_hash=b'\xab' * 32)
     proto = original._to_proto()
     round_tripped = TransactionRecord._from_proto(proto, transaction_id)
@@ -814,6 +824,7 @@ def test_round_trip_ethereum_hash(transaction_id):
 
 
 def test_round_trip_paid_staking_rewards(transaction_id):
+    """Test staking rewards survive protobuf round-trip."""
     rewards = [(AccountId(0, 0, 456), 1000000)]
     original = TransactionRecord(paid_staking_rewards=rewards)
     proto = original._to_proto()
@@ -822,6 +833,7 @@ def test_round_trip_paid_staking_rewards(transaction_id):
 
 
 def test_round_trip_evm_address(transaction_id):
+    """Test EVM address survives protobuf round-trip."""
     original = TransactionRecord(evm_address=b'\x12' * 20)
     proto = original._to_proto()
     round_tripped = TransactionRecord._from_proto(proto, transaction_id)
@@ -829,6 +841,7 @@ def test_round_trip_evm_address(transaction_id):
 
 
 def test_round_trip_contract_create_result(transaction_id):
+    """Test contract creation result survives round-trip."""
     result = ContractFunctionResult(
         contract_id=ContractId(0, 0, 789),
         contract_call_result=b"Created!"


### PR DESCRIPTION
**Description**:
Expose all previously dropped fields from the TransactionRecord protobuf message in the Python SDK.

**Related issue(s)**:

Fixes #1636

**Notes for reviewer**:
Restoration of dropped protobuf fields.

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
