### PR TITLE
docs(examples): fix usage filename in chunked submit example

### DIFF
--- a/examples/consensus/topic_message_submit_chunked_transaction.py
+++ b/examples/consensus/topic_message_submit_chunked_transaction.py
@@ -2,8 +2,8 @@
 
 Example demonstrating topic message submit chunked transaction.
 
-uv run examples/consensus/topic_message_submit_chunked.py
-python examples/consensus/topic_message_submit_chunked.py
+uv run examples/consensus/topic_message_submit_chunked_transaction.py
+python examples/consensus/topic_message_submit_chunked_transaction.py
 """
 
 import sys


### PR DESCRIPTION
Fix incorrect usage/example commands in:

`examples/consensus/topic_message_submit_chunked_transaction.py`

The example previously referenced a non-existent filename:

`topic_message_submit_chunked.py`

This has been corrected to reference the actual example file:

`topic_message_submit_chunked_transaction.py`

**Related issue(s)**:

Fixes #2284

**Notes for reviewer**:

Validation performed:

* verified the updated paths match the real example filename
* confirmed only the intended file changed
* performed a targeted syntax sanity check using:
  `python3 -m py_compile examples/consensus/topic_message_submit_chunked_transaction.py`
