### PR TITLE
docs: create starter roadmap doc

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,21 +4,21 @@ This is a high-level quarterly roadmap for the Hiero SDK Python project. It is a
 
 ---
 
-## Quarter 1 (Underway)
+## 2026 Q1 (Underway)
 
-- TCK and fuzzing tests implementation
-- Static workflow tests
+- Implement [TCK](/tck) and [fuzzing tests](/tests/fuzz)
+- Implement [static workflow tests](/.github/workflows/)
 
-## Quarter 2
+## 2026 Q2
 
-- Complete TCK tests
+- Complete [TCK](/tck) tests
 - Implement 2 new HIPs
 
-## Quarter 3
+## 2026 Q3
 
 - Improve core functionality robustness
 - Implement 2 new HIPs
 
-## Quarter 4
+## 2026 Q4
 
 - Focus on remaining HIP implementations

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,24 @@
+# Hiero SDK Python — Roadmap
+
+This is a high-level quarterly roadmap for the Hiero SDK Python project. It is a living document, updated during team discussions.
+
+---
+
+## Quarter 1 (Underway)
+
+- TCK and fuzzing tests implementation
+- Static workflow tests
+
+## Quarter 2
+
+- Complete TCK tests
+- Implement 2 new HIPs
+
+## Quarter 3
+
+- Improve core functionality robustness
+- Implement 2 new HIPs
+
+## Quarter 4
+
+- Focus on remaining HIP implementations


### PR DESCRIPTION
Closes #2146

**Description**:
Create a starter roadmap document outlining quarterly goals for the Hiero SDK Python project.

* Add `docs/roadmap.md` with high-level quarterly planning and goals

**Related issue(s)**:

Fixes #2146

**Notes for reviewer**:
Brief, living document as requested in the issue — intended to be updated during team discussions. No code changes.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
