### PR TITLE
chore: add return type annotation to _is_payment_required in CryptoGetAccountBalanceQuery

### DIFF
--- a/src/hiero_sdk_python/query/account_balance_query.py
+++ b/src/hiero_sdk_python/query/account_balance_query.py
@@ -172,7 +172,7 @@ class CryptoGetAccountBalanceQuery(Query):
         """
         return response.cryptogetAccountBalance
 
-    def _is_payment_required(self):
+    def _is_payment_required(self) -> bool:
         """
         Account balance query does not require payment.
 


### PR DESCRIPTION
## Description
Add the missing `-> bool` return type annotation to the `_is_payment_required()` method in `CryptoGetAccountBalanceQuery`.
This was the only public/private method in the class without a return type annotation. The return type is unambiguous — the method always returns `False`, and the existing docstring already documents it as `bool`.
## Changes
- **File:** `src/hiero_sdk_python/query/account_balance_query.py`
- **Change:** `def _is_payment_required(self):` → `def _is_payment_required(self) -> bool:`
No other files, methods, or lines were modified. SDK behavior is unchanged.
## Testing
- All 13 unit tests in `tests/unit/account_balance_query_test.py` pass ✅
## Related Issue
Closes #2059 