### PR TITLE
fix: correct usage filename in chunked consensus example

### DIFF
--- a/examples/consensus/topic_message_submit_chunked_transaction.py
+++ b/examples/consensus/topic_message_submit_chunked_transaction.py
@@ -1,9 +1,8 @@
 """
-
 Example demonstrating topic message submit chunked transaction.
 
-uv run examples/consensus/topic_message_submit_chunked.py
-python examples/consensus/topic_message_submit_chunked.py
+uv run examples/consensus/topic_message_submit_chunked_transaction.py
+python examples/consensus/topic_message_submit_chunked_transaction.py
 """
 
 import sys


### PR DESCRIPTION
The usage header in \`topic_message_submit_chunked_transaction.py\` referenced
the non-existent file \`topic_message_submit_chunked.py\`. Updated to the
correct filename so copy-paste commands are runnable.

Fixes #2284