### PR TITLE
Simplify CodeRabbit workflow trigger

### DIFF
--- a/.github/scripts/coderabbit_plan_trigger.js
+++ b/.github/scripts/coderabbit_plan_trigger.js
@@ -2,13 +2,8 @@
 
 const CODERABBIT_MARKER = '<!-- CodeRabbit Plan Trigger -->';
 
-async function triggerCodeRabbitPlan(github, owner, repo, issue, marker = CODERABBIT_MARKER, isDryRun = false) {
+async function triggerCodeRabbitPlan(github, owner, repo, issue, marker = CODERABBIT_MARKER) {
   const comment = `${marker} @coderabbitai plan`;
-
-  if (isDryRun) {
-    console.log(`[DRY RUN] Would trigger CodeRabbit plan for issue #${issue.number}`);
-    return true;
-  }
 
   try {
     await github.rest.issues.createComment({
@@ -105,11 +100,8 @@ async function main({ github, context }) {
       return console.log(`CodeRabbit plan already triggered for #${issue.number}`);
     }
 
-    // Check for dry run (default to true if not specified, for safety)
-    const isDryRun = (process.env.DRY_RUN || 'true').toLowerCase() === 'true';
-
     // Post CodeRabbit plan trigger
-    await triggerCodeRabbitPlan(github, owner, repo, issue, CODERABBIT_MARKER, isDryRun);
+    await triggerCodeRabbitPlan(github, owner, repo, issue, CODERABBIT_MARKER);
 
     logSummary(owner, repo, issue);
   } catch (err) {

--- a/.github/workflows/bot-coderabbit-plan-trigger.yml
+++ b/.github/workflows/bot-coderabbit-plan-trigger.yml
@@ -20,7 +20,7 @@ jobs:
     if: >
       github.event.action == 'labeled' &&
       github.event.issue.state == 'open' &&
-      contains(fromJson('["beginner","intermediate","advanced","Beginner","Intermediate","Advanced"]'), github.event.label.name))
+      contains(fromJson('["beginner","intermediate","advanced","Beginner","Intermediate","Advanced"]'), github.event.label.name)
 
     steps:
       - name: Harden the runner

--- a/.github/workflows/bot-coderabbit-plan-trigger.yml
+++ b/.github/workflows/bot-coderabbit-plan-trigger.yml
@@ -5,16 +5,6 @@ name: CodeRabbit Plan Trigger
 on:
   issues:
     types: [labeled]
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: "Run without posting comments"
-        required: false
-        default: "true"
-        type: choice
-        options:
-          - "true"
-          - "false"
 
 permissions:
   issues: write
@@ -28,8 +18,7 @@ jobs:
       cancel-in-progress: false
     # Only run when the newly added label is beginner, intermediate, or advanced (case-insensitive)
     if: >
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.action == 'labeled' &&
+      github.event.action == 'labeled' &&
       github.event.issue.state == 'open' &&
       contains(fromJson('["beginner","intermediate","advanced","Beginner","Intermediate","Advanced"]'), github.event.label.name))
 
@@ -45,7 +34,6 @@ jobs:
       - name: Trigger CodeRabbit Plan
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9.0.0
         with:
           script: |


### PR DESCRIPTION
# Summary

This PR simplifies the CodeRabbit workflow by removing the manual `workflow_dispatch` path and the dry-run plumbing.

# What changed

- Removed `workflow_dispatch` and its `dry_run` input from `.github/workflows/bot-coderabbit-plan-trigger.yml`
- Simplified the workflow condition so it only runs on labeled issue events
- Removed the `DRY_RUN` env var from the GitHub Actions step
- Removed the dry-run branch from `.github/scripts/coderabbit_plan_trigger.js`
- Kept the named exports intact because another workflow imports them

# Why

Maintainers suggested that the manual dispatch option was unnecessary and confusing because the workflow already has a built-in trigger through issue labels.

# Impact

The workflow now has one clear path: when a qualifying label is added to an open issue, CodeRabbit is triggered automatically. Manual runs no longer appear supported when they are not useful.

# Validation

- Reviewed the resulting diff
- Ran `node --check .github/scripts/coderabbit_plan_trigger.js`

Closes #2190
