### PR TITLE
Add return type annotation -> bool to _is_payment_required()

### DIFF
--- a/src/hiero_sdk_python/query/account_balance_query.py
+++ b/src/hiero_sdk_python/query/account_balance_query.py
@@ -172,7 +172,7 @@ class CryptoGetAccountBalanceQuery(Query):
         """
         return response.cryptogetAccountBalance
 
-    def _is_payment_required(self):
+    def _is_payment_required(self) -> bool:
         """
         Account balance query does not require payment.
 


### PR DESCRIPTION
Fixes issue #2059 - the method always returns False (a bool) but was missing the -> bool return type annotation. Added the correct return type to the method signature.