### PR TITLE
fix: Flaky test with the FeeEstimationQuery e2e test

### DIFF
--- a/.github/workflows/pr-check-secondary-unit-integration-test.yml
+++ b/.github/workflows/pr-check-secondary-unit-integration-test.yml
@@ -2,7 +2,6 @@ name: Secondary PR Check - Hiero Solo Integration & Unit Tests
 on:
   push:
     branches:
-      - "main"
     paths-ignore:
       - "**/*.md"
       - "docs/**"

--- a/.github/workflows/pr-check-secondary-unit-integration-test.yml
+++ b/.github/workflows/pr-check-secondary-unit-integration-test.yml
@@ -2,6 +2,7 @@ name: Secondary PR Check - Hiero Solo Integration & Unit Tests
 on:
   push:
     branches:
+      - "main"
     paths-ignore:
       - "**/*.md"
       - "docs/**"

--- a/tests/integration/fee_estimate_query_e2e_test.py
+++ b/tests/integration/fee_estimate_query_e2e_test.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import datetime
 import time
 
 import pytest
@@ -33,13 +32,13 @@ def wait_for_fee_estimation_service_ready(env):
     if _fee_estimation_error:
         raise _fee_estimation_error
 
-    deadline = datetime.datetime.now() + datetime.timedelta(seconds=600.0)
     attempts = 0
     last_error = None
 
-    print("Waiting for FeeEstimationService to get ready")
+    print("Waiting for FeeEstimationService to get ready...")
 
-    while datetime.datetime.now() < deadline:
+    deadline = time.monotonic() + 600.0
+    while time.monotonic() < deadline:
         attempts += 1
         try:
             probe = (
@@ -48,7 +47,7 @@ def wait_for_fee_estimation_service_ready(env):
                 .add_hbar_transfer(env.operator_id, Hbar(1))
             )
 
-            (FeeEstimateQuery().set_mode(FeeEstimateMode.INTRINSIC).set_transaction(probe).execute(env.client))
+            FeeEstimateQuery().set_mode(FeeEstimateMode.INTRINSIC).set_transaction(probe).execute(env.client)
 
             _fee_estimation_ready = True
 

--- a/tests/integration/fee_estimate_query_e2e_test.py
+++ b/tests/integration/fee_estimate_query_e2e_test.py
@@ -22,8 +22,7 @@ _fee_estimation_error: Exception | None = None
 
 def wait_for_fee_estimation_service_ready(env):
     """
-    Blocks until the Mirror Node's FeeEstimationService is ready.
-    with a 10-minute timeout.
+    Wait until the FeeEstimationService is ready with a timeout.
     """
     global _fee_estimation_ready, _fee_estimation_error
 

--- a/tests/integration/fee_estimate_query_e2e_test.py
+++ b/tests/integration/fee_estimate_query_e2e_test.py
@@ -21,11 +21,6 @@ _fee_estimation_ready = False
 _fee_estimation_error: Exception | None = None
 
 
-def wait_for_mirror_node_sync():
-    """Create delay to allow the MirrorNode to update its internal state."""
-    time.sleep(2.0)
-
-
 def wait_for_fee_estimation_service_ready(env):
     """
     Blocks until the Mirror Node's FeeEstimationService is ready.
@@ -78,7 +73,7 @@ def test_can_execute_fee_estimation_query(env):
     """
     wait_for_fee_estimation_service_ready(env)
     tx = AccountCreateTransaction().set_key_without_alias(PrivateKey.generate_ed25519()).set_initial_balance(1)
-    wait_for_mirror_node_sync()
+    # wait_for_mirror_node_sync()
     query = FeeEstimateQuery().set_transaction(tx)
     result = query.execute(env.client)
 
@@ -92,7 +87,7 @@ def test_can_execute_fee_estimation_query2(env):
     """
     wait_for_fee_estimation_service_ready(env)
     tx = AccountCreateTransaction().set_key_without_alias(PrivateKey.generate_ed25519()).set_initial_balance(1)
-    wait_for_mirror_node_sync()
+    # wait_for_mirror_node_sync()
     query = FeeEstimateQuery().set_mode(FeeEstimateMode.STATE).set_transaction(tx)
     result = query.execute(env.client)
 
@@ -106,7 +101,7 @@ def test__fee_estimation_query_chunk_tx_can_execute(env):
     """
     wait_for_fee_estimation_service_ready(env)
     tx = FileAppendTransaction().set_file_id(FileId(0, 0, 2)).set_chunk_size(10).set_contents("s" * 33)  # 4 chunks
-    wait_for_mirror_node_sync()
+    # wait_for_mirror_node_sync()
 
     tx.freeze_with(env.client)
     query = FeeEstimateQuery().set_mode(FeeEstimateMode.STATE).set_transaction(tx)
@@ -124,7 +119,7 @@ def test_can_execute_fee_estimation_query_chunk_tx(env):
     tx = (
         TopicMessageSubmitTransaction().set_topic_id(TopicId(0, 0, 2)).set_chunk_size(10).set_message("s" * 20)
     )  # 2 chunks
-    wait_for_mirror_node_sync()
+    # wait_for_mirror_node_sync()
 
     tx.freeze_with(env.client)
     query = FeeEstimateQuery().set_mode(FeeEstimateMode.STATE).set_transaction(tx)

--- a/tests/integration/fee_estimate_query_e2e_test.py
+++ b/tests/integration/fee_estimate_query_e2e_test.py
@@ -38,13 +38,13 @@ def wait_for_fee_estimation_service_ready(env):
     if _fee_estimation_error:
         raise _fee_estimation_error
 
-    deadline = datetime.now() + datetime.timedelta(seconds=600.0)
+    deadline = datetime.datetime.now() + datetime.timedelta(seconds=600.0)
     attempts = 0
     last_error = None
 
     print("Waiting for FeeEstimationService to get ready")
 
-    while datetime.now() < deadline:
+    while datetime.datetime.now() < deadline:
         attempts += 1
         try:
             probe = (
@@ -76,7 +76,7 @@ def test_can_execute_fee_estimation_query(env):
     """
     Integration test that verifies a fee estimation query executes successfully and returns a non-null result.
     """
-    wait_for_fee_estimation_service_ready()
+    wait_for_fee_estimation_service_ready(env)
     tx = AccountCreateTransaction().set_key_without_alias(PrivateKey.generate_ed25519()).set_initial_balance(1)
     wait_for_mirror_node_sync()
     query = FeeEstimateQuery().set_transaction(tx)
@@ -90,7 +90,7 @@ def test_can_execute_fee_estimation_query2(env):
     """Integration test that verifies a state-mode fee estimation query
     executes successfully and returns a non-null result.
     """
-    wait_for_fee_estimation_service_ready()
+    wait_for_fee_estimation_service_ready(env)
     tx = AccountCreateTransaction().set_key_without_alias(PrivateKey.generate_ed25519()).set_initial_balance(1)
     wait_for_mirror_node_sync()
     query = FeeEstimateQuery().set_mode(FeeEstimateMode.STATE).set_transaction(tx)
@@ -104,7 +104,7 @@ def test__fee_estimation_query_chunk_tx_can_execute(env):
     """Integration test that verifies a state-mode fee estimation query executes
     successfully for a chunked file append transaction and returns a non-null result.
     """
-    wait_for_fee_estimation_service_ready()
+    wait_for_fee_estimation_service_ready(env)
     tx = FileAppendTransaction().set_file_id(FileId(0, 0, 2)).set_chunk_size(10).set_contents("s" * 33)  # 4 chunks
     wait_for_mirror_node_sync()
 
@@ -120,7 +120,7 @@ def test_can_execute_fee_estimation_query_chunk_tx(env):
     """Integration test that verifies a state-mode fee estimation query executes successfully
     for a chunked topic message submit transaction and returns a non-null result.
     """
-    wait_for_fee_estimation_service_ready()
+    wait_for_fee_estimation_service_ready(env)
     tx = (
         TopicMessageSubmitTransaction().set_topic_id(TopicId(0, 0, 2)).set_chunk_size(10).set_message("s" * 20)
     )  # 2 chunks

--- a/tests/integration/fee_estimate_query_e2e_test.py
+++ b/tests/integration/fee_estimate_query_e2e_test.py
@@ -73,7 +73,7 @@ def test_can_execute_fee_estimation_query(env):
     """
     wait_for_fee_estimation_service_ready(env)
     tx = AccountCreateTransaction().set_key_without_alias(PrivateKey.generate_ed25519()).set_initial_balance(1)
-    # wait_for_mirror_node_sync()
+
     query = FeeEstimateQuery().set_transaction(tx)
     result = query.execute(env.client)
 
@@ -87,7 +87,7 @@ def test_can_execute_fee_estimation_query2(env):
     """
     wait_for_fee_estimation_service_ready(env)
     tx = AccountCreateTransaction().set_key_without_alias(PrivateKey.generate_ed25519()).set_initial_balance(1)
-    # wait_for_mirror_node_sync()
+
     query = FeeEstimateQuery().set_mode(FeeEstimateMode.STATE).set_transaction(tx)
     result = query.execute(env.client)
 
@@ -101,7 +101,6 @@ def test__fee_estimation_query_chunk_tx_can_execute(env):
     """
     wait_for_fee_estimation_service_ready(env)
     tx = FileAppendTransaction().set_file_id(FileId(0, 0, 2)).set_chunk_size(10).set_contents("s" * 33)  # 4 chunks
-    # wait_for_mirror_node_sync()
 
     tx.freeze_with(env.client)
     query = FeeEstimateQuery().set_mode(FeeEstimateMode.STATE).set_transaction(tx)
@@ -119,7 +118,6 @@ def test_can_execute_fee_estimation_query_chunk_tx(env):
     tx = (
         TopicMessageSubmitTransaction().set_topic_id(TopicId(0, 0, 2)).set_chunk_size(10).set_message("s" * 20)
     )  # 2 chunks
-    # wait_for_mirror_node_sync()
 
     tx.freeze_with(env.client)
     query = FeeEstimateQuery().set_mode(FeeEstimateMode.STATE).set_transaction(tx)

--- a/tests/integration/fee_estimate_query_e2e_test.py
+++ b/tests/integration/fee_estimate_query_e2e_test.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import datetime
+import time
+
 import pytest
 
 from hiero_sdk_python.account.account_create_transaction import AccountCreateTransaction
@@ -9,7 +12,63 @@ from hiero_sdk_python.crypto.private_key import PrivateKey
 from hiero_sdk_python.fees.fee_estimate_mode import FeeEstimateMode
 from hiero_sdk_python.file.file_append_transaction import FileAppendTransaction
 from hiero_sdk_python.file.file_id import FileId
+from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.query.fee_estimate_query import FeeEstimateQuery
+from hiero_sdk_python.transaction.transfer_transaction import TransferTransaction
+
+
+_fee_estimation_ready = False
+_fee_estimation_error: Exception | None = None
+
+
+def wait_for_mirror_node_sync():
+    """Create delay to allow the MirrorNode to update its internal state."""
+    time.sleep(2.0)
+
+
+def wait_for_fee_estimation_service_ready(env):
+    """
+    Blocks until the Mirror Node's FeeEstimationService is ready.
+    with a 10-minute timeout.
+    """
+    global _fee_estimation_ready, _fee_estimation_error
+
+    if _fee_estimation_ready:
+        return
+    if _fee_estimation_error:
+        raise _fee_estimation_error
+
+    deadline = datetime.now() + datetime.timedelta(seconds=600.0)
+    attempts = 0
+    last_error = None
+
+    print("Waiting for FeeEstimationService to get ready")
+
+    while datetime.now() < deadline:
+        attempts += 1
+        try:
+            probe = (
+                TransferTransaction()
+                .add_hbar_transfer(env.operator_id, Hbar(-1))
+                .add_hbar_transfer(env.operator_id, Hbar(1))
+            )
+
+            (FeeEstimateQuery().set_mode(FeeEstimateMode.INTRINSIC).set_transaction(probe).execute(env.client))
+
+            _fee_estimation_ready = True
+
+            print(f"FeeEstimationService ready after {attempts} attempts.")
+            return
+
+        except Exception as e:
+            last_error = e
+            time.sleep(5.0)
+
+    _fee_estimation_error = Exception(
+        f"FeeEstimationService not became ready after {attempts} attempts. Last error: {last_error}"
+    )
+
+    raise _fee_estimation_error
 
 
 @pytest.mark.integration
@@ -17,7 +76,9 @@ def test_can_execute_fee_estimation_query(env):
     """
     Integration test that verifies a fee estimation query executes successfully and returns a non-null result.
     """
+    wait_for_fee_estimation_service_ready()
     tx = AccountCreateTransaction().set_key_without_alias(PrivateKey.generate_ed25519()).set_initial_balance(1)
+    wait_for_mirror_node_sync()
     query = FeeEstimateQuery().set_transaction(tx)
     result = query.execute(env.client)
 
@@ -29,7 +90,9 @@ def test_can_execute_fee_estimation_query2(env):
     """Integration test that verifies a state-mode fee estimation query
     executes successfully and returns a non-null result.
     """
+    wait_for_fee_estimation_service_ready()
     tx = AccountCreateTransaction().set_key_without_alias(PrivateKey.generate_ed25519()).set_initial_balance(1)
+    wait_for_mirror_node_sync()
     query = FeeEstimateQuery().set_mode(FeeEstimateMode.STATE).set_transaction(tx)
     result = query.execute(env.client)
 
@@ -41,7 +104,9 @@ def test__fee_estimation_query_chunk_tx_can_execute(env):
     """Integration test that verifies a state-mode fee estimation query executes
     successfully for a chunked file append transaction and returns a non-null result.
     """
+    wait_for_fee_estimation_service_ready()
     tx = FileAppendTransaction().set_file_id(FileId(0, 0, 2)).set_chunk_size(10).set_contents("s" * 33)  # 4 chunks
+    wait_for_mirror_node_sync()
 
     tx.freeze_with(env.client)
     query = FeeEstimateQuery().set_mode(FeeEstimateMode.STATE).set_transaction(tx)
@@ -55,12 +120,11 @@ def test_can_execute_fee_estimation_query_chunk_tx(env):
     """Integration test that verifies a state-mode fee estimation query executes successfully
     for a chunked topic message submit transaction and returns a non-null result.
     """
+    wait_for_fee_estimation_service_ready()
     tx = (
         TopicMessageSubmitTransaction().set_topic_id(TopicId(0, 0, 2)).set_chunk_size(10).set_message("s" * 20)
     )  # 2 chunks
-
-    # 2. IMPORTANT: Let freeze_with generate the valid transaction ID sequence
-    # This ensures tx._transaction_ids is populated correctly.
+    wait_for_mirror_node_sync()
 
     tx.freeze_with(env.client)
     query = FeeEstimateQuery().set_mode(FeeEstimateMode.STATE).set_transaction(tx)

--- a/tests/integration/fee_estimate_query_e2e_test.py
+++ b/tests/integration/fee_estimate_query_e2e_test.py
@@ -20,10 +20,9 @@ _fee_estimation_ready = False
 _fee_estimation_error: Exception | None = None
 
 
+# Wait until the mirror_node FeeEstimationService can return a good mock query.
 def wait_for_fee_estimation_service_ready(env):
-    """
-    Wait until the FeeEstimationService is ready with a timeout.
-    """
+    """Wait until the FeeEstimationService is ready."""
     global _fee_estimation_ready, _fee_estimation_error
 
     if _fee_estimation_ready:
@@ -64,6 +63,11 @@ def wait_for_fee_estimation_service_ready(env):
     raise _fee_estimation_error
 
 
+def wait_for_sync():
+    """Additional wait to ensure the mirror_node sync."""
+    time.sleep(2.0)
+
+
 @pytest.mark.integration
 def test_can_execute_fee_estimation_query(env):
     """
@@ -71,6 +75,7 @@ def test_can_execute_fee_estimation_query(env):
     """
     wait_for_fee_estimation_service_ready(env)
     tx = AccountCreateTransaction().set_key_without_alias(PrivateKey.generate_ed25519()).set_initial_balance(1)
+    wait_for_sync()
 
     query = FeeEstimateQuery().set_transaction(tx)
     result = query.execute(env.client)
@@ -85,6 +90,7 @@ def test_can_execute_fee_estimation_query2(env):
     """
     wait_for_fee_estimation_service_ready(env)
     tx = AccountCreateTransaction().set_key_without_alias(PrivateKey.generate_ed25519()).set_initial_balance(1)
+    wait_for_sync()
 
     query = FeeEstimateQuery().set_mode(FeeEstimateMode.STATE).set_transaction(tx)
     result = query.execute(env.client)
@@ -99,8 +105,9 @@ def test__fee_estimation_query_chunk_tx_can_execute(env):
     """
     wait_for_fee_estimation_service_ready(env)
     tx = FileAppendTransaction().set_file_id(FileId(0, 0, 2)).set_chunk_size(10).set_contents("s" * 33)  # 4 chunks
-
     tx.freeze_with(env.client)
+    wait_for_sync()
+
     query = FeeEstimateQuery().set_mode(FeeEstimateMode.STATE).set_transaction(tx)
     result = query.execute(env.client)
 
@@ -116,8 +123,9 @@ def test_can_execute_fee_estimation_query_chunk_tx(env):
     tx = (
         TopicMessageSubmitTransaction().set_topic_id(TopicId(0, 0, 2)).set_chunk_size(10).set_message("s" * 20)
     )  # 2 chunks
-
     tx.freeze_with(env.client)
+    wait_for_sync()
+
     query = FeeEstimateQuery().set_mode(FeeEstimateMode.STATE).set_transaction(tx)
     result = query.execute(env.client)
 


### PR DESCRIPTION
**Description**:
This PR addresses flaky failures in the integration test  with `FeeEstimateQuery` would fail because the `FeeEstimationService` had not yet started after a fresh Hiero Solo Mirror Node start.

**Changes Made:**
- Added `wait_for_fee_estimation_service_ready` to probe the service using an `INTRINSIC` mode query. This ensures the service is actually functional before the test suite proceeds.

**Related issue(s)**:

Fixes #2275 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
