### PR TITLE
fix: Harden review-sync pipeline and resolve reviewer feedback

### DIFF
--- a/.github/scripts/review-sync/helpers/constants.js
+++ b/.github/scripts/review-sync/helpers/constants.js
@@ -35,11 +35,20 @@ const QUEUE_LABELS = {
   MERGE: {
     name: 'status: ready-to-merge',
     color: '0e8a16',
-    description: 'PR has 1+ maintainer and 2+ total approvals, ready to merge',
+    description: 'PR has 1+ maintainer and 2+ core (committer/maintainer) approvals, ready to merge',
   },
 };
 
 /** All queue label names, used for cleanup operations. */
 const ALL_QUEUE_LABEL_NAMES = Object.values(QUEUE_LABELS).map((l) => l.name);
 
-module.exports = { RATE_LIMIT_FLOOR, QUEUE_LABELS, ALL_QUEUE_LABEL_NAMES };
+/**
+ * The permanent community review label appended to all open PRs.
+ */
+const COMMUNITY_REVIEW = {
+  name: 'open to community review',
+  color: '008672',
+  description: 'PR is open for community review and feedback',
+};
+
+module.exports = { RATE_LIMIT_FLOOR, QUEUE_LABELS, ALL_QUEUE_LABEL_NAMES, COMMUNITY_REVIEW };

--- a/.github/scripts/review-sync/helpers/labels.js
+++ b/.github/scripts/review-sync/helpers/labels.js
@@ -55,17 +55,17 @@ async function ensureLabel(github, owner, repo, label, dryRun) {
 
 /**
  * Check if the latest CI runs for a given commit have any failures.
- * 
+ *
  * We intentionally treat the following as failures:
  * - 'failure', 'timed_out' (explicit test failures)
  * - 'startup_failure' (e.g., invalid workflow YAML)
  * - 'action_required' (e.g., waiting for maintainer approval for first-time contributors)
- * 
+ *
  * We intentionally EXCLUDE 'cancelled':
- * When a developer pushes a new commit, GitHub automatically cancels the currently 
- * running workflows. If we treated 'cancelled' as a failure, every re-push would 
+ * When a developer pushes a new commit, GitHub automatically cancels the currently
+ * running workflows. If we treated 'cancelled' as a failure, every re-push would
  * instantly demote the PR to queue:junior-committer, frustrating contributors.
- * 
+ *
  * @returns {boolean} true if any check run conclusion is a blocking failure.
  */
 async function hasCIFailures(github, owner, repo, sha) {
@@ -80,8 +80,8 @@ async function hasCIFailures(github, owner, repo, sha) {
     });
 
     return checkRuns.some(
-      run => 
-        run.conclusion === 'failure' || 
+      run =>
+        run.conclusion === 'failure' ||
         run.conclusion === 'timed_out' ||
         run.conclusion === 'startup_failure' ||
         run.conclusion === 'action_required'

--- a/.github/scripts/review-sync/helpers/labels.js
+++ b/.github/scripts/review-sync/helpers/labels.js
@@ -55,18 +55,36 @@ async function ensureLabel(github, owner, repo, label, dryRun) {
 
 /**
  * Check if the latest CI runs for a given commit have any failures.
- * Returns true if any check run conclusion is 'failure' or 'timed_out'.
+ * 
+ * We intentionally treat the following as failures:
+ * - 'failure', 'timed_out' (explicit test failures)
+ * - 'startup_failure' (e.g., invalid workflow YAML)
+ * - 'action_required' (e.g., waiting for maintainer approval for first-time contributors)
+ * 
+ * We intentionally EXCLUDE 'cancelled':
+ * When a developer pushes a new commit, GitHub automatically cancels the currently 
+ * running workflows. If we treated 'cancelled' as a failure, every re-push would 
+ * instantly demote the PR to queue:junior-committer, frustrating contributors.
+ * 
+ * @returns {boolean} true if any check run conclusion is a blocking failure.
  */
 async function hasCIFailures(github, owner, repo, sha) {
   try {
-    const { data } = await github.rest.checks.listForRef({
+    // We MUST use paginate, otherwise it silently truncates at 30 runs.
+    // Matrix builds often exceed 30 checks.
+    const checkRuns = await github.paginate(github.rest.checks.listForRef, {
       owner,
       repo,
       ref: sha,
       filter: 'latest'
     });
-    return data.check_runs.some(
-      run => run.conclusion === 'failure' || run.conclusion === 'timed_out'
+
+    return checkRuns.some(
+      run => 
+        run.conclusion === 'failure' || 
+        run.conclusion === 'timed_out' ||
+        run.conclusion === 'startup_failure' ||
+        run.conclusion === 'action_required'
     );
   } catch (error) {
     // Fail securely: do not assume CI is passing if we cannot verify it.

--- a/.github/scripts/review-sync/helpers/labels.js
+++ b/.github/scripts/review-sync/helpers/labels.js
@@ -10,7 +10,7 @@
 //   - syncLabel() adds the correct label FIRST, then removes stale ones
 //     (crash-safe: PR never has zero queue labels)
 
-const { QUEUE_LABELS, ALL_QUEUE_LABEL_NAMES } = require('./constants');
+const { QUEUE_LABELS, ALL_QUEUE_LABEL_NAMES, COMMUNITY_REVIEW } = require('./constants');
 const { countApprovals } = require('./permissions');
 
 /**
@@ -54,26 +54,63 @@ async function ensureLabel(github, owner, repo, label, dryRun) {
 }
 
 /**
+ * Check if the latest CI runs for a given commit have any failures.
+ * Returns true if any check run conclusion is 'failure' or 'timed_out'.
+ */
+async function hasCIFailures(github, owner, repo, sha) {
+  try {
+    const { data } = await github.rest.checks.listForRef({
+      owner,
+      repo,
+      ref: sha,
+      filter: 'latest'
+    });
+    return data.check_runs.some(
+      run => run.conclusion === 'failure' || run.conclusion === 'timed_out'
+    );
+  } catch (error) {
+    // Fail securely: do not assume CI is passing if we cannot verify it.
+    // Throwing ensures this PR skips sync and the workflow registers an error.
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`    ✗ Failed to fetch CI checks for ${sha}: ${message}`);
+    throw error;
+  }
+}
+
+/**
  * Determine the correct queue label for a PR based on approval counts.
  *
- * Phase 1 logic (4-stage pipeline):
- *   maintainerApproval >= 1 AND (maintainerApproval + writeApproval) >= 2  → status: ready-to-merge      (CODEOWNERS + min core reviews)
- *   writeApproval >= 1 OR maintainerApproval >= 1 → queue:maintainers   (senior review present, needs more)
- *   anyApproval >= 1                               → queue:committers    (has any approval, needs committer)
- *   else                                           → queue:junior-committer (no approvals yet)
+ * Phase 1 logic (5-stage pipeline):
+ *   ciFailing                                        → queue:junior-committer (CI broken, block promotion)
+ *   maintainerApprovals >= 1 AND coreApprovals >= 2  → status: ready-to-merge (CODEOWNERS + min core reviews)
+ *   maintainerApprovals >= 1 (but coreApprovals < 2) → queue:committers      (maintainer already in, need committer next)
+ *   coreApprovals >= 1 (no maintainer yet)            → queue:maintainers     (committer reviewed, needs maintainer)
+ *   anyApproval >= 1                                 → queue:committers      (has soft approval, needs committer)
+ *   else                                             → queue:junior-committer (no approvals yet)
  *
- * Note: status: ready-to-merge requires BOTH a maintainer approval AND at least 2
- * total core reviews (maintainer or write). This prevents a single maintainer approval
+ * Note: When a maintainer "jumps in early" before triage/committers, the PR should
+ * route to queue:committers (not queue:maintainers) to attract a committer review
+ * rather than a second maintainer. This prevents wasting maintainer bandwidth.
+ *
+ * status: ready-to-merge requires BOTH a maintainer approval AND at least 2
+ * total core reviews (maintainer or committer). This prevents a single maintainer approval
  * + a soft approval from marking a PR as ready when branch protection requires 2+ core reviews.
  *
- * @param {{ maintainerApproval: number, writeApproval: number, softApproval: number, anyApproval: number }} approvals
+ * @param {{ maintainerApprovals: number, coreApprovals: number, softApprovals: number, anyApproval: number }} approvals
+ * @param {boolean} ciFailing - If true, automatically demotes PR to queue:junior-committer
  * @returns {object} The correct QUEUE_LABELS entry
  */
-function determineLabel(approvals) {
-  if (approvals.maintainerApproval >= 1 && (approvals.maintainerApproval + approvals.writeApproval) >= 2) {
+function determineLabel(approvals, ciFailing = false) {
+  if (ciFailing) {
+    return QUEUE_LABELS.JUNIOR;
+  }
+  if (approvals.maintainerApprovals >= 1 && approvals.coreApprovals >= 2) {
     return QUEUE_LABELS.MERGE;
   }
-  if (approvals.writeApproval >= 1 || approvals.maintainerApproval >= 1) {
+  if (approvals.maintainerApprovals >= 1) {
+    return QUEUE_LABELS.COMMITTERS;
+  }
+  if (approvals.coreApprovals >= 1) {
     return QUEUE_LABELS.MAINTAINERS;
   }
   if (approvals.anyApproval >= 1) {
@@ -106,15 +143,16 @@ async function syncLabel(github, owner, repo, pr, dryRun) {
   const prNumber = pr.number;
   const currentLabels = (pr.labels || []).map((l) => l.name);
 
-  // Count approvals and determine the correct label
+  // Count approvals and check CI status
   const approvals = await countApprovals(github, owner, repo, prNumber);
-  const correctLabel = determineLabel(approvals);
+  const ciFailing = await hasCIFailures(github, owner, repo, pr.head.sha);
+  const correctLabel = determineLabel(approvals, ciFailing);
 
   console.log(
-    `  PR #${prNumber}: maintainerApproval=${approvals.maintainerApproval}, ` +
-    `writeApproval=${approvals.writeApproval}, ` +
-    `softApproval=${approvals.softApproval}, anyApproval=${approvals.anyApproval} ` +
-    `→ ${correctLabel.name}`
+    `  PR #${prNumber}: maintainerApprovals=${approvals.maintainerApprovals}, ` +
+    `coreApprovals=${approvals.coreApprovals}, ` +
+    `softApprovals=${approvals.softApprovals}, anyApproval=${approvals.anyApproval}, ` +
+    `ciFailing=${ciFailing} → ${correctLabel.name}`
   );
 
   // Determine which stale queue labels to remove
@@ -122,28 +160,43 @@ async function syncLabel(github, owner, repo, pr, dryRun) {
     (name) => ALL_QUEUE_LABEL_NAMES.includes(name) && name !== correctLabel.name
   );
 
-  // Check if the correct label is already present AND there are no stale labels to remove
-  if (currentLabels.includes(correctLabel.name) && staleLabels.length === 0) {
-    console.log(`    ✓ Already has "${correctLabel.name}". No change needed.`);
+  const isHuman = pr.user && pr.user.type !== 'Bot';
+  const needsCommunityReview = isHuman && !currentLabels.includes(COMMUNITY_REVIEW.name);
+
+  // Check if the correct labels are already present AND there are no stale labels to remove
+  if (currentLabels.includes(correctLabel.name) && staleLabels.length === 0 && !needsCommunityReview) {
+    console.log(`    ✓ Already has "${correctLabel.name}"${isHuman ? ` and "${COMMUNITY_REVIEW.name}"` : ''}. No change needed.`);
     return false;
   }
 
+  const labelsToAdd = [];
+  if (!currentLabels.includes(correctLabel.name)) {
+    labelsToAdd.push(correctLabel.name);
+  }
+  if (needsCommunityReview) {
+    labelsToAdd.push(COMMUNITY_REVIEW.name);
+  }
+
   if (dryRun) {
-    console.log(`    [DRY RUN] Would add "${correctLabel.name}".`);
+    if (labelsToAdd.length > 0) {
+      console.log(`    [DRY RUN] Would add: ${labelsToAdd.join(', ')}.`);
+    }
     if (staleLabels.length > 0) {
       console.log(`    [DRY RUN] Would remove: ${staleLabels.join(', ')}.`);
     }
     return true;
   }
 
-  // Step 1: ADD the correct label FIRST (crash-safe: PR always has at least one label)
-  await github.rest.issues.addLabels({
-    owner,
-    repo,
-    issue_number: prNumber,
-    labels: [correctLabel.name],
-  });
-  console.log(`    + Added "${correctLabel.name}".`);
+  // Step 1: ADD the correct labels FIRST (crash-safe: PR always has at least one label)
+  if (labelsToAdd.length > 0) {
+    await github.rest.issues.addLabels({
+      owner,
+      repo,
+      issue_number: prNumber,
+      labels: labelsToAdd,
+    });
+    console.log(`    + Added: ${labelsToAdd.join(', ')}.`);
+  }
 
   // Step 2: THEN remove stale queue labels one by one
   for (const stale of staleLabels) {
@@ -170,4 +223,4 @@ async function syncLabel(github, owner, repo, pr, dryRun) {
   return true;
 }
 
-module.exports = { ensureLabel, determineLabel, syncLabel };
+module.exports = { ensureLabel, determineLabel, syncLabel, hasCIFailures };

--- a/.github/scripts/review-sync/helpers/permissions.js
+++ b/.github/scripts/review-sync/helpers/permissions.js
@@ -11,7 +11,7 @@
 //
 //   We MUST use role_name to distinguish maintainers from committers.
 //   If we used permission, Sophie (Maintain role per MAINTAINERS.md) would
-//   appear as 'write', and maintainerApproval would always be 0.
+//   appear as 'write', and maintainerApprovals would always be 0.
 //   PRs would be permanently stuck at queue:maintainers.
 //
 //   Phase 3 will replace this with team membership checks
@@ -19,10 +19,13 @@
 
 const { getLatestReviewStates } = require('./reviews');
 
+const permissionCache = new Map();
+
 /**
  * Check the repository role for a given user.
  *
  * Uses role_name (not legacy permission) to correctly detect the maintain role.
+ * Results are cached in memory to avoid redundant API calls during the cron run.
  *
  * @param {object} github   - Octokit instance
  * @param {string} owner    - Repository owner
@@ -31,6 +34,12 @@ const { getLatestReviewStates } = require('./reviews');
  * @returns {string} 'admin' | 'maintain' | 'write' | 'triage' | 'read' | 'none'
  */
 async function getPermissionLevel(github, owner, repo, username) {
+  const cacheKey = `${owner}/${repo}/${username}`;
+
+  if (permissionCache.has(cacheKey)) {
+    return permissionCache.get(cacheKey);
+  }
+
   try {
     const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
       owner,
@@ -40,10 +49,13 @@ async function getPermissionLevel(github, owner, repo, username) {
     // CRITICAL: Use role_name, NOT permission.
     // The legacy 'permission' field maps maintain → write, triage → read.
     // role_name correctly returns: admin | maintain | write | triage | read
-    return data.role_name || data.permission || 'none';
+    const role = data.role_name || data.permission || 'none';
+    permissionCache.set(cacheKey, role);
+    return role;
   } catch (error) {
     if (error.status === 404) {
       // External contributor — not a collaborator
+      permissionCache.set(cacheKey, 'none');
       return 'none';
     }
     // Log unexpected errors but don't crash the run
@@ -57,22 +69,22 @@ async function getPermissionLevel(github, owner, repo, username) {
  * Count approvals on a PR, split by permission level.
  *
  * Returns three counters:
- *   - maintainerApproval: admin or maintain (maps to CODEOWNERS maintainer teams)
- *   - writeApproval: write (committers)
- *   - softApproval: triage, read, none, external contributors
+ *   - maintainerApprovals: admin or maintain (maps to CODEOWNERS maintainer teams)
+ *   - coreApprovals: write (committers) and maintainers
+ *   - softApprovals: triage, read, none, external contributors
  *
  * @param {object} github   - Octokit instance
  * @param {string} owner    - Repository owner
  * @param {string} repo     - Repository name
  * @param {number} prNumber - Pull request number
- * @returns {{ maintainerApproval: number, writeApproval: number, softApproval: number, anyApproval: number }}
+ * @param {{ maintainerApprovals: number, coreApprovals: number, softApprovals: number, anyApproval: number }}
  */
 async function countApprovals(github, owner, repo, prNumber) {
   const latestStates = await getLatestReviewStates(github, owner, repo, prNumber);
 
-  let maintainerApproval = 0;
-  let writeApproval = 0;
-  let softApproval = 0;
+  let maintainerApprovals = 0; // only maintainers
+  let coreApprovals = 0; // anyone with write permission
+  let softApprovals = 0;
 
   for (const [username, state] of latestStates) {
     if (state !== 'APPROVED') continue;
@@ -80,21 +92,26 @@ async function countApprovals(github, owner, repo, prNumber) {
     const role = await getPermissionLevel(github, owner, repo, username);
 
     if (role === 'admin' || role === 'maintain') {
-      maintainerApproval++;
+      maintainerApprovals++;
+      coreApprovals++; // Maintainers also count as core
     } else if (role === 'write') {
-      writeApproval++;
+      coreApprovals++; // Committers count as core
     } else {
       // triage, read, none, or any unexpected value → soft approval
-      softApproval++;
+      softApprovals++;
     }
   }
 
   return {
-    maintainerApproval,
-    writeApproval,
-    softApproval,
-    anyApproval: maintainerApproval + writeApproval + softApproval,
+    maintainerApprovals,
+    coreApprovals,
+    softApprovals,
+    anyApproval: coreApprovals + softApprovals,
   };
 }
 
-module.exports = { getPermissionLevel, countApprovals };
+function clearPermissionCache() {
+  permissionCache.clear();
+}
+
+module.exports = { getPermissionLevel, countApprovals, clearPermissionCache };

--- a/.github/scripts/review-sync/index.js
+++ b/.github/scripts/review-sync/index.js
@@ -14,7 +14,7 @@
 // Phase 1 of 4 — label sync only.
 
 const helpers = require('./helpers');
-const { QUEUE_LABELS, RATE_LIMIT_FLOOR } = helpers.constants;
+const { QUEUE_LABELS, RATE_LIMIT_FLOOR, COMMUNITY_REVIEW } = helpers.constants;
 const { ensureLabel, syncLabel } = helpers.labels;
 
 module.exports = async ({ github, context, core }) => {
@@ -55,11 +55,12 @@ module.exports = async ({ github, context, core }) => {
     return;
   }
 
-  // ── 3. Ensure queue labels exist ─────────────────────────────────────────
-  console.log('\n--- Ensuring Queue Labels Exist ---');
+  // ── 3. Ensure labels exist ───────────────────────────────────────────────
+  console.log('\n--- Ensuring Labels Exist ---');
   for (const label of Object.values(QUEUE_LABELS)) {
     await ensureLabel(github, owner, repo, label, dryRun);
   }
+  await ensureLabel(github, owner, repo, COMMUNITY_REVIEW, dryRun);
 
   // ── 4. Sync label on each PR ─────────────────────────────────────────────
   console.log('\n--- Syncing Labels ---');
@@ -90,6 +91,6 @@ module.exports = async ({ github, context, core }) => {
   console.log(`  Errors: ${errors}`);
 
   if (errors > 0) {
-    process.exitCode = 1;
+    core.setFailed(`Review sync completed with ${errors} error(s). Check logs above.`);
   }
 };

--- a/.github/scripts/review-sync/package.json
+++ b/.github/scripts/review-sync/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "review-sync",
+  "version": "1.0.0",
+  "description": "Automated PR review queue label sync scripts and tests",
+  "main": "index.js",
+  "scripts": {
+    "test": "node tests/test-labels.js && node tests/test-permissions.js && node tests/test-reviews.js"
+  }
+}

--- a/.github/scripts/review-sync/package.json
+++ b/.github/scripts/review-sync/package.json
@@ -2,6 +2,7 @@
   "name": "review-sync",
   "version": "1.0.0",
   "description": "Automated PR review queue label sync scripts and tests",
+  "private": true,
   "main": "index.js",
   "scripts": {
     "test": "node tests/test-labels.js && node tests/test-permissions.js && node tests/test-reviews.js"

--- a/.github/scripts/review-sync/tests/test-labels.js
+++ b/.github/scripts/review-sync/tests/test-labels.js
@@ -13,58 +13,68 @@ const unitTests = [
   {
     name: 'determineLabel: 0 approvals → queue:junior-committer',
     test: () => {
-      const r = determineLabel({ maintainerApproval: 0, writeApproval: 0, softApproval: 0, anyApproval: 0 });
+      const r = determineLabel({ maintainerApprovals: 0, coreApprovals: 0, softApprovals: 0, anyApproval: 0 });
       return r.name === 'queue:junior-committer';
     },
   },
   {
     name: 'determineLabel: 1 soft approval → queue:committers',
     test: () => {
-      const r = determineLabel({ maintainerApproval: 0, writeApproval: 0, softApproval: 1, anyApproval: 1 });
+      const r = determineLabel({ maintainerApprovals: 0, coreApprovals: 0, softApprovals: 1, anyApproval: 1 });
       return r.name === 'queue:committers';
     },
   },
   {
     name: 'determineLabel: 1 write approval → queue:maintainers',
     test: () => {
-      const r = determineLabel({ maintainerApproval: 0, writeApproval: 1, softApproval: 0, anyApproval: 1 });
+      const r = determineLabel({ maintainerApprovals: 0, coreApprovals: 1, softApprovals: 0, anyApproval: 1 });
       return r.name === 'queue:maintainers';
     },
   },
   {
     name: 'determineLabel: 2 write + 0 maintainer → queue:maintainers (NOT status: ready-to-merge)',
     test: () => {
-      const r = determineLabel({ maintainerApproval: 0, writeApproval: 2, softApproval: 0, anyApproval: 2 });
+      const r = determineLabel({ maintainerApprovals: 0, coreApprovals: 2, softApprovals: 0, anyApproval: 2 });
       return r.name === 'queue:maintainers';
     },
   },
   {
-    name: 'determineLabel: 1 maintainer alone → queue:maintainers (NOT status: ready-to-merge, needs 2 reviews)',
+    name: 'determineLabel: 1 maintainer alone → queue:committers (maintainer reviewed, needs committer next)',
     test: () => {
       // Sophie's edge case: maintainer approves first, only 1 total review
-      const r = determineLabel({ maintainerApproval: 1, writeApproval: 0, softApproval: 0, anyApproval: 1 });
-      return r.name === 'queue:maintainers';
+      // Note: maintainer counts as both maintainer and core
+      const r = determineLabel({ maintainerApprovals: 1, coreApprovals: 1, softApprovals: 0, anyApproval: 1 });
+      return r.name === 'queue:committers';
     },
   },
   {
     name: 'determineLabel: 1 maintainer + 1 write → status: ready-to-merge (2 reviews satisfied)',
     test: () => {
-      const r = determineLabel({ maintainerApproval: 1, writeApproval: 1, softApproval: 0, anyApproval: 2 });
+      // Total: 1 maintainer, 2 core
+      const r = determineLabel({ maintainerApprovals: 1, coreApprovals: 2, softApprovals: 0, anyApproval: 2 });
       return r.name === 'status: ready-to-merge';
     },
   },
   {
-    name: 'determineLabel: 1 maintainer + 1 soft → queue:maintainers (soft approvals do not count as core review)',
+    name: 'determineLabel: 1 maintainer + 1 soft → queue:committers (soft does not count as core, needs committer)',
     test: () => {
-      const r = determineLabel({ maintainerApproval: 1, writeApproval: 0, softApproval: 1, anyApproval: 2 });
-      return r.name === 'queue:maintainers';
+      const r = determineLabel({ maintainerApprovals: 1, coreApprovals: 1, softApprovals: 1, anyApproval: 2 });
+      return r.name === 'queue:committers';
     },
   },
   {
     name: 'determineLabel: 3 soft, 0 write → queue:committers',
     test: () => {
-      const r = determineLabel({ maintainerApproval: 0, writeApproval: 0, softApproval: 3, anyApproval: 3 });
+      const r = determineLabel({ maintainerApprovals: 0, coreApprovals: 0, softApprovals: 3, anyApproval: 3 });
       return r.name === 'queue:committers';
+    },
+  },
+  {
+    name: 'determineLabel: fully approved but ciFailing=true → queue:junior-committer',
+    test: () => {
+      // Passes fully approved PR state, but explicitly passes true for the ciFailing argument
+      const r = determineLabel({ maintainerApprovals: 1, coreApprovals: 2, softApprovals: 0, anyApproval: 2 }, true);
+      return r.name === 'queue:junior-committer';
     },
   },
   {
@@ -95,7 +105,7 @@ const unitTests = [
     name: 'syncLabel: no approvals, no labels → adds junior-committer',
     test: async () => {
       const mock = createMockGithub({ roles: {}, reviews: [] });
-      const changed = await syncLabel(mock, 'o', 'r', { number: 1, labels: [] }, false);
+      const changed = await syncLabel(mock, 'o', 'r', { number: 1, labels: [], head: { sha: '123' }, user: { type: 'User' } }, false);
       return changed === true && mock.calls.labelsAdded[0] === 'queue:junior-committer';
     },
   },
@@ -103,7 +113,7 @@ const unitTests = [
     name: 'syncLabel: already correct, no stale → returns false',
     test: async () => {
       const mock = createMockGithub({ roles: {}, reviews: [] });
-      const changed = await syncLabel(mock, 'o', 'r', { number: 1, labels: [{ name: 'queue:junior-committer' }] }, false);
+      const changed = await syncLabel(mock, 'o', 'r', { number: 1, labels: [{ name: 'queue:junior-committer' }], head: { sha: '123' }, user: { type: 'Bot' } }, false);
       return changed === false && mock.calls.labelsAdded.length === 0;
     },
   },
@@ -120,7 +130,7 @@ const unitTests = [
           { user: { login: 'bob' }, state: 'APPROVED', submitted_at: '2026-01-02T00:00:00Z' },
         ],
       });
-      const changed = await syncLabel(mock, 'o', 'r', { number: 1, labels: [{ name: 'queue:junior-committer' }] }, false);
+      const changed = await syncLabel(mock, 'o', 'r', { number: 1, labels: [{ name: 'queue:junior-committer' }], head: { sha: '123' }, user: { type: 'User' } }, false);
       return changed === true && mock.calls.labelsAdded.includes('status: ready-to-merge') && mock.calls.labelsRemoved.includes('queue:junior-committer');
     },
   },
@@ -128,7 +138,7 @@ const unitTests = [
     name: 'syncLabel: dry run logs but does not modify',
     test: async () => {
       const mock = createMockGithub({ roles: {}, reviews: [] });
-      const changed = await syncLabel(mock, 'o', 'r', { number: 1, labels: [{ name: 'queue:committers' }] }, true);
+      const changed = await syncLabel(mock, 'o', 'r', { number: 1, labels: [{ name: 'queue:committers' }], head: { sha: '123' }, user: { type: 'User' } }, true);
       return changed === true && mock.calls.labelsAdded.length === 0;
     },
   },
@@ -136,9 +146,28 @@ const unitTests = [
     name: 'syncLabel: correct + stale present → cleans up stale',
     test: async () => {
       const mock = createMockGithub({ roles: {}, reviews: [] });
-      const pr = { number: 1, labels: [{ name: 'queue:junior-committer' }, { name: 'queue:committers' }] };
+      const pr = { number: 1, labels: [{ name: 'queue:junior-committer' }, { name: 'queue:committers' }], head: { sha: '123' }, user: { type: 'User' } };
       const changed = await syncLabel(mock, 'o', 'r', pr, false);
       return changed === true && mock.calls.labelsRemoved.includes('queue:committers');
+    },
+  },
+  {
+    name: 'syncLabel: bot PR does NOT receive community review label',
+    test: async () => {
+      const mock = createMockGithub({ roles: {}, reviews: [] });
+      const pr = { number: 1, labels: [{ name: 'queue:junior-committer' }], head: { sha: '123' }, user: { type: 'Bot' } };
+      const changed = await syncLabel(mock, 'o', 'r', pr, false);
+      // Already has junior-committer, and being a Bot means it shouldn't add community review
+      return changed === false && mock.calls.labelsAdded.length === 0;
+    },
+  },
+  {
+    name: 'syncLabel: human PR receives community review label if missing',
+    test: async () => {
+      const mock = createMockGithub({ roles: {}, reviews: [] });
+      const pr = { number: 1, labels: [{ name: 'queue:junior-committer' }], head: { sha: '123' }, user: { type: 'User' } };
+      const changed = await syncLabel(mock, 'o', 'r', pr, false);
+      return changed === true && mock.calls.labelsAdded.includes('open to community review');
     },
   },
 ];

--- a/.github/scripts/review-sync/tests/test-labels.js
+++ b/.github/scripts/review-sync/tests/test-labels.js
@@ -7,7 +7,7 @@
 
 const { runTestSuite, createMockGithub } = require('./test-utils');
 const { determineLabel, ensureLabel, syncLabel } = require('../helpers/labels');
-const { QUEUE_LABELS } = require('../helpers/constants');
+const { QUEUE_LABELS, COMMUNITY_REVIEW } = require('../helpers/constants');
 
 const unitTests = [
   {
@@ -167,7 +167,7 @@ const unitTests = [
       const mock = createMockGithub({ roles: {}, reviews: [] });
       const pr = { number: 1, labels: [{ name: 'queue:junior-committer' }], head: { sha: '123' }, user: { type: 'User' } };
       const changed = await syncLabel(mock, 'o', 'r', pr, false);
-      return changed === true && mock.calls.labelsAdded.includes('open to community review');
+      return changed === true && mock.calls.labelsAdded.includes(COMMUNITY_REVIEW.name);
     },
   },
 ];

--- a/.github/scripts/review-sync/tests/test-permissions.js
+++ b/.github/scripts/review-sync/tests/test-permissions.js
@@ -6,7 +6,7 @@
 // Run with: node .github/scripts/review-sync/tests/test-permissions.js
 
 const { runTestSuite, createMockGithub } = require('./test-utils');
-const { getPermissionLevel, countApprovals } = require('../helpers/permissions');
+const { getPermissionLevel, countApprovals, clearPermissionCache } = require('../helpers/permissions');
 
 // =============================================================================
 // UNIT TESTS
@@ -79,7 +79,7 @@ const unitTests = [
   // countApprovals
   // ---------------------------------------------------------------------------
   {
-    name: 'countApprovals: maintain counted as maintainerApproval, write as writeApproval',
+    name: 'countApprovals: maintain counted as maintainerApprovals and coreApprovals, write as coreApprovals',
     test: async () => {
       const mock = createMockGithub({
         roles: {
@@ -93,15 +93,15 @@ const unitTests = [
       });
       const result = await countApprovals(mock, 'owner', 'repo', 1);
       return (
-        result.maintainerApproval === 1 &&
-        result.writeApproval === 1 &&
-        result.softApproval === 0 &&
+        result.maintainerApprovals === 1 &&
+        result.coreApprovals === 2 &&
+        result.softApprovals === 0 &&
         result.anyApproval === 2
       );
     },
   },
   {
-    name: 'countApprovals: admin counted as maintainerApproval',
+    name: 'countApprovals: admin counted as maintainerApprovals and coreApprovals',
     test: async () => {
       const mock = createMockGithub({
         roles: {
@@ -112,11 +112,11 @@ const unitTests = [
         ],
       });
       const result = await countApprovals(mock, 'owner', 'repo', 1);
-      return result.maintainerApproval === 1 && result.anyApproval === 1;
+      return result.maintainerApprovals === 1 && result.coreApprovals === 1 && result.anyApproval === 1;
     },
   },
   {
-    name: 'countApprovals: external contributor counted as softApproval',
+    name: 'countApprovals: external contributor counted as softApprovals',
     test: async () => {
       const mock = createMockGithub({
         roles: {},
@@ -126,9 +126,9 @@ const unitTests = [
       });
       const result = await countApprovals(mock, 'owner', 'repo', 1);
       return (
-        result.maintainerApproval === 0 &&
-        result.writeApproval === 0 &&
-        result.softApproval === 1 &&
+        result.maintainerApprovals === 0 &&
+        result.coreApprovals === 0 &&
+        result.softApprovals === 1 &&
         result.anyApproval === 1
       );
     },
@@ -154,9 +154,9 @@ const unitTests = [
       const mock = createMockGithub({ roles: {}, reviews: [] });
       const result = await countApprovals(mock, 'owner', 'repo', 1);
       return (
-        result.maintainerApproval === 0 &&
-        result.writeApproval === 0 &&
-        result.softApproval === 0 &&
+        result.maintainerApprovals === 0 &&
+        result.coreApprovals === 0 &&
+        result.softApprovals === 0 &&
         result.anyApproval === 0
       );
     },
@@ -177,9 +177,9 @@ const unitTests = [
       });
       const result = await countApprovals(mock, 'owner', 'repo', 1);
       return (
-        result.maintainerApproval === 1 &&
-        result.writeApproval === 1 &&
-        result.softApproval === 1 &&
+        result.maintainerApprovals === 1 &&
+        result.coreApprovals === 2 &&
+        result.softApprovals === 1 &&
         result.anyApproval === 3
       );
     },
@@ -197,7 +197,7 @@ const unitTests = [
         ],
       });
       const result = await countApprovals(mock, 'owner', 'repo', 1);
-      return result.maintainerApproval === 0 && result.anyApproval === 0;
+      return result.maintainerApprovals === 0 && result.anyApproval === 0;
     },
   },
 ];
@@ -212,6 +212,7 @@ async function runUnitTests() {
   let passed = 0;
   let failed = 0;
   for (const test of unitTests) {
+    clearPermissionCache();
     try {
       const result = await Promise.resolve(test.test());
       if (result) {

--- a/.github/scripts/review-sync/tests/test-utils.js
+++ b/.github/scripts/review-sync/tests/test-utils.js
@@ -97,6 +97,7 @@ function createMockGithub(options = {}) {
     roles = {},
     reviews = [],
     existingLabels = {},
+    checkRuns = [],
   } = options;
 
   const calls = {
@@ -122,6 +123,9 @@ function createMockGithub(options = {}) {
       },
       pulls: {
         listReviews: async () => ({ data: reviews }),
+      },
+      checks: {
+        listForRef: async () => ({ data: { check_runs: checkRuns } }),
       },
       issues: {
         getLabel: async ({ name }) => {

--- a/.github/scripts/review-sync/tests/test-utils.js
+++ b/.github/scripts/review-sync/tests/test-utils.js
@@ -156,6 +156,8 @@ function createMockGithub(options = {}) {
     },
     paginate: async (fn, opts) => {
       const result = await fn(opts);
+      // github.paginate automatically unwraps the array from the response data
+      if (result.data && result.data.check_runs) return result.data.check_runs;
       return result.data || result || [];
     },
   };

--- a/.github/workflows/review-sync.yml
+++ b/.github/workflows/review-sync.yml
@@ -26,6 +26,7 @@ permissions:
   pull-requests: write
   issues: write
   contents: read
+  checks: read
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/test-review-sync.yml
+++ b/.github/workflows/test-review-sync.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   test:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: hl-sdk-py-lin-md
     permissions:
       contents: read

--- a/.github/workflows/test-review-sync.yml
+++ b/.github/workflows/test-review-sync.yml
@@ -1,0 +1,34 @@
+name: Test Review Sync
+
+on:
+  push:
+    paths:
+      - '.github/scripts/review-sync/**'
+      - '.github/workflows/test-review-sync.yml'
+  pull_request:
+    paths:
+      - '.github/scripts/review-sync/**'
+      - '.github/workflows/test-review-sync.yml'
+
+jobs:
+  test:
+    runs-on: hl-sdk-py-lin-md
+    permissions:
+      contents: read
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: '20'
+
+      - name: Run Tests
+        working-directory: .github/scripts/review-sync
+        run: npm test


### PR DESCRIPTION
**Description**:
Harden the review-sync infrastructure ahead of Phase 2 with 6 atomic fixes addressing API efficiency, error visibility, CI safety, test coverage, routing correctness, and community visibility.

* Add module-level permission cache in `permissions.js` to eliminate redundant API calls
* Use `core.setFailed()` in `index.js` when error count > 0 to surface broken syncs
* Add CI failure rollback via `hasCIFailures()` , failing checks override all approvals   and demote PRs back to `queue:junior-committer`
* Create `test-review-sync.yml` workflow to run `npm test` on review-sync changes
* Refactor approval counters to use `coreApprovals` (write + maintain + admin) so  maintainers inherently satisfy the core requirement
* Add permanent `open to community review` label on all open PRs
* Route early maintainer approvals to `queue:committers` instead of `queue:maintainers`  to prevent duplicate maintainer reviews when a maintainer jumps in before triage



**Related issue(s)**: #2229

Fixes #2260 

**Notes for reviewer**:

Live-tested on fork (`darshit2308/hiero-sdk-python`) for API connectivity and permissions:
1. Unit tests: 33/33 passing ([View Test Run](https://github.com/darshit2308/hiero-sdk-python/actions/runs/25598206098))
2. Dry run (`dry_run: true`): Correctly logs intended label changes without modifying state
3. Write mode (`dry_run: false`): Successfully creates and applies labels to PRs via API ([View Test Run](https://github.com/darshit2308/hiero-sdk-python/actions/runs/25599959295))

Logic Edge-Cases Proven via Automated Tests:
4. Early maintainer routing: When a maintainer approves before triage, the test suite verifies the PR routes to `queue:committers` (not `queue:maintainers`) to call a committer, preventing wasted maintainer bandwidth.
5. CI rollback: Test suite verifies `ciFailing=true` overrides all approvals -> `queue:junior-committer`.


Key files changed:
  .github/scripts/review-sync/helpers/permissions.js  --> permission cache + coreApprovals
  .github/scripts/review-sync/helpers/labels.js       --> determineLabel routing + CI rollback
  .github/scripts/review-sync/helpers/constants.js    --> community review label definition
  .github/scripts/review-sync/helpers/ci.js           --> hasCIFailures() helper
  .github/scripts/review-sync/index.js                --> core.setFailed() error handling
  .github/scripts/review-sync/tests/*                 --> 33 unit tests
  .github/workflows/review-sync.yml                   --> checks:read permission for CI API
  .github/workflows/test-review-sync.yml              --> [NEW] CI test workflow


**Checklist**

- [x] Documented (Code comments, etc.)
- [x] Tested (unit, integration, etc.)
