### PR TITLE
refactor: simplify delete_token_nft_allowance_all_serials entry handling

### DIFF
--- a/src/hiero_sdk_python/account/account_allowance_approve_transaction.py
+++ b/src/hiero_sdk_python/account/account_allowance_approve_transaction.py
@@ -281,12 +281,6 @@ class AccountAllowanceApproveTransaction(Transaction):
         """
         self._require_not_frozen()
 
-        for allowance in self.nft_allowances:
-            if allowance.token_id == token_id and allowance.spender_account_id == spender_account_id:
-                allowance.serial_numbers = []
-                allowance.approved_for_all = True
-                return self
-
         self.nft_allowances.append(
             TokenNftAllowance(
                 token_id=token_id,

--- a/tests/integration/account_allowance_e2e_test.py
+++ b/tests/integration/account_allowance_e2e_test.py
@@ -15,7 +15,9 @@ from hiero_sdk_python.account.account_allowance_delete_transaction import (
 from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.nft_id import NftId
-from hiero_sdk_python.tokens.token_associate_transaction import TokenAssociateTransaction
+from hiero_sdk_python.tokens.token_associate_transaction import (
+    TokenAssociateTransaction,
+)
 from hiero_sdk_python.tokens.token_mint_transaction import TokenMintTransaction
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 from hiero_sdk_python.transaction.transfer_transaction import TransferTransaction
@@ -61,7 +63,9 @@ def _mint_nft(env, token_id, metadata):
 
 
 @pytest.mark.integration
-def test_integration_cannot_transfer_on_behalf_of_spender_without_allowance_approval(env):
+def test_integration_cannot_transfer_on_behalf_of_spender_without_allowance_approval(
+    env,
+):
     """Test that a spender cannot transfer NFTs on behalf of account without allowance approval."""
     spender_account, receiver_account = _create_spender_and_receiver_accounts(env)
 
@@ -264,7 +268,9 @@ def test_integration_fungible_token_allowance(env):
 
 
 @pytest.mark.integration
-def test_integration_cant_transfer_on_behalf_of_spender_after_removing_the_allowance_approval(env):
+def test_integration_cant_transfer_on_behalf_of_spender_after_removing_the_allowance_approval(
+    env,
+):
     """Test that a spender cannot transfer NFTs after the allowance approval is removed."""
     spender_account, receiver_account = _create_spender_and_receiver_accounts(env)
 
@@ -485,4 +491,59 @@ def test_integration_cannot_send_deleted_token_nft_serials(env):
     assert transfer_receipt.status == ResponseCode.SPENDER_DOES_NOT_HAVE_ALLOWANCE, (
         f"Transfer should have failed with SPENDER_DOES_NOT_HAVE_ALLOWANCE"
         f"status but got: {ResponseCode(transfer_receipt.status).name}"
+    )
+
+
+@pytest.mark.integration
+def test_integration_can_approve_serial_and_delete_all_serials_in_one_transaction(env):
+    """Test that approve-serial + delete-all-serials in one transaction preserves the per-serial allowance."""
+    spender_account, receiver_account = _create_spender_and_receiver_accounts(env)
+
+    token_id = create_nft_token(env)
+    assert token_id is not None
+
+    _associate_token_with_account(env, receiver_account, token_id)
+
+    nft_ids = _mint_nft(env, token_id, [b"\x01", b"\x02"])
+    nft1 = nft_ids[0]
+    nft2 = nft_ids[1]
+
+    # Approve nft1 specifically and delete-all-serials for the same (token, spender)
+    # pair in the same transaction. The per-serial approval is preserved because the
+    # two operations produce independent NftAllowance entries.
+    receipt = (
+        AccountAllowanceApproveTransaction()
+        .approve_token_nft_allowance(nft1, env.operator_id, spender_account.id)
+        .delete_token_nft_allowance_all_serials(token_id, env.operator_id, spender_account.id)
+        .execute(env.client)
+    )
+    assert receipt.status == ResponseCode.SUCCESS, (
+        f"Allowance approval failed with status: {ResponseCode(receipt.status).name}"
+    )
+
+    # Transfer nft1 (should succeed - per-serial allowance preserved)
+    transfer_receipt = (
+        TransferTransaction()
+        .set_transaction_id(TransactionId.generate(spender_account.id))
+        .add_approved_nft_transfer(nft1, env.operator_id, receiver_account.id)
+        .freeze_with(env.client)
+        .sign(spender_account.key)
+        .execute(env.client)
+    )
+    assert transfer_receipt.status == ResponseCode.SUCCESS, (
+        f"Transfer failed with status: {ResponseCode(transfer_receipt.status).name}"
+    )
+
+    # Transfer nft2 (should fail - delete-all-serials revoked any blanket allowance)
+    transfer_receipt2 = (
+        TransferTransaction()
+        .set_transaction_id(TransactionId.generate(spender_account.id))
+        .add_approved_nft_transfer(nft2, env.operator_id, receiver_account.id)
+        .freeze_with(env.client)
+        .sign(spender_account.key)
+        .execute(env.client)
+    )
+    assert transfer_receipt2.status == ResponseCode.SPENDER_DOES_NOT_HAVE_ALLOWANCE, (
+        f"Transfer should have failed with SPENDER_DOES_NOT_HAVE_ALLOWANCE"
+        f"status but got: {ResponseCode(transfer_receipt2.status).name}"
     )

--- a/tests/integration/account_allowance_e2e_test.py
+++ b/tests/integration/account_allowance_e2e_test.py
@@ -13,6 +13,7 @@ from hiero_sdk_python.account.account_allowance_delete_transaction import (
     AccountAllowanceDeleteTransaction,
 )
 from hiero_sdk_python.hbar import Hbar
+from hiero_sdk_python.query.token_nft_info_query import TokenNftInfoQuery
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.nft_id import NftId
 from hiero_sdk_python.tokens.token_associate_transaction import (
@@ -532,6 +533,12 @@ def test_integration_can_approve_serial_and_delete_all_serials_in_one_transactio
     )
     assert transfer_receipt.status == ResponseCode.SUCCESS, (
         f"Transfer failed with status: {ResponseCode(transfer_receipt.status).name}"
+    )
+
+    # Confirm nft1 ownership has actually moved to the receiver
+    nft1_info = TokenNftInfoQuery(nft1).execute(env.client)
+    assert nft1_info.account_id == receiver_account.id, (
+        f"Expected nft1 owner to be receiver {receiver_account.id} after transfer, got {nft1_info.account_id}"
     )
 
     # Transfer nft2 (should fail - delete-all-serials revoked any blanket allowance)

--- a/tests/unit/account_allowance_approve_transaction_test.py
+++ b/tests/unit/account_allowance_approve_transaction_test.py
@@ -229,21 +229,25 @@ def test_delete_token_nft_allowance_all_serials_preserves_prior_serial_approval(
     account_allowance_transaction.approve_token_nft_allowance(nft_id, owner, spender)
     account_allowance_transaction.delete_token_nft_allowance_all_serials(token_id, owner, spender)
 
-    assert len(account_allowance_transaction.nft_allowances) == 2
+    assert len(account_allowance_transaction.nft_allowances) == 2, (
+        "Expected delete-all after per-serial approval to append a second NFT allowance entry"
+    )
 
     first = account_allowance_transaction.nft_allowances[0]
-    assert first.token_id == token_id
-    assert first.owner_account_id == owner
-    assert first.spender_account_id == spender
-    assert first.serial_numbers == [1]
-    assert first.approved_for_all is False
+    assert first.token_id == token_id, "Expected first entry token_id to match the approved NFT's token"
+    assert first.owner_account_id == owner, "Expected first entry owner to match"
+    assert first.spender_account_id == spender, "Expected first entry spender to match"
+    assert first.serial_numbers == [1], "Expected first entry to preserve approved serial [1]"
+    assert first.approved_for_all is False, (
+        "Expected first entry approved_for_all to remain False (per-serial approval)"
+    )
 
     second = account_allowance_transaction.nft_allowances[1]
-    assert second.token_id == token_id
-    assert second.owner_account_id == owner
-    assert second.spender_account_id == spender
-    assert second.serial_numbers == []
-    assert second.approved_for_all is False
+    assert second.token_id == token_id, "Expected second entry token_id to match the delete-all token"
+    assert second.owner_account_id == owner, "Expected second entry owner to match"
+    assert second.spender_account_id == spender, "Expected second entry spender to match"
+    assert second.serial_numbers == [], "Expected second entry to represent delete-all with empty serials"
+    assert second.approved_for_all is False, "Expected second entry approved_for_all to be False (revoke semantics)"
 
 
 def test_delete_token_nft_allowance_all_serials_appends_per_call(
@@ -257,13 +261,15 @@ def test_delete_token_nft_allowance_all_serials_appends_per_call(
     account_allowance_transaction.delete_token_nft_allowance_all_serials(token_id, owner, spender)
     account_allowance_transaction.delete_token_nft_allowance_all_serials(token_id, owner, spender)
 
-    assert len(account_allowance_transaction.nft_allowances) == 2
-    for allowance in account_allowance_transaction.nft_allowances:
-        assert allowance.token_id == token_id
-        assert allowance.owner_account_id == owner
-        assert allowance.spender_account_id == spender
-        assert allowance.serial_numbers == []
-        assert allowance.approved_for_all is False
+    assert len(account_allowance_transaction.nft_allowances) == 2, (
+        "Expected each delete-all call to append a separate NFT allowance entry"
+    )
+    for index, allowance in enumerate(account_allowance_transaction.nft_allowances):
+        assert allowance.token_id == token_id, f"Entry {index}: token_id mismatch"
+        assert allowance.owner_account_id == owner, f"Entry {index}: owner mismatch"
+        assert allowance.spender_account_id == spender, f"Entry {index}: spender mismatch"
+        assert allowance.serial_numbers == [], f"Entry {index}: expected empty serial_numbers for delete-all"
+        assert allowance.approved_for_all is False, f"Entry {index}: expected approved_for_all=False (revoke semantics)"
 
 
 def test_add_all_token_nft_approval(account_allowance_transaction, sample_accounts, sample_tokens):

--- a/tests/unit/account_allowance_approve_transaction_test.py
+++ b/tests/unit/account_allowance_approve_transaction_test.py
@@ -217,6 +217,55 @@ def test_delete_token_nft_allowance_all_serials(account_allowance_transaction, s
     assert allowance.approved_for_all is False
 
 
+def test_delete_token_nft_allowance_all_serials_preserves_prior_serial_approval(
+    account_allowance_transaction, sample_accounts, sample_tokens
+):
+    """Test that delete-all-serials does not fold into a prior per-serial approval."""
+    token_id = sample_tokens["token1"]
+    owner = sample_accounts["owner"]
+    spender = sample_accounts["spender"]
+    nft_id = NftId(token_id, 1)
+
+    account_allowance_transaction.approve_token_nft_allowance(nft_id, owner, spender)
+    account_allowance_transaction.delete_token_nft_allowance_all_serials(token_id, owner, spender)
+
+    assert len(account_allowance_transaction.nft_allowances) == 2
+
+    first = account_allowance_transaction.nft_allowances[0]
+    assert first.token_id == token_id
+    assert first.owner_account_id == owner
+    assert first.spender_account_id == spender
+    assert first.serial_numbers == [1]
+    assert first.approved_for_all is False
+
+    second = account_allowance_transaction.nft_allowances[1]
+    assert second.token_id == token_id
+    assert second.owner_account_id == owner
+    assert second.spender_account_id == spender
+    assert second.serial_numbers == []
+    assert second.approved_for_all is False
+
+
+def test_delete_token_nft_allowance_all_serials_appends_per_call(
+    account_allowance_transaction, sample_accounts, sample_tokens
+):
+    """Test that repeated delete-all-serials calls append one entry per call."""
+    token_id = sample_tokens["token1"]
+    owner = sample_accounts["owner"]
+    spender = sample_accounts["spender"]
+
+    account_allowance_transaction.delete_token_nft_allowance_all_serials(token_id, owner, spender)
+    account_allowance_transaction.delete_token_nft_allowance_all_serials(token_id, owner, spender)
+
+    assert len(account_allowance_transaction.nft_allowances) == 2
+    for allowance in account_allowance_transaction.nft_allowances:
+        assert allowance.token_id == token_id
+        assert allowance.owner_account_id == owner
+        assert allowance.spender_account_id == spender
+        assert allowance.serial_numbers == []
+        assert allowance.approved_for_all is False
+
+
 def test_add_all_token_nft_approval(account_allowance_transaction, sample_accounts, sample_tokens):
     """Test adding all token NFT approval"""
     token_id = sample_tokens["token1"]


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->
Simplify `AccountAllowanceApproveTransaction.delete_token_nft_allowance_all_serials` so that each call produces its own `TokenNftAllowance` entry. Repeated or chained calls on the same `(token, spender)` pair are no longer folded into a single entry 
* Update `delete_token_nft_allowance_all_serials` to append a new `TokenNftAllowance` entry per call instead of folding into an existing entry
* Add unit test covering `approve_token_nft_allowance` followed by `delete_token_nft_allowance_all_serials` on the same `(token, spender)` pair
* Add unit test covering repeated `delete_token_nft_allowance_all_serials` calls on the same `(token, spender)` pair
* Add e2e test covering `approve_token_nft_allowance` followed by `delete_token_nft_allowance_all_serials` on the same `(token, spender)` pair

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
