### PR TITLE
chore: update spam list

### DIFF
--- a/.github/spam-list.txt
+++ b/.github/spam-list.txt
@@ -11,3 +11,4 @@ shixian-HFUT
 Yuki9814
 ashrafzunaira18
 HrachShah
+fauds-dev101


### PR DESCRIPTION
Adds `fauds-dev101` to the spam list as required in issue #2217.

Only `.github/spam-list.txt` was modified. No other changes included.