### PR TITLE
chore: update remaining bot workflows to self-hosted runners

### DIFF
--- a/.github/workflows/bot-advanced-check.yml
+++ b/.github/workflows/bot-advanced-check.yml
@@ -25,7 +25,7 @@ jobs:
   #######################################
   check-advanced-qualification:
     # steps are skipped, job completes successfully
-    runs-on: ubuntu-latest
+    runs-on: hl-sdk-py-lin-md
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0

--- a/.github/workflows/bot-gfi-assign-on-comment.yml
+++ b/.github/workflows/bot-gfi-assign-on-comment.yml
@@ -14,7 +14,7 @@ jobs:
         # Only run on issue comments (not PR comments)
         if: github.event.issue.pull_request == null
 
-        runs-on: ubuntu-latest
+        runs-on: hl-sdk-py-lin-md
 
         # Prevent assignment-limit races across different issues by processing
         # one GFI assignment workflow at a time for this repository.

--- a/.github/workflows/bot-intermediate-assignment.yml
+++ b/.github/workflows/bot-intermediate-assignment.yml
@@ -23,7 +23,7 @@ jobs:
       group: intermediate-guard-${{ github.event.issue.number || github.run_id }}
       cancel-in-progress: false
     if: contains(github.event.issue.labels.*.name, 'intermediate')
-    runs-on: ubuntu-latest
+    runs-on: hl-sdk-py-lin-md
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0

--- a/.github/workflows/bot-linked-issue-enforcer.yml
+++ b/.github/workflows/bot-linked-issue-enforcer.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   pr-linked-issue-checker:
-    runs-on: ubuntu-latest
+    runs-on: hl-sdk-py-lin-md
     env:
       DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
 

--- a/.github/workflows/unassign-on-comment.yml
+++ b/.github/workflows/unassign-on-comment.yml
@@ -14,7 +14,7 @@ jobs:
     # Only run on issue comments (not PR comments)
     if: github.event.issue.pull_request == null
 
-    runs-on: ubuntu-latest
+    runs-on: hl-sdk-py-lin-md
 
     concurrency:
       group: unassign-${{ github.event.issue.number }}

--- a/.github/workflows/working-on-comment.yml
+++ b/.github/workflows/working-on-comment.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   working-command:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/working'))
-    runs-on: ubuntu-latest
+    runs-on: hl-sdk-py-lin-md
     permissions:
       issues: write
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Refactored intermediate issue template with quality standards, testing requirements, breaking change awareness, and protobuf verification guidance to reduce review burden and improve PR quality (#1892)
 - fix: prevent CodeRabbit from posting comments on closed issues(#1962)
 - chore: update spam list #1988
+- chore: Update `bot-advanced-check.yml`, `bot-gfi-assign-on-comment.yml`, `bot-intermediate-assignment.yml`, `bot-linked-issue-enforcer.yml`, `unassign-on-comment.yml`, `working-on-comment.yml` workflow runner configuration
 
 
 


### PR DESCRIPTION
**Description**:
<!--
Switches bots still running on ubuntu-latest to use self hosted runner
-->

**Related issue(s)**:

Fixes #1984 

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)

cc @exploreriii 