### PR TITLE
Add missing return type annotation to _is_payment_required()

### DIFF
--- a/src/hiero_sdk_python/query/account_balance_query.py
+++ b/src/hiero_sdk_python/query/account_balance_query.py
@@ -172,7 +172,7 @@ class CryptoGetAccountBalanceQuery(Query):
         """
         return response.cryptogetAccountBalance
 
-    def _is_payment_required(self):
+    def _is_payment_required(self) -> bool:
         """
         Account balance query does not require payment.
 


### PR DESCRIPTION
Good day,

## Summary
This PR adds the missing `-> bool` return type annotation to the `_is_payment_required()` method in `CryptoGetAccountBalanceQuery`.

## Problem
The `_is_payment_required()` method at line 175 of `src/hiero_sdk_python/query/account_balance_query.py` was missing its return type annotation, while all other public and private methods in the same class already have complete type annotations.

## Fix
Changed the method signature from:
```python
def _is_payment_required(self):
```
to:
```python
def _is_payment_required(self) -> bool:
```

The return type is unambiguous — the method always returns `False`, which is a `bool`, and this is already documented in the docstring.

## Testing
- Only a single line was changed (adding `-> bool`)
- No changes to docstring, method body, or any other code
- Fix aligns with the existing code style in the same file

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof