### PR TITLE
chore: refactor spam labels 

### DIFF
--- a/.github/scripts/cron-admin-update-spam-list.js
+++ b/.github/scripts/cron-admin-update-spam-list.js
@@ -12,6 +12,14 @@ const fs = require('fs').promises;
 const SPAM_LIST_PATH = '.github/spam-list.txt';
 const dryRun = (process.env.DRY_RUN || 'false').toString().toLowerCase() === 'true';
 
+/**
+ * These constants control the GitHub label names used by the spam automation.
+ * To rename labels, update only the constant values here.
+ * Ensure corresponding labels exist in the GitHub repository settings.
+ */
+const LABEL_SPAM = 'notes: spam';
+const LABEL_SPAM_LIST_UPDATE = 'notes: spam-list-update';
+
 // Load current spam list and compute updates based on spam vs rehabilitated users
 
 async function computeSpamListUpdates(spamUsers, rehabilitatedUsers) {
@@ -121,7 +129,7 @@ module.exports = async ({github, context, core}) => {
     const searches = [
       {
         name: 'spam PRs',
-        query: `repo:${owner}/${repo} is:pr is:closed -is:merged label:spam`,
+        query: `repo:${owner}/${repo} is:pr is:closed -is:merged label:"${LABEL_SPAM}"`,
         process: async (pr) => {
           if (!pr.user?.login) {
             console.log(`Skipping PR #${pr.number}: user account unavailable`);
@@ -208,7 +216,7 @@ module.exports = async ({github, context, core}) => {
         const { data: existing } = await github.rest.issues.listForRepo({
           owner,
           repo,
-          labels: 'spam-list-update',
+          labels: LABEL_SPAM_LIST_UPDATE,
           state: 'open',
           per_page: 1
         });
@@ -221,7 +229,7 @@ module.exports = async ({github, context, core}) => {
           repo,
           title,
           body,
-          labels: ['spam-list-update', 'automated']
+          labels: [LABEL_SPAM_LIST_UPDATE, 'automated']
         });
         console.log('Issue created successfully');
       }


### PR DESCRIPTION
**Description**:
Refactor the GitHub spam list automation script to use the newly standardized label names for spam tracking and issue creation. To make future renaming effortless, the label strings have been extracted into central constants at the top of the module.

* Add `LABEL_SPAM` and `LABEL_SPAM_LIST_UPDATE` constants to the spam list updater script
* Change search queries querying the `spam` label to query `"notes: spam"` with proper syntax quoting
* Change the default issue-tracking label from `spam-list-update` to `notes: spam-list-update` 
* Update module documentation to clearly specify how to rename these labels in the future

**Related issue(s)**:

Fixes #2129

**Notes for reviewer**:
N/A - This is an internal CI/automation script refactor. The search query string syntax was specifically verified to properly handle the spaces inside `notes: spam` during graph queries.

**Checklist**

- [x] Documented (Code comments)
