### PR TITLE
chore: update `soloVersion` to `v0.69.0` in examples and tests workflow

### DIFF
--- a/.github/workflows/pr-check-secondary-examples.yml
+++ b/.github/workflows/pr-check-secondary-examples.yml
@@ -37,7 +37,7 @@ jobs:
         uses: hiero-ledger/hiero-solo-action@328bc84c3b00a990a151418144fd682a4eb76ea6 #v0.19.0
         with:
           installMirrorNode: true
-          soloVersion: v0.65.0
+          soloVersion: v0.69.0
           mirrorNodeVersion: v0.153.0
           hieroVersion: v0.73.0
 

--- a/.github/workflows/pr-check-secondary-unit-integration-test.yml
+++ b/.github/workflows/pr-check-secondary-unit-integration-test.yml
@@ -132,7 +132,7 @@ jobs:
         uses: hiero-ledger/hiero-solo-action@328bc84c3b00a990a151418144fd682a4eb76ea6 # v0.19.0
         with:
           installMirrorNode: true
-          soloVersion: v0.65.0
+          soloVersion: v0.69.0
           mirrorNodeVersion: v0.153.0
           hieroVersion: v0.73.0
 


### PR DESCRIPTION
**Description**:
This PR updates the workflow configurations to use a newer version of the `solo` component in GitHub Actions. The change ensures that both the secondary examples and unit/integration test jobs use `soloVersion` v0.69.0 instead of v0.65.0.


**Related issue(s)**:
Fixes #2297 