### PR TITLE
fix: add missing -> bool return type annotation to _is_payment_required()

### DIFF
--- a/src/hiero_sdk_python/query/account_balance_query.py
+++ b/src/hiero_sdk_python/query/account_balance_query.py
@@ -172,7 +172,7 @@ class CryptoGetAccountBalanceQuery(Query):
         """
         return response.cryptogetAccountBalance
 
-    def _is_payment_required(self):
+    def _is_payment_required(self) -> bool:
         """
         Account balance query does not require payment.
 


### PR DESCRIPTION
## Summary

Closes #2059

## Changes

Added the missing `-> bool` return type annotation to the `_is_payment_required()` method in `CryptoGetAccountBalanceQuery`.

**Before:**
```python
def _is_payment_required(self):
```

**After:**
```python
def _is_payment_required(self) -> bool:
```

All other methods in this class already have return type annotations. The docstring explicitly documents the return type as `bool`, so this is an unambiguous fix that brings the method in line with the rest of the file.

## Type of change
- [x] Bug fix / minor improvement (non-breaking)