### PR TITLE
chore: add Chocolatey to Windows setup prerequisites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Added TCK endpoint for the createAccount method
 
 ### Docs
+- Add Chocolatey as a prerequisite in the Windows setup guide (#1961)
 
 
 ### .github

--- a/docs/sdk_developers/setup_windows.md
+++ b/docs/sdk_developers/setup_windows.md
@@ -25,6 +25,7 @@ Before you begin, ensure you have the following installed on your system:
 1.  **Git for Windows**: [Download and install Git](https://gitforwindows.org/).
 2.  **Python 3.10+**: [Download and install Python](https://www.python.org/downloads/windows/). Ensure "Add Python to PATH" is checked during installation.
 3.  **GitHub Account**: You will need a GitHub account to fork the repository.
+4.  **Chocolatey**: For Windows 10 users, you must install Chocolatey. [Install Chocolatey](https://chocolatey.org/install). Make sure Chocolatey is added to PATH.
 
 ---
 


### PR DESCRIPTION
**Description**:
<!--
Added Chocolatey as a 4th prerequisite in docs/sdk_developers/setup_windows.md for Windows 10 users.


-->

**Related issue(s)**:  Fixes #1961


