### PR TITLE
chore: add return type annotation to _is_payment_required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 ## [Unreleased]
 
 ### Src
+- Add return type annotation `bool` to `_is_payment_required` method in `CryptoGetAccountBalanceQuery` (#2060)
 - Exposed all missing `TransactionRecord` protobuf fields `consensusTimestamp`, `scheduleRef`, `assessed_custom_fees`, `automatic_token_associations`, `parent_consensus_timestamp`, `alias`, `ethereum_hash`, `paid_staking_rewards`, `evm_address`, `contractCreateResult` with proper `None` handling, PRNG oneof handling with unset values return `None` instead of default values 0 / b"" (#1636)
 
 ### Tests

--- a/src/hiero_sdk_python/query/account_balance_query.py
+++ b/src/hiero_sdk_python/query/account_balance_query.py
@@ -177,7 +177,7 @@ class CryptoGetAccountBalanceQuery(Query):
         """
         return response.cryptogetAccountBalance
 
-    def _is_payment_required(self):
+    def _is_payment_required(self) -> bool:
         """
         Account balance query does not require payment.
 


### PR DESCRIPTION
## Summary
Add missing `-> bool` return type annotation to `_is_payment_required` method in `CryptoGetAccountBalanceQuery` class.

## Changes
- Add `-> bool` return type annotation to `_is_payment_required()` method
- Add changelog entry under `[Unreleased]` section

## Related Issue
This addresses the type annotation completeness for query classes.

Signed-off-by: Terry Carson YM <cym3118288@gmail.com>