### PR TITLE
docs: fix broken markdown links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ We welcome blog posts! Whether you're sharing a tutorial, case study, or your ex
 | [Setup](docs/sdk_developers/setup.md) | Fork, clone, install, configure |
 | [Workflow](docs/sdk_developers/workflow.md) | Branching, committing, PRs |
 | [Signing](https://github.com/hiero-ledger/sdk-collaboration-hub/blob/main/guides/issue-progression/for-developers/signing.md) | GPG + DCO commit signing |
-| [Checklist](docs/sdk_developers/checklist.md) | Pre-submission checklist |
+| [Checklist](docs/sdk_developers/testing.md#testing-checklist-for-contributors) | Pre-submission checklist |
 | [Rebasing](https://github.com/hiero-ledger/sdk-collaboration-hub/blob/main/guides/issue-progression/for-developers/rebasing.md) | Keeping branch updated |
 | [Merge Conflicts](https://github.com/hiero-ledger/sdk-collaboration-hub/blob/main/guides/issue-progression/for-developers/merge_conflicts.md) | Resolving conflicts |
 | [Types](docs/sdk_developers/types.md) | Python type hints |

--- a/docs/sdk_developers/pylance.md
+++ b/docs/sdk_developers/pylance.md
@@ -370,7 +370,7 @@ Before every PR:
 
 * [Hiero SDK Contributing Guide](https://github.com/hiero-ledger/hiero-sdk-python/blob/main/CONTRIBUTING.md)
 
-* [Hiero SDK CHANGELOG](https://github.com/hiero-ledger/hiero-sdk-python/blob/main/CHANGELOG.md)
+* [Hiero SDK Releases](https://github.com/hiero-ledger/hiero-sdk-python/releases)
 
 
 

--- a/docs/team.md
+++ b/docs/team.md
@@ -24,8 +24,6 @@ GitHub IDs and names are provided as listed on GitHub.
 | Mounil2005 | @Mounil2005 |
 | cheese-cakee | @cheese-cakee |
 
-[View Triage Team on GitHub](https://github.com/orgs/hiero-ledger/teams/hiero-sdk-python-triage)
-
 ## Committer Members
 
 **Committer members** have write access. Their responsibilities include: creating and laddering issues to incrementally train developers, reviewing pull requests to ensure they meet project standards, and actively contributing code for the benefit of the Python SDK.
@@ -40,8 +38,6 @@ GitHub IDs and names are provided as listed on GitHub.
 | Akshat | @Akshat8510 |
 | Nadine Loepfe | @nadineloepfe |
 
-[View Committer Team on GitHub](https://github.com/orgs/hiero-ledger/teams/hiero-sdk-python-committers)
-
 ## Maintainer Members
 
 **Maintainer members** have special write access. Their responsibilities include: provide technical leadership for the SDK, provide leadership on the overall health and direction of the project to ensure it satisfies various scaling and stakeholder needs. They also ensure a welcoming and nourishing environment for all developers and community members, laddering issues, reviewing pull requests and actively contributing code for the benefit of the Python SDK.
@@ -51,7 +47,5 @@ GitHub IDs and names are provided as listed on GitHub.
 | Manish Dait | @manishdait |
 | Sophie Bulloch | @exploreriii |
 | Nadine Loepfe | @nadineloepfe |
-
-[View Maintainer Team on GitHub](https://github.com/orgs/hiero-ledger/teams/hiero-sdk-python-maintainers)
 
 Read more at [MAINTAINERS.md](https://github.com/hiero-ledger/hiero-sdk-python/blob/main/MAINTAINERS.md)


### PR DESCRIPTION
Fixes #2216.

## Summary
- Update the missing checklist link to the existing testing checklist anchor
- Replace the missing CHANGELOG link with the repository Releases page
- Remove private GitHub team links from the public team page

## Testing
- Verified replacement Releases URL returns HTTP 200
- Verified the testing checklist heading exists in docs/sdk_developers/testing.md