### PR TITLE
Fix: close consensus node gRPC channels in Client.close()

### DIFF
--- a/src/hiero_sdk_python/client/client.py
+++ b/src/hiero_sdk_python/client/client.py
@@ -200,11 +200,17 @@ class Client:
         Closes any open gRPC channels and frees resources.
         Call this when you are done using the Client to ensure a clean shutdown.
         """
+        # Close mirror channel
         if self.mirror_channel is not None:
             self.mirror_channel.close()
             self.mirror_channel = None
 
         self.mirror_stub = None
+
+        # Fix: Close all consensus node channels
+        if self.network and self.network.nodes:
+            for node in self.network.nodes:
+                node._close()
 
     def set_transport_security(self, enabled: bool) -> Client:
         """


### PR DESCRIPTION
**Description**:
Fix resource leak in Client.close() by closing all consensus node gRPC channels.

Previously, `Client.close()` only closed the mirror node channel, leaving all
consensus node channels (`_Node._channel`) open. This caused lingering gRPC
connections even when using the client as a context manager.

### Changes
* Close all `_Node._channel` instances in `client.network.nodes`
* Ensure proper cleanup of all gRPC resources on `Client.close()`
* Prevent connection leaks and improve resource management


Fixes #2202 

**Notes for reviewer**:
- Verified that all gRPC channels are closed after calling `client.close()`
- Tested using context manager (`with Client(...)`)
- No runtime errors observed after cleanup

**Checklist**

- [x] Documented (Code comments added)
- [x] Tested (basic manual testing with client lifecycle)
