### PR TITLE
docs: add PR review guidelines link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,13 @@ We welcome contributions! Whether you're:
 
 ---
 
+## Pull Request Reviews
+
+We welcome community reviews on our PRs.
+Please use this link [PR Review Guidelines](https://github.com/hiero-ledger/hiero-sdk-python/blob/main/docs/sdk_developers/pr_review_guidelines.md) to find a detailed guide on reviewing PRs.
+
+---
+
 ## License
 
 This project is licensed under the [Apache License 2.0](https://github.com/hiero-ledger/hiero-sdk-python/blob/main/LICENSE).


### PR DESCRIPTION
## Summary
Adds a new `## Pull Request Reviews` section to `README.md` with a link to the PR review guidelines document, making it easy for community contributors to find the guide.

## Changes
- Added `## Pull Request Reviews` section to `README.md` after `## Contributions`
- Link points to the full GitHub URL of `docs/sdk_developers/pr_review_guidelines.md`

Fixes #2277
