### PR TITLE
chore: configure Codacy to skip assert_used rule in test files

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -10,3 +10,10 @@ engines:
       - "B101"
     exclude_paths:
       - tests/**
+  pylint:
+    enabled: true
+    rules:
+      assert_used:
+        skips:
+          - "*_test.py"
+          - "*test_*.py"

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -10,10 +10,8 @@ engines:
       - "B101"
     exclude_paths:
       - tests/**
-  pylint:
+  pylintpython3:
     enabled: true
-    rules:
-      assert_used:
-        skips:
-        - "**/*_test.py"
-        - "**/test_*.py"
+    exclude_paths:
+      - "**/*_test.py"
+      - "**/test_*.py"

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -15,5 +15,5 @@ engines:
     rules:
       assert_used:
         skips:
-          - "*_test.py"
-          - "*test_*.py"
+        - "**/*_test.py"
+        - "**/test_*.py"

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -10,8 +10,10 @@ engines:
       - "B101"
     exclude_paths:
       - tests/**
-  pylintpython3:
+  pylint:
     enabled: true
-    exclude_paths:
-      - "**/*_test.py"
-      - "**/test_*.py"
+    rules:
+      assert_used:
+        skips:
+          - "**/*_test.py"
+          - "**/test_*.py"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - chore: update GitHub Actions runners from ubuntu-latest to hl-sdk-py-lin-md (#2021)
 - Refactored the Advanced Issue Template to V2 with stricter prerequisites and a focus on architectural design (#2016).
 - Refactored the Advanced Issue Template to ensure PR-level quality checklists do not block maintainers during issue creation (#2036)
+- chore: configure codacy to skip assert_used rule in test files
 
 ## [0.2.3] - 2026-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - chore: update GitHub Actions runners from ubuntu-latest to hl-sdk-py-lin-md (#2021)
 - Refactored the Advanced Issue Template to V2 with stricter prerequisites and a focus on architectural design (#2016).
 - Refactored the Advanced Issue Template to ensure PR-level quality checklists do not block maintainers during issue creation (#2036)
-- chore: configure codacy to skip assert_used rule in test files
+- chore: configure codacy to skip assert_used rule in test files (#2025)
 
 ## [0.2.3] - 2026-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - fix: prevent CodeRabbit from posting comments on closed issues(#1962)
 - chore: update spam list #1988
 - chore: Update `bot-advanced-check.yml`, `bot-gfi-assign-on-comment.yml`, `bot-intermediate-assignment.yml`, `bot-linked-issue-enforcer.yml`, `unassign-on-comment.yml`, `working-on-comment.yml` workflow runner configuration
+- chore: configure Codacy to skip assert_used rule in test files
 - Fix build failing in `publish.yml`
 
 


### PR DESCRIPTION
**Description**:
<!--
Added a configuration in `.codacy.yml` to skip assert_used rules for all test files
-->

**Related issue(s)**:

Fixes #1974 

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)

cc @exploreriii
