### PR TITLE
fix(crypto): correct ECDSA hash mismatch by removing keccak usage

### DIFF
--- a/src/hiero_sdk_python/crypto/private_key.py
+++ b/src/hiero_sdk_python/crypto/private_key.py
@@ -283,8 +283,11 @@ class PrivateKey(Key):
             # Ed25519 automatically handles the hashing internally
             return self._private_key.sign(data)
 
-        data_hash = keccak256(data)
-        signature_der = self._private_key.sign(data_hash, ec.ECDSA(asym_utils.Prehashed(hashes.SHA256())))
+        # ECDSA (secp256k1) uses SHA-256 for hashing during signing
+        signature_der = self._private_key.sign(
+            data,
+            ec.ECDSA(hashes.SHA256())
+        )
         r, s = asym_utils.decode_dss_signature(signature_der)
         return r.to_bytes(32, "big") + s.to_bytes(32, "big")
 


### PR DESCRIPTION
Fix mismatch between hashing algorithm and ECDSA signing.

Previously, data was hashed using Keccak-256 but passed to the cryptography
library as Prehashed(SHA256), leading to inconsistent and incorrect signature behavior.

This change removes manual Keccak hashing and lets the cryptography library
handle hashing internally using SHA-256, ensuring correctness.

Changes:
- Removed keccak256 hashing
- Removed incorrect Prehashed(SHA256) usage
- Use ec.ECDSA(hashes.SHA256()) directly

---

**Related issue(s)**:

Fixes #2198

---

**Notes for reviewer**:
- This change aligns hashing with the declared algorithm
- No changes to Ed25519 behavior
- Improves cryptographic correctness and consistency

---

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (basic validation of signing flow)