### PR TITLE
fix: handle beginner label in triage workflow

### DIFF
--- a/.github/workflows/request-triage-review.yml
+++ b/.github/workflows/request-triage-review.yml
@@ -14,8 +14,11 @@ permissions:
 
 jobs:
   request-triage:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'Good First Issue') || contains(github.event.pull_request.labels.*.name, 'skill: beginner') || contains(github.event.pull_request.labels.*.name, 'beginner') }}
-    runs-on: [self-hosted,hl-sdk-py-lin-md]
+    if: >
+      contains(github.event.pull_request.labels.*.name, 'Good First Issue') ||
+      contains(github.event.pull_request.labels.*.name, 'skill: beginner') ||
+      contains(github.event.pull_request.labels.*.name, 'beginner')
+    runs-on: [self-hosted, hl-sdk-py-lin-md]
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -29,15 +32,15 @@ jobs:
           script: |
             const tag = "<!-- triage -->";
             const { data: comments } = await github.rest.issues.listComments({
-                                         owner: context.repo.owner,
-                                         repo: context.repo.repo,
-                                         issue_number: context.payload.pull_request.number
-                                    });
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number
+            });
             if (!comments.some(c => c.body?.includes(tag))) {
-                await github.rest.issues.createComment({
-                 owner: context.repo.owner,
-                  repo: context.repo.repo,
-                   issue_number: context.payload.pull_request.number,
-             body: `${tag} Requesting triage review from: @hiero-ledger/hiero-sdk-python-triage`
-               });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: `${tag} Requesting triage review from: @hiero-ledger/hiero-sdk-python-triage`
+              });
             }


### PR DESCRIPTION
**Description**:

Fix the triage review workflow condition for beginner labeled PRs.

* Remove the redundant `${{ }}` wrapper from the job-level `if` condition
* Add support for the `skill: beginner` label in the triage review workflow
* Preserve the existing `Good First Issue` and `beginner` label checks
* Format the workflow condition and GitHub script block for readability

**Related issue(s)**:

Fixes #2227

**Notes for reviewer**:

This is a CI workflow only change. GitHub Actions evaluates job-level `if:` conditions as expressions by default, so removing the wrapper avoids YAML parsing issues with labels containing a colon, such as `skill: beginner`.

Validated locally:
* Parsed `.github/workflows/request-triage-review.yml` with Python YAML loading
* Ran `actionlint` with the repository’s custom self-hosted runner label warning ignored

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
