### PR TITLE
fix(ci): align linked issue grace period with documented policy

### DIFF
--- a/.github/scripts/cron-enforcer-pr-linked-issue.js
+++ b/.github/scripts/cron-enforcer-pr-linked-issue.js
@@ -1,8 +1,8 @@
-// A script to  closes pull requests without a linked issue after 12 hours automatically.
+// A script to  closes pull requests without a linked issue after 24 hours automatically.
 
 // dryRun env var: any case-insensitive 'true' value will enable dry-run
 const dryRun = (process.env.DRY_RUN || 'false').toString().toLowerCase() === 'true';
-const hoursBeforeClose = parseInt(process.env.HOURS_BEFORE_CLOSE || '12', 10);
+const hoursBeforeClose = parseInt(process.env.HOURS_BEFORE_CLOSE || '24', 10);
 const requireAuthorAssigned = (process.env.REQUIRE_AUTHOR_ASSIGNED || 'true').toLowerCase() === 'true';
 
 const getHoursOpen = (pr) =>

--- a/.github/workflows/cron-enforcer-pr-linked-issue.yml
+++ b/.github/workflows/cron-enforcer-pr-linked-issue.yml
@@ -1,4 +1,4 @@
-# This workflow automatically closes pull requests without a linked issue after 3 days.
+# This workflow automatically closes pull requests without a linked issue after 1 day.
 
 name: Linked Issue Enforcer
 
@@ -33,7 +33,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRY_RUN: ${{ env.DRY_RUN }}
-          HOURS_BEFORE_CLOSE: "12"
+          HOURS_BEFORE_CLOSE: "24"
           REQUIRE_AUTHOR_ASSIGNED: "true"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9.0.0
         with:


### PR DESCRIPTION
## Summary

Align the linked-issue enforcer workflow configuration with the documented 1-day grace period.

The workflow currently states that PRs without linked issues are automatically closed after 3 days, but the workflow passes `HOURS_BEFORE_CLOSE: "12"` to the enforcement script, causing PRs to potentially close after 12 hours instead.

This change updates the workflow env value to `24` so runtime behavior matches the documented policy.

Closes #2243 