### PR TITLE
Add discussion label check and test to bot inactivity script

### DIFF
--- a/.github/scripts/bot-inactivity-unassign.sh
+++ b/.github/scripts/bot-inactivity-unassign.sh
@@ -212,6 +212,13 @@ EOF
         continue
       fi
 
+      PR_LABELS=$(gh pr view "$PR_NUM" --repo "$REPO" --json labels --jq '.labels[].name' 2>/dev/null || true)
+
+      if echo "$PR_LABELS" | grep -qi '^discussion$'; then
+        echo "    [SKIP] PR #$PR_NUM has 'discussion' label — skipping close & unassign"
+        continue
+      fi
+
 
 
       COMMITS_JSON=$(gh api "repos/$REPO/pulls/$PR_NUM/commits" --paginate 2>/dev/null || echo "[]")

--- a/.github/scripts/test-bot-inactivity-unassign.sh
+++ b/.github/scripts/test-bot-inactivity-unassign.sh
@@ -1,0 +1,478 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Test suite for bot-inactivity-unassign.sh
+# Tests the discussion label functionality and other key behaviors
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_REPO="test-org/test-repo"
+TEMP_DIR=""
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Test counters
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Setup test environment
+setup() {
+  TEMP_DIR=$(mktemp -d)
+  export PATH="$TEMP_DIR/mocks:$PATH"
+  mkdir -p "$TEMP_DIR/mocks"
+  
+  # Create mock gh command directory
+  export GH_MOCK_DIR="$TEMP_DIR/gh_mock_data"
+  mkdir -p "$GH_MOCK_DIR"
+  
+  echo "Test environment created at: $TEMP_DIR"
+}
+
+# Cleanup test environment
+cleanup() {
+  if [[ -n "$TEMP_DIR" && -d "$TEMP_DIR" ]]; then
+    rm -rf "$TEMP_DIR"
+    echo "Test environment cleaned up"
+  fi
+}
+
+# Print test result
+print_result() {
+  local test_name="$1"
+  local result="$2"
+  local message="${3:-}"
+  
+  TESTS_RUN=$((TESTS_RUN + 1))
+  
+  if [[ "$result" == "PASS" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓ PASS${NC}: $test_name"
+  else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗ FAIL${NC}: $test_name"
+    if [[ -n "$message" ]]; then
+      echo -e "  ${YELLOW}→${NC} $message"
+    fi
+  fi
+}
+
+# Create mock gh command
+create_gh_mock() {
+  cat > "$TEMP_DIR/mocks/gh" << 'MOCK_END'
+#!/usr/bin/env bash
+# Mock gh CLI for testing
+
+GH_MOCK_DIR="${GH_MOCK_DIR:-/tmp/gh_mock_data}"
+
+# Parse command
+if [[ "$1" == "api" ]]; then
+  # Handle API calls
+  endpoint=""
+  for arg in "$@"; do
+    if [[ "$arg" =~ ^repos/ ]] || [[ "$arg" =~ ^issues/ ]]; then
+      endpoint="$arg"
+      break
+    fi
+  done
+  
+  # Return mock data based on endpoint
+  if [[ -f "$GH_MOCK_DIR/${endpoint//\//_}.json" ]]; then
+    cat "$GH_MOCK_DIR/${endpoint//\//_}.json"
+  else
+    echo "[]"
+  fi
+  
+elif [[ "$1" == "pr" && "$2" == "view" ]]; then
+  # Handle pr view command
+  pr_num="$3"
+  
+  # Check if asking for state
+  if [[ "$*" == *"--json state"* ]]; then
+    if [[ -f "$GH_MOCK_DIR/pr_${pr_num}_state.json" ]]; then
+      cat "$GH_MOCK_DIR/pr_${pr_num}_state.json"
+    else
+      echo '{"state":"OPEN"}'
+    fi
+  # Check if asking for labels
+  elif [[ "$*" == *"--json labels"* ]]; then
+    # Check if jq filter is also requested
+    if [[ "$*" == *"--jq"* ]]; then
+      # Extract the jq filter and apply it
+      if [[ -f "$GH_MOCK_DIR/pr_${pr_num}_labels.json" ]]; then
+        cat "$GH_MOCK_DIR/pr_${pr_num}_labels.json" | jq -r '.labels[].name | select(. == "discussion")' 2>/dev/null || echo ""
+      else
+        echo ""
+      fi
+    else
+      # Just return the JSON
+      if [[ -f "$GH_MOCK_DIR/pr_${pr_num}_labels.json" ]]; then
+        cat "$GH_MOCK_DIR/pr_${pr_num}_labels.json"
+      else
+        echo '{"labels":[]}'
+      fi
+    fi
+  fi
+  
+elif [[ "$1" == "pr" && "$2" == "comment" ]]; then
+  # Mock PR comment - just succeed
+  echo "Comment added to PR"
+  
+elif [[ "$1" == "pr" && "$2" == "close" ]]; then
+  # Mock PR close - record that it was called
+  pr_num="$3"
+  echo "CLOSED_PR_$pr_num" >> "$GH_MOCK_DIR/actions.log"
+  echo "PR closed"
+  
+elif [[ "$1" == "issue" && "$2" == "comment" ]]; then
+  # Mock issue comment
+  echo "Comment added to issue"
+  
+elif [[ "$1" == "issue" && "$2" == "edit" ]]; then
+  # Mock issue edit - record unassignment
+  if [[ "$*" == *"--remove-assignee"* ]]; then
+    for i in "${!@}"; do
+      if [[ "${!i}" == "--remove-assignee" ]]; then
+        next=$((i + 1))
+        user="${!next}"
+        issue_num=""
+        for arg in "$@"; do
+          if [[ "$arg" =~ ^[0-9]+$ ]]; then
+            issue_num="$arg"
+            break
+          fi
+        done
+        echo "UNASSIGNED_${user}_FROM_${issue_num}" >> "$GH_MOCK_DIR/actions.log"
+        break
+      fi
+    done
+  fi
+  echo "Issue edited"
+  
+elif [[ "$1" == "auth" && "$2" == "status" ]]; then
+  # Mock auth check - always succeed
+  exit 0
+fi
+MOCK_END
+  
+  chmod +x "$TEMP_DIR/mocks/gh"
+  
+  # Also create mock for jq (in case it's needed)
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "WARNING: jq not found, some tests may fail"
+  fi
+}
+
+# Create mock date command for consistent testing
+create_date_mock() {
+  # We'll use real date but could mock if needed for time-based tests
+  return 0
+}
+
+# Setup mock data for a PR with discussion label
+setup_pr_with_discussion_label() {
+  local pr_num="$1"
+  
+  # PR is open
+  echo '{"state":"OPEN"}' > "$GH_MOCK_DIR/pr_${pr_num}_state.json"
+  
+  # PR has discussion label
+  cat > "$GH_MOCK_DIR/pr_${pr_num}_labels.json" << 'EOF'
+{"labels":[{"name":"discussion"},{"name":"enhancement"}]}
+EOF
+  
+  # Mock stale commits (21+ days old)
+  local old_date=$(date -u -v-25d +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d "25 days ago" +"%Y-%m-%dT%H:%M:%SZ")
+  cat > "$GH_MOCK_DIR/repos_${TEST_REPO//\//_}_pulls_${pr_num}_commits.json" << EOF
+[{"commit":{"committer":{"date":"$old_date"}}}]
+EOF
+}
+
+# Setup mock data for a stale PR without discussion label
+setup_stale_pr_without_discussion() {
+  local pr_num="$1"
+  
+  # PR is open
+  echo '{"state":"OPEN"}' > "$GH_MOCK_DIR/pr_${pr_num}_state.json"
+  
+  # PR has no discussion label
+  echo '{"labels":[{"name":"bug"}]}' > "$GH_MOCK_DIR/pr_${pr_num}_labels.json"
+  
+  # Mock stale commits
+  local old_date=$(date -u -v-25d +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d "25 days ago" +"%Y-%m-%dT%H:%M:%SZ")
+  cat > "$GH_MOCK_DIR/repos_${TEST_REPO//\//_}_pulls_${pr_num}_commits.json" << EOF
+[{"commit":{"committer":{"date":"$old_date"}}}]
+EOF
+}
+
+# Setup mock data for an active PR
+setup_active_pr() {
+  local pr_num="$1"
+  
+  # PR is open
+  echo '{"state":"OPEN"}' > "$GH_MOCK_DIR/pr_${pr_num}_state.json"
+  
+  # PR has no discussion label
+  echo '{"labels":[{"name":"feature"}]}' > "$GH_MOCK_DIR/pr_${pr_num}_labels.json"
+  
+  # Mock recent commits
+  local recent_date=$(date -u -v-5d +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d "5 days ago" +"%Y-%m-%dT%H:%M:%SZ")
+  cat > "$GH_MOCK_DIR/repos_${TEST_REPO//\//_}_pulls_${pr_num}_commits.json" << EOF
+[{"commit":{"committer":{"date":"$recent_date"}}}]
+EOF
+}
+
+# Setup mock data for a closed PR
+setup_closed_pr() {
+  local pr_num="$1"
+  
+  # PR is closed
+  echo '{"state":"CLOSED"}' > "$GH_MOCK_DIR/pr_${pr_num}_state.json"
+  
+  # Labels don't matter for closed PR
+  echo '{"labels":[]}' > "$GH_MOCK_DIR/pr_${pr_num}_labels.json"
+}
+
+# Test 1: PR with discussion label should NOT be closed
+test_pr_with_discussion_label_not_closed() {
+  echo ""
+  echo "Test 1: PR with 'discussion' label should not be closed"
+  echo "=========================================================="
+  
+  setup_pr_with_discussion_label "100"
+  
+  # Create a minimal test scenario
+  # We'll test the relevant part of the script logic
+  
+  # Simulate the check
+  local pr_num="100"
+  local HAS_DISCUSSION_LABEL
+  HAS_DISCUSSION_LABEL=$(gh pr view "$pr_num" --repo "$TEST_REPO" --json labels --jq '.labels[].name | select(. == "discussion")' 2>/dev/null || echo "")
+  
+  if [[ -n "$HAS_DISCUSSION_LABEL" ]]; then
+    # Should skip closing
+    print_result "PR with discussion label detected" "PASS"
+    
+    # Verify PR was not closed
+    if [[ ! -f "$GH_MOCK_DIR/actions.log" ]] || ! grep -q "CLOSED_PR_$pr_num" "$GH_MOCK_DIR/actions.log" 2>/dev/null; then
+      print_result "PR with discussion label was NOT closed" "PASS"
+    else
+      print_result "PR with discussion label was NOT closed" "FAIL" "PR was incorrectly closed"
+    fi
+  else
+    print_result "PR with discussion label detected" "FAIL" "Discussion label not detected"
+  fi
+}
+
+# Test 2: Stale PR without discussion label should be closed
+test_stale_pr_without_discussion_closed() {
+  echo ""
+  echo "Test 2: Stale PR without 'discussion' label should be closed"
+  echo "=============================================================="
+  
+  setup_stale_pr_without_discussion "200"
+  
+  local pr_num="200"
+  local HAS_DISCUSSION_LABEL
+  HAS_DISCUSSION_LABEL=$(gh pr view "$pr_num" --repo "$TEST_REPO" --json labels --jq '.labels[].name | select(. == "discussion")' 2>/dev/null || echo "")
+  
+  if [[ -z "$HAS_DISCUSSION_LABEL" ]]; then
+    print_result "PR without discussion label detected" "PASS"
+  else
+    print_result "PR without discussion label detected" "FAIL" "Discussion label incorrectly detected"
+  fi
+}
+
+# Test 3: Verify label check uses correct jq filter
+test_jq_filter_correctness() {
+  echo ""
+  echo "Test 3: Verify jq filter correctly identifies 'discussion' label"
+  echo "=================================================================="
+  
+  # Test with discussion label present
+  setup_pr_with_discussion_label "300"
+  local result
+  result=$(gh pr view "300" --repo "$TEST_REPO" --json labels --jq '.labels[].name | select(. == "discussion")' 2>/dev/null || echo "")
+  
+  if [[ "$result" == "discussion" ]]; then
+    print_result "jq filter finds 'discussion' label" "PASS"
+  else
+    print_result "jq filter finds 'discussion' label" "FAIL" "Expected 'discussion', got '$result'"
+  fi
+  
+  # Test with no discussion label
+  setup_stale_pr_without_discussion "301"
+  result=$(gh pr view "301" --repo "$TEST_REPO" --json labels --jq '.labels[].name | select(. == "discussion")' 2>/dev/null || echo "")
+  
+  if [[ -z "$result" ]]; then
+    print_result "jq filter returns empty for missing 'discussion' label" "PASS"
+  else
+    print_result "jq filter returns empty for missing 'discussion' label" "FAIL" "Expected empty, got '$result'"
+  fi
+}
+
+# Test 4: Closed PRs should be skipped
+test_closed_pr_skipped() {
+  echo ""
+  echo "Test 4: Closed PRs should be skipped"
+  echo "======================================"
+  
+  setup_closed_pr "400"
+  
+  local pr_num="400"
+  local pr_state
+  pr_state=$(gh pr view "$pr_num" --repo "$TEST_REPO" --json state --jq '.state' 2>/dev/null || echo "")
+  
+  if [[ "$pr_state" != "OPEN" ]]; then
+    print_result "Closed PR correctly identified" "PASS"
+  else
+    print_result "Closed PR correctly identified" "FAIL" "PR state is '$pr_state'"
+  fi
+}
+
+# Test 5: Active PR should not be closed
+test_active_pr_not_closed() {
+  echo ""
+  echo "Test 5: Active PR (recent commits) should not be closed"
+  echo "========================================================="
+  
+  setup_active_pr "500"
+  
+  local pr_num="500"
+  local COMMITS_JSON
+  COMMITS_JSON=$(gh api "repos/$TEST_REPO/pulls/$pr_num/commits" 2>/dev/null || echo "[]")
+  
+  if echo "$COMMITS_JSON" | jq -e 'length > 0' >/dev/null 2>&1; then
+    print_result "Active PR has commit data" "PASS"
+    
+    # In real script, this would calculate age and skip if < 21 days
+    local last_commit_date
+    last_commit_date=$(echo "$COMMITS_JSON" | jq -r 'last | .commit.committer.date // empty')
+    if [[ -n "$last_commit_date" ]]; then
+      print_result "Active PR commit timestamp retrieved" "PASS"
+    else
+      print_result "Active PR commit timestamp retrieved" "FAIL" "No timestamp found"
+    fi
+  else
+    print_result "Active PR has commit data" "FAIL" "No commits found"
+  fi
+}
+
+# Test 6: Log output verification
+test_log_output() {
+  echo ""
+  echo "Test 6: Verify correct log messages are generated"
+  echo "==================================================="
+  
+  setup_pr_with_discussion_label "600"
+  
+  # Capture output
+  local output
+  local pr_num="600"
+  output=$(
+    HAS_DISCUSSION_LABEL=$(gh pr view "$pr_num" --repo "$TEST_REPO" --json labels --jq '.labels[].name | select(. == "discussion")' 2>/dev/null || echo "")
+    if [[ -n "$HAS_DISCUSSION_LABEL" ]]; then
+      echo "    [SKIP] PR #$pr_num has 'discussion' label, keeping open"
+    fi
+  )
+  
+  if echo "$output" | grep -q "\[SKIP\].*discussion.*keeping open"; then
+    print_result "Correct log message for discussion label" "PASS"
+  else
+    print_result "Correct log message for discussion label" "FAIL" "Expected log message not found"
+  fi
+}
+
+# Test 7: Multiple labels including discussion
+test_multiple_labels_with_discussion() {
+  echo ""
+  echo "Test 7: PR with multiple labels including 'discussion'"
+  echo "========================================================"
+  
+  # Create PR with multiple labels including discussion
+  echo '{"state":"OPEN"}' > "$GH_MOCK_DIR/pr_700_state.json"
+  cat > "$GH_MOCK_DIR/pr_700_labels.json" << 'EOF'
+{"labels":[{"name":"bug"},{"name":"discussion"},{"name":"priority-high"}]}
+EOF
+  
+  local pr_num="700"
+  local HAS_DISCUSSION_LABEL
+  HAS_DISCUSSION_LABEL=$(gh pr view "$pr_num" --repo "$TEST_REPO" --json labels --jq '.labels[].name | select(. == "discussion")' 2>/dev/null || echo "")
+  
+  if [[ "$HAS_DISCUSSION_LABEL" == "discussion" ]]; then
+    print_result "Discussion label found among multiple labels" "PASS"
+  else
+    print_result "Discussion label found among multiple labels" "FAIL" "Label not detected"
+  fi
+}
+
+# Test 8: Case sensitivity check
+test_case_sensitivity() {
+  echo ""
+  echo "Test 8: Label matching is case-sensitive"
+  echo "=========================================="
+  
+  # Create PR with "Discussion" (capital D)
+  echo '{"state":"OPEN"}' > "$GH_MOCK_DIR/pr_800_state.json"
+  echo '{"labels":[{"name":"Discussion"}]}' > "$GH_MOCK_DIR/pr_800_labels.json"
+  
+  local pr_num="800"
+  local HAS_DISCUSSION_LABEL
+  HAS_DISCUSSION_LABEL=$(gh pr view "$pr_num" --repo "$TEST_REPO" --json labels --jq '.labels[].name | select(. == "discussion")' 2>/dev/null || echo "")
+  
+  if [[ -z "$HAS_DISCUSSION_LABEL" ]]; then
+    print_result "Case-sensitive matching (Discussion != discussion)" "PASS"
+  else
+    print_result "Case-sensitive matching (Discussion != discussion)" "FAIL" "Should not match different case"
+  fi
+}
+
+# Main test runner
+main() {
+  echo "=============================================="
+  echo "  Bot Inactivity Unassign - Test Suite"
+  echo "=============================================="
+  echo ""
+  
+  # Setup
+  setup
+  trap cleanup EXIT
+  
+  # Create mocks
+  create_gh_mock
+  create_date_mock
+  
+  # Clear actions log
+  rm -f "$GH_MOCK_DIR/actions.log"
+  
+  # Run tests
+  test_pr_with_discussion_label_not_closed
+  test_stale_pr_without_discussion_closed
+  test_jq_filter_correctness
+  test_closed_pr_skipped
+  test_active_pr_not_closed
+  test_log_output
+  test_multiple_labels_with_discussion
+  test_case_sensitivity
+  
+  # Summary
+  echo ""
+  echo "=============================================="
+  echo "  Test Summary"
+  echo "=============================================="
+  echo "Total tests run:    $TESTS_RUN"
+  echo -e "${GREEN}Tests passed:       $TESTS_PASSED${NC}"
+  if [[ $TESTS_FAILED -gt 0 ]]; then
+    echo -e "${RED}Tests failed:       $TESTS_FAILED${NC}"
+    exit 1
+  else
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+  fi
+}
+
+# Run tests
+main "$@"

--- a/.github/scripts/test-bot-inactivity-unassign.sh
+++ b/.github/scripts/test-bot-inactivity-unassign.sh
@@ -60,6 +60,7 @@ print_result() {
 create_gh_mock() {
   cat > "$TEMP_DIR/mocks/gh" << 'MOCK_END'
 #!/usr/bin/env bash
+set -euo pipefail
 # Mock gh CLI for testing
 
 GH_MOCK_DIR="${GH_MOCK_DIR:-/tmp/gh_mock_data}"
@@ -383,20 +384,21 @@ test_pr_with_discussion_label_not_closed() {
   setup_pr_with_discussion_label "$pr_num"
 
   local output
-  output=$(REPO="$TEST_REPO" DAYS=21 DRY_RUN=0 bash "$BOT_SCRIPT" 2>&1 || true)
-
-  if [[ -n "$output" ]]; then
+  if output=$(REPO="$TEST_REPO" DAYS=21 DRY_RUN=0 bash "$BOT_SCRIPT" 2>&1); then
     print_result "script executed with mocked data" "PASS"
   else
-    print_result "script executed with mocked data" "FAIL" "Bot output was unexpectedly empty"
+    print_result "script executed with mocked data" "FAIL" "Bot exited non-zero: $output"
   fi
-
+  if grep -Eq "\\[SKIP\\].*discussion" <<<"$output"; then
+    print_result "discussion-label skip log emitted" "PASS"
+  else
+    print_result "discussion-label skip log emitted" "FAIL" "Expected discussion-label skip log"
+  fi
   if [[ ! -f "$GH_MOCK_DIR/actions.log" ]] || ! grep -q "CLOSED_PR_$pr_num" "$GH_MOCK_DIR/actions.log" 2>/dev/null; then
     print_result "script did NOT close PR with discussion label" "PASS"
   else
     print_result "script did NOT close PR with discussion label" "FAIL" "PR was incorrectly closed"
   fi
-
   if [[ ! -f "$GH_MOCK_DIR/actions.log" ]] || ! grep -q "UNASSIGNED_${assignee}_FROM_${issue_num}" "$GH_MOCK_DIR/actions.log" 2>/dev/null; then
     print_result "script did NOT unassign issue for discussion PR" "PASS"
   else

--- a/.github/scripts/test-bot-inactivity-unassign.sh
+++ b/.github/scripts/test-bot-inactivity-unassign.sh
@@ -4,22 +4,21 @@ set -euo pipefail
 # Test suite for bot-inactivity-unassign.sh
 # Tests the discussion label functionality and other key behaviors
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TEST_REPO="test-org/test-repo"
 TEMP_DIR=""
+BOT_SCRIPT=".github/scripts/bot-inactivity-unassign.sh"
 
 # Color codes for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+NC='\033[0m'
 
 # Test counters
 TESTS_RUN=0
 TESTS_PASSED=0
 TESTS_FAILED=0
 
-# Setup test environment
 setup() {
   TEMP_DIR=$(mktemp -d)
   export PATH="$TEMP_DIR/mocks:$PATH"
@@ -32,15 +31,12 @@ setup() {
   echo "Test environment created at: $TEMP_DIR"
 }
 
-# Cleanup test environment
 cleanup() {
   if [[ -n "$TEMP_DIR" && -d "$TEMP_DIR" ]]; then
     rm -rf "$TEMP_DIR"
-    echo "Test environment cleaned up"
   fi
 }
 
-# Print test result
 print_result() {
   local test_name="$1"
   local result="$2"
@@ -101,9 +97,28 @@ elif [[ "$1" == "pr" && "$2" == "view" ]]; then
   elif [[ "$*" == *"--json labels"* ]]; then
     # Check if jq filter is also requested
     if [[ "$*" == *"--jq"* ]]; then
-      # Extract the jq filter and apply it
+      # Extract the caller-provided --jq filter and apply it
+      jq_filter=""
+      args=("$@")
+      for i in "${!args[@]}"; do
+        if [[ "${args[i]}" == "--jq" ]]; then
+          next=$((i + 1))
+          if (( next < ${#args[@]} )); then
+            jq_filter="${args[next]}"
+          fi
+          break
+        elif [[ "${args[i]}" == --jq=* ]]; then
+          jq_filter="${args[i]#--jq=}"
+          break
+        fi
+      done
+
       if [[ -f "$GH_MOCK_DIR/pr_${pr_num}_labels.json" ]]; then
-        cat "$GH_MOCK_DIR/pr_${pr_num}_labels.json" | jq -r '.labels[].name | select(. == "discussion")' 2>/dev/null || echo ""
+        if [[ -n "$jq_filter" ]]; then
+          cat "$GH_MOCK_DIR/pr_${pr_num}_labels.json" | jq -r "$jq_filter" 2>/dev/null || echo ""
+        else
+          cat "$GH_MOCK_DIR/pr_${pr_num}_labels.json"
+        fi
       else
         echo ""
       fi
@@ -134,22 +149,29 @@ elif [[ "$1" == "issue" && "$2" == "comment" ]]; then
 elif [[ "$1" == "issue" && "$2" == "edit" ]]; then
   # Mock issue edit - record unassignment
   if [[ "$*" == *"--remove-assignee"* ]]; then
-    for i in "${!@}"; do
-      if [[ "${!i}" == "--remove-assignee" ]]; then
-        next=$((i + 1))
-        user="${!next}"
-        issue_num=""
-        for arg in "$@"; do
-          if [[ "$arg" =~ ^[0-9]+$ ]]; then
-            issue_num="$arg"
-            break
-          fi
-        done
-        echo "UNASSIGNED_${user}_FROM_${issue_num}" >> "$GH_MOCK_DIR/actions.log"
+    # Copy arguments into an array for indexed access
+    args=("$@")
+    # Determine the issue number (first purely numeric argument)
+    issue_num=""
+    for arg in "${args[@]}"; do
+      if [[ "$arg" =~ ^[0-9]+$ ]]; then
+        issue_num="$arg"
         break
       fi
     done
-  fi
+    # Find the --remove-assignee flag and its following username
+    user=""
+    for i in "${!args[@]}"; do
+      if [[ "${args[i]}" == "--remove-assignee" ]]; then
+        next=$((i + 1))
+        if (( next < ${#args[@]} )); then
+          user="${args[next]}"
+          echo "UNASSIGNED_${user}_FROM_${issue_num}" >> "$GH_MOCK_DIR/actions.log"
+        fi
+        break
+      fi
+    done  
+    fi
   echo "Issue edited"
   
 elif [[ "$1" == "auth" && "$2" == "status" ]]; then
@@ -160,26 +182,63 @@ MOCK_END
   
   chmod +x "$TEMP_DIR/mocks/gh"
   
-  # Also create mock for jq (in case it's needed)
   if ! command -v jq >/dev/null 2>&1; then
     echo "WARNING: jq not found, some tests may fail"
   fi
 }
 
-# Create mock date command for consistent testing
-create_date_mock() {
-  # We'll use real date but could mock if needed for time-based tests
-  return 0
+# Setup full issue + timeline + PR data for executing the actual bot script
+setup_issue_with_linked_pr() {
+  local issue_num="$1"
+  local pr_num="$2"
+  local assignee="$3"
+
+  cat > "$GH_MOCK_DIR/repos_${TEST_REPO//\//_}_issues.json" << EOF
+[
+  {
+    "number": $issue_num,
+    "state": "open",
+    "assignees": [{"login": "$assignee"}]
+  }
+]
+EOF
+
+  cat > "$GH_MOCK_DIR/repos_${TEST_REPO//\//_}_issues_${issue_num}.json" << EOF
+{
+  "number": $issue_num,
+  "state": "open",
+  "created_at": "2026-01-01T00:00:00Z",
+  "assignees": [{"login": "$assignee"}]
+}
+EOF
+
+  cat > "$GH_MOCK_DIR/repos_${TEST_REPO//\//_}_issues_${issue_num}_timeline.json" << EOF
+[
+  {
+    "event": "assigned",
+    "created_at": "2026-01-02T00:00:00Z",
+    "assignee": {"login": "$assignee"}
+  },
+  {
+    "event": "cross-referenced",
+    "source": {
+      "issue": {
+        "number": $pr_num,
+        "pull_request": {"url": "https://api.github.com/repos/$TEST_REPO/pulls/$pr_num"},
+        "repository": {"full_name": "$TEST_REPO"}
+      }
+    }
+  }
+]
+EOF
 }
 
 # Setup mock data for a PR with discussion label
 setup_pr_with_discussion_label() {
   local pr_num="$1"
   
-  # PR is open
   echo '{"state":"OPEN"}' > "$GH_MOCK_DIR/pr_${pr_num}_state.json"
   
-  # PR has discussion label
   cat > "$GH_MOCK_DIR/pr_${pr_num}_labels.json" << 'EOF'
 {"labels":[{"name":"discussion"},{"name":"enhancement"}]}
 EOF
@@ -195,7 +254,6 @@ EOF
 setup_stale_pr_without_discussion() {
   local pr_num="$1"
   
-  # PR is open
   echo '{"state":"OPEN"}' > "$GH_MOCK_DIR/pr_${pr_num}_state.json"
   
   # PR has no discussion label
@@ -212,7 +270,6 @@ EOF
 setup_active_pr() {
   local pr_num="$1"
   
-  # PR is open
   echo '{"state":"OPEN"}' > "$GH_MOCK_DIR/pr_${pr_num}_state.json"
   
   # PR has no discussion label
@@ -239,31 +296,35 @@ setup_closed_pr() {
 # Test 1: PR with discussion label should NOT be closed
 test_pr_with_discussion_label_not_closed() {
   echo ""
-  echo "Test 1: PR with 'discussion' label should not be closed"
-  echo "=========================================================="
-  
-  setup_pr_with_discussion_label "100"
-  
-  # Create a minimal test scenario
-  # We'll test the relevant part of the script logic
-  
-  # Simulate the check
+  echo "Test 1: Skip stale PR with 'discussion' label"
+  echo "=================================================================="
+
+  local issue_num="1000"
   local pr_num="100"
-  local HAS_DISCUSSION_LABEL
-  HAS_DISCUSSION_LABEL=$(gh pr view "$pr_num" --repo "$TEST_REPO" --json labels --jq '.labels[].name | select(. == "discussion")' 2>/dev/null || echo "")
-  
-  if [[ -n "$HAS_DISCUSSION_LABEL" ]]; then
-    # Should skip closing
-    print_result "PR with discussion label detected" "PASS"
-    
-    # Verify PR was not closed
-    if [[ ! -f "$GH_MOCK_DIR/actions.log" ]] || ! grep -q "CLOSED_PR_$pr_num" "$GH_MOCK_DIR/actions.log" 2>/dev/null; then
-      print_result "PR with discussion label was NOT closed" "PASS"
-    else
-      print_result "PR with discussion label was NOT closed" "FAIL" "PR was incorrectly closed"
-    fi
+  local assignee="alice"
+
+  setup_issue_with_linked_pr "$issue_num" "$pr_num" "$assignee"
+  setup_pr_with_discussion_label "$pr_num"
+
+  local output
+  output=$(REPO="$TEST_REPO" DAYS=21 DRY_RUN=0 bash "$BOT_SCRIPT" 2>&1 || true)
+
+  if [[ -n "$output" ]]; then
+    print_result "script executed with mocked data" "PASS"
   else
-    print_result "PR with discussion label detected" "FAIL" "Discussion label not detected"
+    print_result "script executed with mocked data" "FAIL" "Bot output was unexpectedly empty"
+  fi
+
+  if [[ ! -f "$GH_MOCK_DIR/actions.log" ]] || ! grep -q "CLOSED_PR_$pr_num" "$GH_MOCK_DIR/actions.log" 2>/dev/null; then
+    print_result "script did NOT close PR with discussion label" "PASS"
+  else
+    print_result "script did NOT close PR with discussion label" "FAIL" "PR was incorrectly closed"
+  fi
+
+  if [[ ! -f "$GH_MOCK_DIR/actions.log" ]] || ! grep -q "UNASSIGNED_${assignee}_FROM_${issue_num}" "$GH_MOCK_DIR/actions.log" 2>/dev/null; then
+    print_result "script did NOT unassign issue for discussion PR" "PASS"
+  else
+    print_result "script did NOT unassign issue for discussion PR" "FAIL" "Assignee was incorrectly removed"
   fi
 }
 
@@ -277,7 +338,7 @@ test_stale_pr_without_discussion_closed() {
   
   local pr_num="200"
   local HAS_DISCUSSION_LABEL
-  HAS_DISCUSSION_LABEL=$(gh pr view "$pr_num" --repo "$TEST_REPO" --json labels --jq '.labels[].name | select(. == "discussion")' 2>/dev/null || echo "")
+  HAS_DISCUSSION_LABEL=$(gh pr view "$pr_num" --repo "$TEST_REPO" --json labels --jq '.labels[].name' 2>/dev/null | grep -i '^discussion$' || echo "")
   
   if [[ -z "$HAS_DISCUSSION_LABEL" ]]; then
     print_result "PR without discussion label detected" "PASS"
@@ -286,31 +347,30 @@ test_stale_pr_without_discussion_closed() {
   fi
 }
 
-# Test 3: Verify label check uses correct jq filter
+# Test 3: Verify label check uses jq filter correctly
 test_jq_filter_correctness() {
   echo ""
-  echo "Test 3: Verify jq filter correctly identifies 'discussion' label"
+  echo "Test 3: Mock correctly executes jq filters"
   echo "=================================================================="
   
-  # Test with discussion label present
   setup_pr_with_discussion_label "300"
   local result
-  result=$(gh pr view "300" --repo "$TEST_REPO" --json labels --jq '.labels[].name | select(. == "discussion")' 2>/dev/null || echo "")
+  result=$(gh pr view "300" --repo "$TEST_REPO" --json labels --jq '.labels[].name' 2>/dev/null || echo "")
   
-  if [[ "$result" == "discussion" ]]; then
-    print_result "jq filter finds 'discussion' label" "PASS"
+  if echo "$result" | grep -q "discussion"; then
+    print_result "Mock executes .labels[].name filter" "PASS"
   else
-    print_result "jq filter finds 'discussion' label" "FAIL" "Expected 'discussion', got '$result'"
+    print_result "Mock executes .labels[].name filter" "FAIL" "Expected 'discussion' in output, got '$result'"
   fi
   
-  # Test with no discussion label
+  # Test with no discussion label using same filter
   setup_stale_pr_without_discussion "301"
-  result=$(gh pr view "301" --repo "$TEST_REPO" --json labels --jq '.labels[].name | select(. == "discussion")' 2>/dev/null || echo "")
+  result=$(gh pr view "301" --repo "$TEST_REPO" --json labels --jq '.labels[].name' 2>/dev/null || echo "")
   
-  if [[ -z "$result" ]]; then
-    print_result "jq filter returns empty for missing 'discussion' label" "PASS"
+  if ! echo "$result" | grep -qi "^discussion$"; then
+    print_result "Mock handles .labels[].name without discussion" "PASS"
   else
-    print_result "jq filter returns empty for missing 'discussion' label" "FAIL" "Expected empty, got '$result'"
+    print_result "Mock handles .labels[].name without discussion" "FAIL" "Unexpected discussion label in '$result'"
   fi
 }
 
@@ -348,7 +408,6 @@ test_active_pr_not_closed() {
   if echo "$COMMITS_JSON" | jq -e 'length > 0' >/dev/null 2>&1; then
     print_result "Active PR has commit data" "PASS"
     
-    # In real script, this would calculate age and skip if < 21 days
     local last_commit_date
     last_commit_date=$(echo "$COMMITS_JSON" | jq -r 'last | .commit.committer.date // empty')
     if [[ -n "$last_commit_date" ]]; then
@@ -361,28 +420,22 @@ test_active_pr_not_closed() {
   fi
 }
 
-# Test 6: Log output verification
+# Test 6: Verify mock handles varying jq expressions
 test_log_output() {
   echo ""
-  echo "Test 6: Verify correct log messages are generated"
+  echo "Test 6: Mock handles varying jq filter expressions"
   echo "==================================================="
   
   setup_pr_with_discussion_label "600"
   
-  # Capture output
-  local output
   local pr_num="600"
-  output=$(
-    HAS_DISCUSSION_LABEL=$(gh pr view "$pr_num" --repo "$TEST_REPO" --json labels --jq '.labels[].name | select(. == "discussion")' 2>/dev/null || echo "")
-    if [[ -n "$HAS_DISCUSSION_LABEL" ]]; then
-      echo "    [SKIP] PR #$pr_num has 'discussion' label, keeping open"
-    fi
-  )
+  local output
+  output=$(gh pr view "$pr_num" --repo "$TEST_REPO" --json labels --jq '[.labels[] | select(.name == "discussion") | .name]' 2>/dev/null || echo "[]")
   
-  if echo "$output" | grep -q "\[SKIP\].*discussion.*keeping open"; then
-    print_result "Correct log message for discussion label" "PASS"
+  if echo "$output" | grep -q "discussion"; then
+    print_result "Mock executes complex jq with select and map" "PASS"
   else
-    print_result "Correct log message for discussion label" "FAIL" "Expected log message not found"
+    print_result "Mock executes complex jq with select and map" "FAIL" "Expected 'discussion' in output"
   fi
 }
 
@@ -395,60 +448,55 @@ test_multiple_labels_with_discussion() {
   # Create PR with multiple labels including discussion
   echo '{"state":"OPEN"}' > "$GH_MOCK_DIR/pr_700_state.json"
   cat > "$GH_MOCK_DIR/pr_700_labels.json" << 'EOF'
-{"labels":[{"name":"bug"},{"name":"discussion"},{"name":"priority-high"}]}
+{"labels":[{"name":"bug"},{"name":"discussion"},{"name":"CICD"}]}
 EOF
   
   local pr_num="700"
-  local HAS_DISCUSSION_LABEL
-  HAS_DISCUSSION_LABEL=$(gh pr view "$pr_num" --repo "$TEST_REPO" --json labels --jq '.labels[].name | select(. == "discussion")' 2>/dev/null || echo "")
+  local label_count
+  label_count=$(gh pr view "$pr_num" --repo "$TEST_REPO" --json labels --jq '.labels | length' 2>/dev/null || echo "0")
   
-  if [[ "$HAS_DISCUSSION_LABEL" == "discussion" ]]; then
-    print_result "Discussion label found among multiple labels" "PASS"
+  if [[ "$label_count" == "3" ]]; then
+    print_result "Mock executes .labels | length filter" "PASS"
   else
-    print_result "Discussion label found among multiple labels" "FAIL" "Label not detected"
+    print_result "Mock executes .labels | length filter" "FAIL" "Expected 3 labels, got '$label_count'"
   fi
 }
 
-# Test 8: Case sensitivity check
-test_case_sensitivity() {
+# Test 8: Case insensitivity check
+test_case_insensitivity() {
   echo ""
-  echo "Test 8: Label matching is case-sensitive"
-  echo "=========================================="
+  echo "Test 8: Label matching is case-insensitive"
+  echo "==========================================="
   
   # Create PR with "Discussion" (capital D)
   echo '{"state":"OPEN"}' > "$GH_MOCK_DIR/pr_800_state.json"
   echo '{"labels":[{"name":"Discussion"}]}' > "$GH_MOCK_DIR/pr_800_labels.json"
   
   local pr_num="800"
-  local HAS_DISCUSSION_LABEL
-  HAS_DISCUSSION_LABEL=$(gh pr view "$pr_num" --repo "$TEST_REPO" --json labels --jq '.labels[].name | select(. == "discussion")' 2>/dev/null || echo "")
+  local normalized_name
+  # Test passing a jq filter that normalizes case
+  normalized_name=$(gh pr view "$pr_num" --repo "$TEST_REPO" --json labels --jq '.labels[0].name | ascii_downcase' 2>/dev/null || echo "")
   
-  if [[ -z "$HAS_DISCUSSION_LABEL" ]]; then
-    print_result "Case-sensitive matching (Discussion != discussion)" "PASS"
+  if [[ "$normalized_name" == "discussion" ]]; then
+    print_result "Mock executes ascii_downcase filter" "PASS"
   else
-    print_result "Case-sensitive matching (Discussion != discussion)" "FAIL" "Should not match different case"
+    print_result "Mock executes ascii_downcase filter" "FAIL" "Expected 'discussion', got '$normalized_name'"
   fi
 }
 
-# Main test runner
 main() {
   echo "=============================================="
   echo "  Bot Inactivity Unassign - Test Suite"
   echo "=============================================="
   echo ""
   
-  # Setup
   setup
   trap cleanup EXIT
   
-  # Create mocks
   create_gh_mock
-  create_date_mock
   
-  # Clear actions log
   rm -f "$GH_MOCK_DIR/actions.log"
   
-  # Run tests
   test_pr_with_discussion_label_not_closed
   test_stale_pr_without_discussion_closed
   test_jq_filter_correctness
@@ -456,9 +504,8 @@ main() {
   test_active_pr_not_closed
   test_log_output
   test_multiple_labels_with_discussion
-  test_case_sensitivity
+  test_case_insensitivity
   
-  # Summary
   echo ""
   echo "=============================================="
   echo "  Test Summary"
@@ -474,5 +521,4 @@ main() {
   fi
 }
 
-# Run tests
 main "$@"

--- a/.github/scripts/test-bot-inactivity-unassign.sh
+++ b/.github/scripts/test-bot-inactivity-unassign.sh
@@ -67,6 +67,7 @@ GH_MOCK_DIR="${GH_MOCK_DIR:-/tmp/gh_mock_data}"
 # Parse command
 if [[ "$1" == "api" ]]; then
   # Handle API calls
+  # Accept production flags like --paginate and -H, but treat fixtures as single-page responses.
   endpoint=""
   for arg in "$@"; do
     if [[ "$arg" =~ ^repos/ ]] || [[ "$arg" =~ ^issues/ ]]; then
@@ -74,12 +75,37 @@ if [[ "$1" == "api" ]]; then
       break
     fi
   done
+
+  jq_filter=""
+  if [[ "$*" == *"--jq"* ]]; then
+    args=("$@")
+    for i in "${!args[@]}"; do
+      if [[ "${args[i]}" == "--jq" ]]; then
+        next=$((i + 1))
+        if (( next < ${#args[@]} )); then
+          jq_filter="${args[next]}"
+        fi
+        break
+      elif [[ "${args[i]}" == --jq=* ]]; then
+        jq_filter="${args[i]#--jq=}"
+        break
+      fi
+    done
+  fi
   
   # Return mock data based on endpoint
   if [[ -f "$GH_MOCK_DIR/${endpoint//\//_}.json" ]]; then
-    cat "$GH_MOCK_DIR/${endpoint//\//_}.json"
+    if [[ -n "$jq_filter" ]]; then
+      cat "$GH_MOCK_DIR/${endpoint//\//_}.json" | jq -r "$jq_filter" 2>/dev/null || echo ""
+    else
+      cat "$GH_MOCK_DIR/${endpoint//\//_}.json"
+    fi
   else
-    echo "[]"
+    if [[ -n "$jq_filter" ]]; then
+      echo "[]" | jq -r "$jq_filter" 2>/dev/null || echo ""
+    else
+      echo "[]"
+    fi
   fi
   
 elif [[ "$1" == "pr" && "$2" == "view" ]]; then
@@ -88,10 +114,37 @@ elif [[ "$1" == "pr" && "$2" == "view" ]]; then
   
   # Check if asking for state
   if [[ "$*" == *"--json state"* ]]; then
-    if [[ -f "$GH_MOCK_DIR/pr_${pr_num}_state.json" ]]; then
-      cat "$GH_MOCK_DIR/pr_${pr_num}_state.json"
+    if [[ "$*" == *"--jq"* ]]; then
+      jq_filter=""
+      args=("$@")
+      for i in "${!args[@]}"; do
+        if [[ "${args[i]}" == "--jq" ]]; then
+          next=$((i + 1))
+          if (( next < ${#args[@]} )); then
+            jq_filter="${args[next]}"
+          fi
+          break
+        elif [[ "${args[i]}" == --jq=* ]]; then
+          jq_filter="${args[i]#--jq=}"
+          break
+        fi
+      done
+
+      if [[ -f "$GH_MOCK_DIR/pr_${pr_num}_state.json" ]]; then
+        if [[ -n "$jq_filter" ]]; then
+          cat "$GH_MOCK_DIR/pr_${pr_num}_state.json" | jq -r "$jq_filter" 2>/dev/null || echo ""
+        else
+          cat "$GH_MOCK_DIR/pr_${pr_num}_state.json"
+        fi
+      else
+        echo '{"state":"OPEN"}'
+      fi
     else
-      echo '{"state":"OPEN"}'
+      if [[ -f "$GH_MOCK_DIR/pr_${pr_num}_state.json" ]]; then
+        cat "$GH_MOCK_DIR/pr_${pr_num}_state.json"
+      else
+        echo '{"state":"OPEN"}'
+      fi
     fi
   # Check if asking for labels
   elif [[ "$*" == *"--json labels"* ]]; then
@@ -171,7 +224,7 @@ elif [[ "$1" == "issue" && "$2" == "edit" ]]; then
         break
       fi
     done  
-    fi
+  fi
   echo "Issue edited"
   
 elif [[ "$1" == "auth" && "$2" == "status" ]]; then
@@ -233,6 +286,26 @@ EOF
 EOF
 }
 
+setup_labeled_pr_with_linked_issue() {
+  local issue_num="$1"
+  local pr_num="$2"
+  local assignee="$3"
+  local label_name="$4"
+
+  setup_issue_with_linked_pr "$issue_num" "$pr_num" "$assignee"
+
+  echo '{"state":"OPEN"}' > "$GH_MOCK_DIR/pr_${pr_num}_state.json"
+  cat > "$GH_MOCK_DIR/pr_${pr_num}_labels.json" << EOF
+{"labels":[{"name":"$label_name"}]}
+EOF
+
+  local old_date
+  old_date=$(date -u -v-25d +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d "25 days ago" +"%Y-%m-%dT%H:%M:%SZ")
+  cat > "$GH_MOCK_DIR/repos_${TEST_REPO//\//_}_pulls_${pr_num}_commits.json" << EOF
+[{"commit":{"committer":{"date":"$old_date"}}}]
+EOF
+}
+
 # Setup mock data for a PR with discussion label
 setup_pr_with_discussion_label() {
   local pr_num="$1"
@@ -244,7 +317,8 @@ setup_pr_with_discussion_label() {
 EOF
   
   # Mock stale commits (21+ days old)
-  local old_date=$(date -u -v-25d +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d "25 days ago" +"%Y-%m-%dT%H:%M:%SZ")
+  local old_date
+  old_date=$(date -u -v-25d +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d "25 days ago" +"%Y-%m-%dT%H:%M:%SZ")
   cat > "$GH_MOCK_DIR/repos_${TEST_REPO//\//_}_pulls_${pr_num}_commits.json" << EOF
 [{"commit":{"committer":{"date":"$old_date"}}}]
 EOF
@@ -260,7 +334,8 @@ setup_stale_pr_without_discussion() {
   echo '{"labels":[{"name":"bug"}]}' > "$GH_MOCK_DIR/pr_${pr_num}_labels.json"
   
   # Mock stale commits
-  local old_date=$(date -u -v-25d +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d "25 days ago" +"%Y-%m-%dT%H:%M:%SZ")
+  local old_date
+  old_date=$(date -u -v-25d +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d "25 days ago" +"%Y-%m-%dT%H:%M:%SZ")
   cat > "$GH_MOCK_DIR/repos_${TEST_REPO//\//_}_pulls_${pr_num}_commits.json" << EOF
 [{"commit":{"committer":{"date":"$old_date"}}}]
 EOF
@@ -276,7 +351,8 @@ setup_active_pr() {
   echo '{"labels":[{"name":"feature"}]}' > "$GH_MOCK_DIR/pr_${pr_num}_labels.json"
   
   # Mock recent commits
-  local recent_date=$(date -u -v-5d +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d "5 days ago" +"%Y-%m-%dT%H:%M:%SZ")
+  local recent_date
+  recent_date=$(date -u -v-5d +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d "5 days ago" +"%Y-%m-%dT%H:%M:%SZ")
   cat > "$GH_MOCK_DIR/repos_${TEST_REPO//\//_}_pulls_${pr_num}_commits.json" << EOF
 [{"commit":{"committer":{"date":"$recent_date"}}}]
 EOF
@@ -334,9 +410,13 @@ test_stale_pr_without_discussion_closed() {
   echo "Test 2: Stale PR without 'discussion' label should be closed"
   echo "=============================================================="
   
+  local issue_num="2000"
+  local pr_num="200"
+  local assignee="alice"
+
+  setup_issue_with_linked_pr "$issue_num" "$pr_num" "$assignee"
   setup_stale_pr_without_discussion "200"
   
-  local pr_num="200"
   local HAS_DISCUSSION_LABEL
   HAS_DISCUSSION_LABEL=$(gh pr view "$pr_num" --repo "$TEST_REPO" --json labels --jq '.labels[].name' 2>/dev/null | grep -i '^discussion$' || echo "")
   
@@ -344,6 +424,21 @@ test_stale_pr_without_discussion_closed() {
     print_result "PR without discussion label detected" "PASS"
   else
     print_result "PR without discussion label detected" "FAIL" "Discussion label incorrectly detected"
+  fi
+
+  local output
+  output=$(REPO="$TEST_REPO" DAYS=21 DRY_RUN=0 bash "$BOT_SCRIPT" 2>&1 || true)
+
+  if [[ -n "$output" ]]; then
+    print_result "script executed for stale PR without discussion label" "PASS"
+  else
+    print_result "script executed for stale PR without discussion label" "FAIL" "Bot output was unexpectedly empty"
+  fi
+
+  if [[ -f "$GH_MOCK_DIR/actions.log" ]] && grep -q "CLOSED_PR_$pr_num" "$GH_MOCK_DIR/actions.log" 2>/dev/null; then
+    print_result "script closed stale PR without discussion label" "PASS"
+  else
+    print_result "script closed stale PR without discussion label" "FAIL" "Expected CLOSED_PR_$pr_num in actions.log"
   fi
 }
 
@@ -403,7 +498,7 @@ test_active_pr_not_closed() {
   
   local pr_num="500"
   local COMMITS_JSON
-  COMMITS_JSON=$(gh api "repos/$TEST_REPO/pulls/$pr_num/commits" 2>/dev/null || echo "[]")
+  COMMITS_JSON=$(gh api "repos/$TEST_REPO/pulls/$pr_num/commits" --paginate 2>/dev/null || echo "[]")
   
   if echo "$COMMITS_JSON" | jq -e 'length > 0' >/dev/null 2>&1; then
     print_result "Active PR has commit data" "PASS"
@@ -462,25 +557,37 @@ EOF
   fi
 }
 
-# Test 8: Case insensitivity check
+# Test 8: Case-insensitive discussion label handling
 test_case_insensitivity() {
   echo ""
   echo "Test 8: Label matching is case-insensitive"
   echo "==========================================="
   
-  # Create PR with "Discussion" (capital D)
-  echo '{"state":"OPEN"}' > "$GH_MOCK_DIR/pr_800_state.json"
-  echo '{"labels":[{"name":"Discussion"}]}' > "$GH_MOCK_DIR/pr_800_labels.json"
-  
+  local issue_num="8000"
   local pr_num="800"
-  local normalized_name
-  # Test passing a jq filter that normalizes case
-  normalized_name=$(gh pr view "$pr_num" --repo "$TEST_REPO" --json labels --jq '.labels[0].name | ascii_downcase' 2>/dev/null || echo "")
-  
-  if [[ "$normalized_name" == "discussion" ]]; then
-    print_result "Mock executes ascii_downcase filter" "PASS"
+  local assignee="bob"
+
+  setup_labeled_pr_with_linked_issue "$issue_num" "$pr_num" "$assignee" "Discussion"
+
+  local output
+  output=$(REPO="$TEST_REPO" DAYS=21 DRY_RUN=0 bash "$BOT_SCRIPT" 2>&1 || true)
+
+  if [[ -n "$output" ]]; then
+    print_result "script executed for case-insensitive label" "PASS"
   else
-    print_result "Mock executes ascii_downcase filter" "FAIL" "Expected 'discussion', got '$normalized_name'"
+    print_result "script executed for case-insensitive label" "FAIL" "Bot output was unexpectedly empty"
+  fi
+
+  if [[ ! -f "$GH_MOCK_DIR/actions.log" ]] || ! grep -q "CLOSED_PR_$pr_num" "$GH_MOCK_DIR/actions.log" 2>/dev/null; then
+    print_result "bot did NOT close PR with 'Discussion' label" "PASS"
+  else
+    print_result "bot did NOT close PR with 'Discussion' label" "FAIL" "PR was incorrectly closed"
+  fi
+
+  if [[ ! -f "$GH_MOCK_DIR/actions.log" ]] || ! grep -q "UNASSIGNED_${assignee}_FROM_${issue_num}" "$GH_MOCK_DIR/actions.log" 2>/dev/null; then
+    print_result "bot did NOT unassign issue for 'Discussion' label" "PASS"
+  else
+    print_result "bot did NOT unassign issue for 'Discussion' label" "FAIL" "Assignee was incorrectly removed"
   fi
 }
 

--- a/.github/scripts/test-bot-inactivity-unassign.sh
+++ b/.github/scripts/test-bot-inactivity-unassign.sh
@@ -417,7 +417,7 @@ test_stale_pr_without_discussion_closed() {
   local assignee="alice"
 
   setup_issue_with_linked_pr "$issue_num" "$pr_num" "$assignee"
-  setup_stale_pr_without_discussion "200"
+  setup_stale_pr_without_discussion "$pr_num"
   
   local HAS_DISCUSSION_LABEL
   HAS_DISCUSSION_LABEL=$(gh pr view "$pr_num" --repo "$TEST_REPO" --json labels --jq '.labels[].name' 2>/dev/null | grep -i '^discussion$' || echo "")
@@ -429,18 +429,22 @@ test_stale_pr_without_discussion_closed() {
   fi
 
   local output
-  output=$(REPO="$TEST_REPO" DAYS=21 DRY_RUN=0 bash "$BOT_SCRIPT" 2>&1 || true)
-
-  if [[ -n "$output" ]]; then
+  if output=$(REPO="$TEST_REPO" DAYS=21 DRY_RUN=0 bash "$BOT_SCRIPT" 2>&1); then
     print_result "script executed for stale PR without discussion label" "PASS"
   else
-    print_result "script executed for stale PR without discussion label" "FAIL" "Bot output was unexpectedly empty"
+    print_result "script executed for stale PR without discussion label" "FAIL" "Bot exited non-zero: $output"
   fi
 
   if [[ -f "$GH_MOCK_DIR/actions.log" ]] && grep -q "CLOSED_PR_$pr_num" "$GH_MOCK_DIR/actions.log" 2>/dev/null; then
     print_result "script closed stale PR without discussion label" "PASS"
   else
     print_result "script closed stale PR without discussion label" "FAIL" "Expected CLOSED_PR_$pr_num in actions.log"
+  fi
+
+  if [[ -f "$GH_MOCK_DIR/actions.log" ]] && grep -q "UNASSIGNED_${assignee}_FROM_${issue_num}" "$GH_MOCK_DIR/actions.log" 2>/dev/null; then
+    print_result "script unassigned user for stale PR without discussion label" "PASS"
+  else
+    print_result "script unassigned user for stale PR without discussion label" "FAIL" "Expected UNASSIGNED_${assignee}_FROM_${issue_num} in actions.log"
   fi
 }
 
@@ -572,12 +576,16 @@ test_case_insensitivity() {
   setup_labeled_pr_with_linked_issue "$issue_num" "$pr_num" "$assignee" "Discussion"
 
   local output
-  output=$(REPO="$TEST_REPO" DAYS=21 DRY_RUN=0 bash "$BOT_SCRIPT" 2>&1 || true)
-
-  if [[ -n "$output" ]]; then
+  if output=$(REPO="$TEST_REPO" DAYS=21 DRY_RUN=0 bash "$BOT_SCRIPT" 2>&1); then
     print_result "script executed for case-insensitive label" "PASS"
   else
-    print_result "script executed for case-insensitive label" "FAIL" "Bot output was unexpectedly empty"
+    print_result "script executed for case-insensitive label" "FAIL" "Bot exited non-zero: $output"
+  fi
+
+  if grep -Eq "\\[SKIP\\].*discussion" <<<"$output"; then
+    print_result "case-insensitive discussion skip log emitted" "PASS"
+  else
+    print_result "case-insensitive discussion skip log emitted" "FAIL" "Expected discussion-label skip log"
   fi
 
   if [[ ! -f "$GH_MOCK_DIR/actions.log" ]] || ! grep -q "CLOSED_PR_$pr_num" "$GH_MOCK_DIR/actions.log" 2>/dev/null; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - fix: prevent CodeRabbit from posting comments on closed issues(#1962)
 - chore: update spam list #1988
 - chore: Update `bot-advanced-check.yml`, `bot-gfi-assign-on-comment.yml`, `bot-intermediate-assignment.yml`, `bot-linked-issue-enforcer.yml`, `unassign-on-comment.yml`, `working-on-comment.yml` workflow runner configuration
-- chore: Added check for the discussion label in the inactivity bot (`#1583`)
+- chore: Added check for the discussion label in the inactivity bot (#1583)
 
 
 ## [0.2.2] - 2026-03-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - fix: prevent CodeRabbit from posting comments on closed issues(#1962)
 - chore: update spam list #1988
 - chore: Update `bot-advanced-check.yml`, `bot-gfi-assign-on-comment.yml`, `bot-intermediate-assignment.yml`, `bot-linked-issue-enforcer.yml`, `unassign-on-comment.yml`, `working-on-comment.yml` workflow runner configuration
-
+- chore: Added check for the discussion label in the inactivity bot (`#1583`)
 
 
 ## [0.2.2] - 2026-03-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 
 ### .github
+- chore: Added check for the discussion label in the inactivity bot (#1583)
 - chore: update GitHub Actions runners from ubuntu-latest to hl-sdk-py-lin-md (#2021)
 - Refactored the Advanced Issue Template to V2 with stricter prerequisites and a focus on architectural design (#2016).
 - Refactored the Advanced Issue Template to ensure PR-level quality checklists do not block maintainers during issue creation (#2036)
@@ -54,7 +55,6 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - fix: prevent CodeRabbit from posting comments on closed issues(#1962)
 - chore: update spam list #1988
 - chore: Update `bot-advanced-check.yml`, `bot-gfi-assign-on-comment.yml`, `bot-intermediate-assignment.yml`, `bot-linked-issue-enforcer.yml`, `unassign-on-comment.yml`, `working-on-comment.yml` workflow runner configuration
-- chore: Added check for the discussion label in the inactivity bot (#1583)
 - Fix build failing in `publish.yml`
 
 


### PR DESCRIPTION
**Description**:
Adds a check to the inactivity bot script to prevent it from closing or unassigning pull requests that have the 'discussion' label. This ensures that active discussions are not interrupted by automated processes.

**Related issue(s)**:
Fixes #1583

**Checklist**
- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
