### PR TITLE
feat: add user agent header using gRPC interceptor

### DIFF
--- a/src/hiero_sdk_python/channels.py
+++ b/src/hiero_sdk_python/channels.py
@@ -1,4 +1,8 @@
 from __future__ import annotations
+from collections import namedtuple
+from importlib.metadata import PackageNotFoundError, version
+
+import grpc
 
 from hiero_sdk_python.hapi.services import (
     address_book_service_pb2_grpc,
@@ -12,6 +16,84 @@ from hiero_sdk_python.hapi.services import (
     token_service_pb2_grpc,
     util_service_pb2_grpc,
 )
+
+
+class _UserAgentInterceptor(grpc.UnaryUnaryClientInterceptor, grpc.UnaryStreamClientInterceptor):
+    """
+    gRPC interceptor that appends an x-user-agent header to all outgoing requests.
+    """
+
+    _HEADER_KEY = "x-user-agent"
+    _SDK_NAME = "hiero-sdk-python"
+    _CallDetails = namedtuple(
+        "_CallDetails",
+        ("method", "timeout", "metadata", "credentials", "wait_for_ready", "compression"),
+    )
+
+    def __init__(self) -> None:
+        """
+        Initialize the interceptor and compute the user agent value.
+        The user agent is computed once during initialization to avoid repeated package metadata lookups on every request.
+        """
+
+        try:
+            sdk_version = version(self._SDK_NAME)
+        except PackageNotFoundError:
+            sdk_version = "dev"
+        self._user_agent = f"{self._SDK_NAME}/{sdk_version}"
+
+    def _with_user_agent(self, details: grpc.ClientCallDetails) -> grpc.ClientCallDetails:
+        """
+        Append the user agent header to the call details.
+
+        Args:
+            details: The original gRPC call details.
+
+        Returns:
+            A new ClientCallDetails object with the x-user-agent header included in the metadata.
+        """
+        metadata = [] if details.metadata is None else list(details.metadata)
+        metadata = [entry for entry in metadata if entry[0] != self._HEADER_KEY]
+        metadata.append((self._HEADER_KEY, self._user_agent))
+
+        return self._CallDetails(
+            details.method,
+            details.timeout,
+            metadata,
+            getattr(details, "credentials", None),
+            getattr(details, "wait_for_ready", None),
+            getattr(details, "compression", None),
+        )
+
+    def intercept_unary_unary(self, continuation, client_call_details, request):
+        """
+        Intercept unary-unary calls and append the user agent header.
+
+        Args:
+            continuation: The gRPC continuation function to call the next interceptor or actual RPC.
+            client_call_details: The details of the gRPC call, including method, timeout, metadata, etc.
+            request: The request object being sent.
+
+        Returns:
+            The result of the gRPC call after appending the user agent header.
+        """
+
+        return continuation(self._with_user_agent(client_call_details), request)
+
+    def intercept_unary_stream(self, continuation, client_call_details, request):
+        """
+        Intercept unary-stream calls and append the user agent header.
+
+        Args:
+            continuation: The gRPC continuation function to call the next interceptor or actual RPC.
+            client_call_details: The details of the gRPC call, including method, timeout, metadata, etc.
+            request: The request object being sent.
+
+        Returns:
+            The result of the gRPC call after appending the user agent header.
+        """
+
+        return continuation(self._with_user_agent(client_call_details), request)
 
 
 class _Channel:

--- a/src/hiero_sdk_python/channels.py
+++ b/src/hiero_sdk_python/channels.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from collections import namedtuple
 from importlib.metadata import PackageNotFoundError, version
 

--- a/src/hiero_sdk_python/client/client.py
+++ b/src/hiero_sdk_python/client/client.py
@@ -18,6 +18,7 @@ from hiero_sdk_python.hapi.mirror import (
 )
 from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.logger.logger import Logger, LogLevel
+from hiero_sdk_python.node import _UserAgentInterceptor
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 from .network import Network
@@ -163,6 +164,8 @@ class Client:
             self.mirror_channel = grpc.secure_channel(mirror_address, grpc.ssl_channel_credentials())
         else:
             self.mirror_channel = grpc.insecure_channel(mirror_address)
+
+        self.mirror_channel = grpc.intercept_channel(self.mirror_channel, _UserAgentInterceptor())
         self.mirror_stub = mirror_consensus_grpc.ConsensusServiceStub(self.mirror_channel)
 
     def set_operator(self, account_id: AccountId, private_key: PrivateKey) -> None:

--- a/src/hiero_sdk_python/client/client.py
+++ b/src/hiero_sdk_python/client/client.py
@@ -18,7 +18,7 @@ from hiero_sdk_python.hapi.mirror import (
 )
 from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.logger.logger import Logger, LogLevel
-from hiero_sdk_python.node import _UserAgentInterceptor
+from hiero_sdk_python.channels import _UserAgentInterceptor
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 from .network import Network

--- a/src/hiero_sdk_python/client/client.py
+++ b/src/hiero_sdk_python/client/client.py
@@ -12,13 +12,13 @@ import grpc
 from dotenv import load_dotenv
 
 from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.channels import _UserAgentInterceptor
 from hiero_sdk_python.crypto.private_key import PrivateKey
 from hiero_sdk_python.hapi.mirror import (
     consensus_service_pb2_grpc as mirror_consensus_grpc,
 )
 from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.logger.logger import Logger, LogLevel
-from hiero_sdk_python.channels import _UserAgentInterceptor
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 from .network import Network

--- a/src/hiero_sdk_python/node.py
+++ b/src/hiero_sdk_python/node.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from collections import namedtuple
 import hashlib
-from importlib.metadata import PackageNotFoundError, version
 import socket
 import ssl  # Python's ssl module implements TLS (despite the name)
 import time
@@ -11,48 +9,12 @@ import grpc
 
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.address_book.node_address import NodeAddress
-from hiero_sdk_python.channels import _Channel
+from hiero_sdk_python.channels import _Channel, _UserAgentInterceptor
 from hiero_sdk_python.managed_node_address import _ManagedNodeAddress
 
 
 # Timeout for fetching server certificates during TLS validation
 CERT_FETCH_TIMEOUT_SECONDS = 10
-
-
-class _UserAgentInterceptor(grpc.UnaryUnaryClientInterceptor, grpc.UnaryStreamClientInterceptor):
-    _HEADER_KEY = "x-user-agent"
-    _SDK_NAME = "hiero-sdk-python"
-    _CallDetails = namedtuple(
-        "_CallDetails",
-        ("method", "timeout", "metadata", "credentials", "wait_for_ready", "compression"),
-    )
-
-    def _user_agent_value(self) -> str:
-        try:
-            sdk_version = version(self._SDK_NAME)
-        except PackageNotFoundError:
-            sdk_version = "dev"
-
-        return f"{self._SDK_NAME}/{sdk_version}"
-
-    def _with_user_agent(self, details: grpc.ClientCallDetails) -> grpc.ClientCallDetails:
-        metadata = [] if details.metadata is None else list(details.metadata)
-        metadata.append((self._HEADER_KEY, self._user_agent_value()))
-
-        return self._CallDetails(
-            details.method,
-            details.timeout,
-            metadata,
-            getattr(details, "credentials", None),
-            getattr(details, "wait_for_ready", None),
-            getattr(details, "compression", None),
-        )
-
-    def intercept_unary_unary(self, continuation, client_call_details, request):
-        return continuation(self._with_user_agent(client_call_details), request)
-
-    def intercept_unary_stream(self, continuation, client_call_details, request):
-        return continuation(self._with_user_agent(client_call_details), request)
 
 
 class _HederaTrustManager:

--- a/src/hiero_sdk_python/node.py
+++ b/src/hiero_sdk_python/node.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from collections import namedtuple
 import hashlib
+from importlib.metadata import PackageNotFoundError, version
 import socket
 import ssl  # Python's ssl module implements TLS (despite the name)
 import time
@@ -15,6 +17,42 @@ from hiero_sdk_python.managed_node_address import _ManagedNodeAddress
 
 # Timeout for fetching server certificates during TLS validation
 CERT_FETCH_TIMEOUT_SECONDS = 10
+
+
+class _UserAgentInterceptor(grpc.UnaryUnaryClientInterceptor, grpc.UnaryStreamClientInterceptor):
+    _HEADER_KEY = "x-user-agent"
+    _SDK_NAME = "hiero-sdk-python"
+    _CallDetails = namedtuple(
+        "_CallDetails",
+        ("method", "timeout", "metadata", "credentials", "wait_for_ready", "compression"),
+    )
+
+    def _user_agent_value(self) -> str:
+        try:
+            sdk_version = version(self._SDK_NAME)
+        except PackageNotFoundError:
+            sdk_version = "dev"
+
+        return f"{self._SDK_NAME}/{sdk_version}"
+
+    def _with_user_agent(self, details: grpc.ClientCallDetails) -> grpc.ClientCallDetails:
+        metadata = [] if details.metadata is None else list(details.metadata)
+        metadata.append((self._HEADER_KEY, self._user_agent_value()))
+
+        return self._CallDetails(
+            details.method,
+            details.timeout,
+            metadata,
+            getattr(details, "credentials", None),
+            getattr(details, "wait_for_ready", None),
+            getattr(details, "compression", None),
+        )
+
+    def intercept_unary_unary(self, continuation, client_call_details, request):
+        return continuation(self._with_user_agent(client_call_details), request)
+
+    def intercept_unary_stream(self, continuation, client_call_details, request):
+        return continuation(self._with_user_agent(client_call_details), request)
 
 
 class _HederaTrustManager:
@@ -146,6 +184,8 @@ class _Node:
             channel = grpc.secure_channel(str(self._address), credentials, options=options)
         else:
             channel = grpc.insecure_channel(str(self._address))
+
+        channel = grpc.intercept_channel(channel, _UserAgentInterceptor())
 
         self._channel = _Channel(channel)
 

--- a/tests/unit/channel_interceptor_test.py
+++ b/tests/unit/channel_interceptor_test.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import grpc
 import pytest
 
-from hiero_sdk_python import node
-from hiero_sdk_python.node import _UserAgentInterceptor
+from hiero_sdk_python import channels
+from hiero_sdk_python.channels import _UserAgentInterceptor
 
 
 pytestmark = pytest.mark.unit
@@ -30,28 +31,28 @@ class _DummyCallDetails:
 def test_user_agent_value_from_installed_version(monkeypatch):
     """Interceptor should build x-user-agent from package version when available."""
 
-    monkeypatch.setattr(node, "version", lambda _name: "0.0.0")
+    monkeypatch.setattr(channels, "version", lambda _name: "0.0.0")
 
     interceptor = _UserAgentInterceptor()
-    assert interceptor._user_agent_value() == "hiero-sdk-python/0.0.0"
+    assert interceptor._user_agent == "hiero-sdk-python/0.0.0"
 
 
 def test_user_agent_value_falls_back_to_dev(monkeypatch):
     """Interceptor should fall back to dev when package metadata is unavailable."""
 
     def _raise_not_found(_name):
-        raise node.PackageNotFoundError
+        raise channels.PackageNotFoundError
 
-    monkeypatch.setattr(node, "version", _raise_not_found)
+    monkeypatch.setattr(channels, "version", _raise_not_found)
 
     interceptor = _UserAgentInterceptor()
-    assert interceptor._user_agent_value() == "hiero-sdk-python/dev"
+    assert interceptor._user_agent == "hiero-sdk-python/dev"
 
 
 def test_intercept_unary_unary_appends_user_agent_metadata(monkeypatch):
     """Unary calls should forward metadata including x-user-agent."""
 
-    monkeypatch.setattr(node, "version", lambda _name: "0.0.0")
+    monkeypatch.setattr(channels, "version", lambda _name: "0.0.0")
 
     interceptor = _UserAgentInterceptor()
     request = object()
@@ -75,7 +76,7 @@ def test_intercept_unary_unary_appends_user_agent_metadata(monkeypatch):
 def test_intercept_unary_stream_adds_metadata_when_none(monkeypatch):
     """Unary-stream calls should work even when original metadata is None."""
 
-    monkeypatch.setattr(node, "version", lambda _name: "0.0.0")
+    monkeypatch.setattr(channels, "version", lambda _name: "0.0.0")
 
     interceptor = _UserAgentInterceptor()
     request = object()
@@ -93,3 +94,10 @@ def test_intercept_unary_stream_adds_metadata_when_none(monkeypatch):
     assert captured["request"] is request
     expected_header = (interceptor._HEADER_KEY, f"{interceptor._SDK_NAME}/0.0.0")
     assert captured["details"].metadata == [expected_header]
+
+
+def test_interceptor_implements_required_grpc_interfaces():
+    """Guard against accidental loss of gRPC interceptor interface inheritance."""
+    interceptor = _UserAgentInterceptor()
+    assert isinstance(interceptor, grpc.UnaryUnaryClientInterceptor)
+    assert isinstance(interceptor, grpc.UnaryStreamClientInterceptor)

--- a/tests/unit/channel_interceptor_test.py
+++ b/tests/unit/channel_interceptor_test.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import pytest
+
+from hiero_sdk_python import node
+from hiero_sdk_python.node import _UserAgentInterceptor
+
+
+pytestmark = pytest.mark.unit
+
+
+class _DummyCallDetails:
+    def __init__(
+        self,
+        metadata=None,
+        method: str = "/proto.Service/Method",
+        timeout: float | None = None,
+        credentials=None,
+        wait_for_ready: bool | None = None,
+        compression=None,
+    ):
+        self.method = method
+        self.timeout = timeout
+        self.metadata = metadata
+        self.credentials = credentials
+        self.wait_for_ready = wait_for_ready
+        self.compression = compression
+
+
+def test_user_agent_value_from_installed_version(monkeypatch):
+    """Interceptor should build x-user-agent from package version when available."""
+
+    monkeypatch.setattr(node, "version", lambda _name: "0.0.0")
+
+    interceptor = _UserAgentInterceptor()
+    assert interceptor._user_agent_value() == "hiero-sdk-python/0.0.0"
+
+
+def test_user_agent_value_falls_back_to_dev(monkeypatch):
+    """Interceptor should fall back to dev when package metadata is unavailable."""
+
+    def _raise_not_found(_name):
+        raise node.PackageNotFoundError
+
+    monkeypatch.setattr(node, "version", _raise_not_found)
+
+    interceptor = _UserAgentInterceptor()
+    assert interceptor._user_agent_value() == "hiero-sdk-python/dev"
+
+
+def test_intercept_unary_unary_appends_user_agent_metadata(monkeypatch):
+    """Unary calls should forward metadata including x-user-agent."""
+
+    monkeypatch.setattr(node, "version", lambda _name: "0.0.0")
+
+    interceptor = _UserAgentInterceptor()
+    request = object()
+    captured = {}
+
+    def continuation(client_call_details, req):
+        captured["details"] = client_call_details
+        captured["request"] = req
+        return "ok"
+
+    details = _DummyCallDetails(metadata=[("existing", "value")])
+    result = interceptor.intercept_unary_unary(continuation, details, request)
+
+    assert result == "ok"
+    assert captured["request"] is request
+    assert ("existing", "value") in captured["details"].metadata
+    expected_header = (interceptor._HEADER_KEY, f"{interceptor._SDK_NAME}/0.0.0")
+    assert expected_header in captured["details"].metadata
+
+
+def test_intercept_unary_stream_adds_metadata_when_none(monkeypatch):
+    """Unary-stream calls should work even when original metadata is None."""
+
+    monkeypatch.setattr(node, "version", lambda _name: "0.0.0")
+
+    interceptor = _UserAgentInterceptor()
+    request = object()
+    captured = {}
+
+    def continuation(client_call_details, req):
+        captured["details"] = client_call_details
+        captured["request"] = req
+        return "stream"
+
+    details = _DummyCallDetails(metadata=None)
+    result = interceptor.intercept_unary_stream(continuation, details, request)
+
+    assert result == "stream"
+    assert captured["request"] is request
+    expected_header = (interceptor._HEADER_KEY, f"{interceptor._SDK_NAME}/0.0.0")
+    assert captured["details"].metadata == [expected_header]


### PR DESCRIPTION
**Description**:
Added gRPC client interceptor, `_UserAgentInterceptor`, which adds an `x-user-agent` header to all outgoing gRPC requests, identifying the SDK and its version. 

**Related issue(s)**:

Fixes #2169 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
