### PR TITLE
fix: grant write permissions for review queue sync

### DIFF
--- a/.github/workflows/review-sync.yml
+++ b/.github/workflows/review-sync.yml
@@ -23,7 +23,7 @@ on:
         type: string
 
 permissions:
-  pull-requests: read
+  pull-requests: write
   issues: write
   contents: read
 


### PR DESCRIPTION
**Description**:
Adds `pull-requests: write`  permissions to `review-sync.yml` to resolve the `403 Resource not accessible by integration` error encountered during the label sync phase.

**Notes for reviewer**:
Opening a follow-up PR specifically to fix the missing GitHub Actions permissions we discussed. 

**Checklist**
- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
