### PR TITLE
fix: export MaxAttemptsError and add typed MaxQueryPaymentExceededError

### DIFF
--- a/src/hiero_sdk_python/__init__.py
+++ b/src/hiero_sdk_python/__init__.py
@@ -46,7 +46,7 @@ from .crypto.public_key import PublicKey
 from .Duration import Duration
 
 # Errors
-from .exceptions import PrecheckError, ReceiptStatusError
+from .exceptions import MaxAttemptsError, MaxQueryPaymentExceededError, PrecheckError, ReceiptStatusError
 
 # File
 from .file.file_append_transaction import FileAppendTransaction
@@ -293,6 +293,8 @@ __all__ = [
     "FreezeTransaction",
     "FreezeType",
     # Errors
-    "ReceiptStatusError",
+    "MaxAttemptsError",
+    "MaxQueryPaymentExceededError",
     "PrecheckError",
+    "ReceiptStatusError",
 ]

--- a/src/hiero_sdk_python/exceptions.py
+++ b/src/hiero_sdk_python/exceptions.py
@@ -7,6 +7,7 @@ from hiero_sdk_python.response_code import ResponseCode
 
 if TYPE_CHECKING:
     from hiero_sdk_python import TransactionId, TransactionReceipt
+    from hiero_sdk_python.hbar import Hbar
 
 
 class PrecheckError(Exception):
@@ -114,3 +115,50 @@ class ReceiptStatusError(Exception):
 
     def __repr__(self) -> str:
         return f"ReceiptStatusError(status={self.status}, transaction_id={self.transaction_id})"
+
+
+class MaxQueryPaymentExceededError(ValueError):
+    """
+    Exception raised when a query's actual network cost exceeds the configured maximum payment.
+
+    This is raised during query execution when the SDK fetches the real cost from the
+    network and finds it is higher than the allowed ceiling set by
+    ``Query.set_max_query_payment()`` or ``Client.set_default_max_query_payment()``.
+
+    Because this inherits from ``ValueError``, existing code that catches ``ValueError``
+    continues to work without modification.
+
+    Attributes:
+        query_cost (Hbar): The actual cost the network quoted for the query.
+        max_query_payment (Hbar): The maximum the caller was willing to pay.
+        message (str): Human-readable description of the violation.
+
+    Example::
+
+        from hiero_sdk_python import MaxQueryPaymentExceededError
+
+        try:
+            result = query.execute(client)
+        except MaxQueryPaymentExceededError as e:
+            print(f"Query costs {e.query_cost} but limit is {e.max_query_payment}")
+    """
+
+    def __init__(self, query_cost: Hbar, max_query_payment: Hbar) -> None:
+        self.query_cost = query_cost
+        self.max_query_payment = max_query_payment
+        message = (
+            f"Query cost {query_cost.to_hbars():.8f} ℏ "
+            f"exceeds the maximum query payment of {max_query_payment.to_hbars():.8f} ℏ"
+        )
+        self.message = message
+        super().__init__(message)
+
+    def __str__(self) -> str:
+        return self.message
+
+    def __repr__(self) -> str:
+        return (
+            f"MaxQueryPaymentExceededError("
+            f"query_cost={self.query_cost!r}, "
+            f"max_query_payment={self.max_query_payment!r})"
+        )

--- a/src/hiero_sdk_python/query/query.py
+++ b/src/hiero_sdk_python/query/query.py
@@ -10,7 +10,7 @@ from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client, Operator
 from hiero_sdk_python.crypto.private_key import PrivateKey
-from hiero_sdk_python.exceptions import PrecheckError, ReceiptStatusError
+from hiero_sdk_python.exceptions import MaxQueryPaymentExceededError, PrecheckError, ReceiptStatusError
 from hiero_sdk_python.executable import _Executable, _ExecutionState, _Method
 from hiero_sdk_python.hapi.services import (
     basic_types_pb2,
@@ -133,6 +133,10 @@ class Query(_Executable):
 
         Args:
             client: The client instance to use for execution
+
+        Raises:
+            MaxQueryPaymentExceededError: If the network-quoted cost is higher than
+                ``max_query_payment`` (per-query) or ``client.default_max_query_payment``.
         """
         self.operator = self.operator or client.operator
 
@@ -147,10 +151,7 @@ class Query(_Executable):
             )
 
             if self.payment_amount > max_payment:
-                raise ValueError(
-                    f"Query cost ℏ{self.payment_amount.to_hbars()} HBAR "
-                    f"exceeds max set query payment: ℏ{max_payment.to_hbars()} HBAR"
-                )
+                raise MaxQueryPaymentExceededError(self.payment_amount, max_payment)
 
     def _make_request_header(self) -> query_header_pb2.QueryHeader:
         """

--- a/tests/unit/exceptions_test.py
+++ b/tests/unit/exceptions_test.py
@@ -4,7 +4,9 @@ from unittest.mock import Mock
 
 import pytest
 
-from hiero_sdk_python.exceptions import MaxAttemptsError, PrecheckError, ReceiptStatusError
+import hiero_sdk_python
+from hiero_sdk_python.exceptions import MaxAttemptsError, MaxQueryPaymentExceededError, PrecheckError, ReceiptStatusError
+from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.response_code import ResponseCode
 
 
@@ -123,3 +125,46 @@ def test_precheck_error_with_none_transaction_id():
     err_custom = PrecheckError(ResponseCode.INVALID_SIGNATURE, None, "Missing transaction context")
     assert err_custom.transaction_id is None
     assert str(err_custom) == "Missing transaction context"
+
+
+def test_max_query_payment_exceeded_error_attributes():
+    """MaxQueryPaymentExceededError should carry typed Hbar attributes and a clear message."""
+    cost = Hbar(5)
+    limit = Hbar(1)
+    err = MaxQueryPaymentExceededError(cost, limit)
+
+    assert err.query_cost == cost
+    assert err.max_query_payment == limit
+    assert "5.00000000" in str(err)
+    assert "1.00000000" in str(err)
+
+
+def test_max_query_payment_exceeded_error_is_value_error():
+    """MaxQueryPaymentExceededError must inherit from ValueError for backward compatibility."""
+    err = MaxQueryPaymentExceededError(Hbar(10), Hbar(2))
+    assert isinstance(err, ValueError)
+
+
+def test_max_query_payment_exceeded_error_repr():
+    """repr() should include both Hbar amounts for debugging."""
+    err = MaxQueryPaymentExceededError(Hbar(3), Hbar(1))
+    r = repr(err)
+    assert "MaxQueryPaymentExceededError" in r
+    assert "query_cost" in r
+    assert "max_query_payment" in r
+
+
+def test_max_attempts_error_exported_from_top_level():
+    """MaxAttemptsError must be importable directly from hiero_sdk_python."""
+    assert hasattr(hiero_sdk_python, "MaxAttemptsError")
+    cls = hiero_sdk_python.MaxAttemptsError
+    err = cls("timed out", "0.0.3")
+    assert isinstance(err, Exception)
+
+
+def test_max_query_payment_exceeded_error_exported_from_top_level():
+    """MaxQueryPaymentExceededError must be importable directly from hiero_sdk_python."""
+    assert hasattr(hiero_sdk_python, "MaxQueryPaymentExceededError")
+    cls = hiero_sdk_python.MaxQueryPaymentExceededError
+    err = cls(Hbar(5), Hbar(1))
+    assert isinstance(err, ValueError)


### PR DESCRIPTION
## What problem does this fix?

I was reading through the SDK's retry logic and noticed something odd: `MaxAttemptsError` is documented in the docstrings of every single `execute()` and `get_cost()` call across 15+ files, and it is actively raised by `executable.py` — but it is **nowhere** in the top-level `hiero_sdk_python` package exports.

So if you write:

```python
from hiero_sdk_python import MaxAttemptsError  # ImportError 
```

…you get an `ImportError`. You have to know to reach into `hiero_sdk_python.exceptions` directly, which is inconsistent with how `PrecheckError` and `ReceiptStatusError` are already surfaced at the top level.

Separately, when a query's actual network cost exceeds the configured maximum, the SDK raises a bare `ValueError` with a formatted string. That means callers can't distinguish this specific failure from any other `ValueError` without parsing the message text — which is fragile.

## What this PR does

**1. Exports `MaxAttemptsError` from the top-level package**

No code change to the class itself — just adds it to `__init__.py` and `__all__`. Callers can now do:

```python
from hiero_sdk_python import MaxAttemptsError

try:
    receipt = tx.execute(client)
except MaxAttemptsError as e:
    print(f"Node {e.node_id} gave up after too many retries")
```

**2. Adds `MaxQueryPaymentExceededError(ValueError)`**

New exception class in `exceptions.py` with typed `query_cost` and `max_query_payment` attributes:

```python
from hiero_sdk_python import MaxQueryPaymentExceededError

try:
    result = query.execute(client)
except MaxQueryPaymentExceededError as e:
    print(f"Query costs {e.query_cost} but my limit is {e.max_query_payment}")
    # Retry with a higher limit or bail gracefully
```

Because it inherits from `ValueError`, any existing `except ValueError` blocks continue to catch it — fully backward-compatible.

**3. Updates `Query._before_execute()` to raise the new exception**

Replaces the bare `raise ValueError(f"Query cost ℏ... HBAR exceeds ...")` with `raise MaxQueryPaymentExceededError(cost, limit)`.

**4. Adds unit tests**

New tests in `exceptions_test.py` covering:
- `MaxQueryPaymentExceededError` attributes (`query_cost`, `max_query_payment`)
- Its inheritance from `ValueError`
- `repr()` output includes both amounts
- Both `MaxAttemptsError` and `MaxQueryPaymentExceededError` are importable from the top-level package

## Files changed

| File | Change |
|------|--------|
| `src/hiero_sdk_python/exceptions.py` | Add `MaxQueryPaymentExceededError` class |
| `src/hiero_sdk_python/__init__.py` | Export both exception classes |
| `src/hiero_sdk_python/query/query.py` | Raise typed exception; update docstring |
| `tests/unit/exceptions_test.py` | Five new test cases |

## Checklist

- [x] No new dependencies
- [x] No breaking changes (`MaxQueryPaymentExceededError` inherits `ValueError`)
- [x] Existing `except ValueError` blocks still work
- [x] Tests added for new behaviour
- [x] Ruff-clean (no style changes beyond the fix)