### PR TITLE
feat: add freeze_with method to TopicCreateTransaction for auto-renew account handling

### DIFF
--- a/src/hiero_sdk_python/consensus/topic_create_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_create_transaction.py
@@ -9,6 +9,8 @@ transaction body for submission to the Hedera network .
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.crypto.key import Key
@@ -21,6 +23,10 @@ from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
 from hiero_sdk_python.tokens.custom_fixed_fee import CustomFixedFee
 from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.utils.key_utils import key_to_proto
+
+
+if TYPE_CHECKING:
+    from hiero_sdk_python.client.client import Client
 
 
 class TopicCreateTransaction(Transaction):
@@ -186,6 +192,27 @@ class TopicCreateTransaction(Transaction):
         self._require_not_frozen()
         self.fee_exempt_keys = keys
         return self
+
+    def freeze_with(self, client: Client) -> TopicCreateTransaction:
+        """
+        Freeze the transaction with the given client.
+
+        If `auto_renew_account` was not explicitly set, automatically assigns it:
+        - If `transaction_id` is already set, use its `account_id`.
+        - Otherwise, fall back to the client's `operator_account_id`.
+
+        Args:
+            client (Client): The client instance to use for setting defaults.
+
+        Returns:
+            TopicCreateTransaction: The current transaction instance for method chaining.
+        """
+        if client is not None and client.operator_account_id is not None and self.auto_renew_account is None:
+            self.auto_renew_account = (
+                self.transaction_id.account_id if self.transaction_id is not None else client.operator_account_id
+            )
+
+        return super().freeze_with(client)
 
     def _to_proto_key(self, key: Key | None):
         """

--- a/tck/handlers/topic.py
+++ b/tck/handlers/topic.py
@@ -73,9 +73,6 @@ def create_topic(params: CreateTopicParams) -> CreateTopicResponse:
 
     transaction = _build_create_topic_transaction(params)
 
-    if params.autoRenewAccountId is None and client is not None and client.operator_account_id is not None:
-        transaction.set_auto_renew_account(client.operator_account_id)
-
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 

--- a/tests/unit/topic_create_transaction_test.py
+++ b/tests/unit/topic_create_transaction_test.py
@@ -630,3 +630,14 @@ def test_freeze_with_auto_renew_account_set_via_setter(mock_client):
     body = frozen_tx.build_transaction_body()
 
     assert body.consensusCreateTopic.autoRenewAccount == explicit_account._to_proto()
+
+
+def test_freeze_with_leaves_auto_renew_account_unset_without_operator(mock_client):
+    """Test that freeze_with leaves auto_renew_account unset when operator_account_id is None."""
+    mock_client.operator_account_id = None
+    tx = TopicCreateTransaction(memo="test topic")
+    tx.transaction_id = _generate_transaction_id(AccountId(0, 0, 1234))
+    frozen_tx = tx.freeze_with(mock_client)
+    body = frozen_tx.build_transaction_body()
+
+    assert not body.consensusCreateTopic.HasField("autoRenewAccount")

--- a/tests/unit/topic_create_transaction_test.py
+++ b/tests/unit/topic_create_transaction_test.py
@@ -23,6 +23,7 @@ from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.custom_fixed_fee import CustomFixedFee
 from hiero_sdk_python.tokens.token_id import TokenId
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 from tests.unit.mock_server import mock_hedera_servers
 
 
@@ -574,3 +575,58 @@ def test_mixed_key_types_in_constructor(mock_account_ids):
     assert transaction_body.consensusCreateTopic.submitKey.ed25519 == ed25519_public.to_bytes_raw()
     assert transaction_body.consensusCreateTopic.fee_schedule_key.HasField("ECDSA_secp256k1")
     assert len(transaction_body.consensusCreateTopic.fee_exempt_key_list) == 2
+
+
+def _generate_transaction_id(account_id):
+    """Generate a unique transaction ID based on the account ID and the current timestamp."""
+    import time
+
+    from hiero_sdk_python.hapi.services import timestamp_pb2
+
+    current_time = time.time()
+    timestamp_seconds = int(current_time)
+    timestamp_nanos = int((current_time - timestamp_seconds) * 1e9)
+
+    tx_timestamp = timestamp_pb2.Timestamp(seconds=timestamp_seconds, nanos=timestamp_nanos)
+    return TransactionId(valid_start=tx_timestamp, account_id=account_id)
+
+
+def test_freeze_with_defaults_auto_renew_account_to_operator(mock_client):
+    """Test that freeze_with sets auto_renew_account to operator when not explicitly set."""
+    tx = TopicCreateTransaction(memo="test topic")
+    frozen_tx = tx.freeze_with(mock_client)
+    body = frozen_tx.build_transaction_body()
+
+    assert body.consensusCreateTopic.autoRenewAccount == mock_client.operator_account_id._to_proto()
+
+
+def test_freeze_with_preserves_explicit_auto_renew_account(mock_client):
+    """Test that freeze_with does not override an explicitly set auto_renew_account."""
+    explicit_account = AccountId(0, 0, 9999)
+    tx = TopicCreateTransaction(memo="test topic", auto_renew_account=explicit_account)
+    frozen_tx = tx.freeze_with(mock_client)
+    body = frozen_tx.build_transaction_body()
+
+    assert body.consensusCreateTopic.autoRenewAccount == explicit_account._to_proto()
+
+
+def test_freeze_with_uses_transaction_id_account_when_set(mock_client):
+    """Test that freeze_with uses transaction_id.account_id when transaction_id is set."""
+    tx_account = AccountId(0, 0, 5555)
+    tx = TopicCreateTransaction(memo="test topic")
+    tx.transaction_id = _generate_transaction_id(tx_account)
+    frozen_tx = tx.freeze_with(mock_client)
+    body = frozen_tx.build_transaction_body()
+
+    assert body.consensusCreateTopic.autoRenewAccount == tx_account._to_proto()
+
+
+def test_freeze_with_auto_renew_account_set_via_setter(mock_client):
+    """Test that freeze_with preserves auto_renew_account set via set_auto_renew_account."""
+    explicit_account = AccountId(0, 0, 7777)
+    tx = TopicCreateTransaction(memo="test topic")
+    tx.set_auto_renew_account(explicit_account)
+    frozen_tx = tx.freeze_with(mock_client)
+    body = frozen_tx.build_transaction_body()
+
+    assert body.consensusCreateTopic.autoRenewAccount == explicit_account._to_proto()

--- a/tests/unit/topic_create_transaction_test.py
+++ b/tests/unit/topic_create_transaction_test.py
@@ -577,20 +577,6 @@ def test_mixed_key_types_in_constructor(mock_account_ids):
     assert len(transaction_body.consensusCreateTopic.fee_exempt_key_list) == 2
 
 
-def _generate_transaction_id(account_id):
-    """Generate a unique transaction ID based on the account ID and the current timestamp."""
-    import time
-
-    from hiero_sdk_python.hapi.services import timestamp_pb2
-
-    current_time = time.time()
-    timestamp_seconds = int(current_time)
-    timestamp_nanos = int((current_time - timestamp_seconds) * 1e9)
-
-    tx_timestamp = timestamp_pb2.Timestamp(seconds=timestamp_seconds, nanos=timestamp_nanos)
-    return TransactionId(valid_start=tx_timestamp, account_id=account_id)
-
-
 def test_freeze_with_defaults_auto_renew_account_to_operator(mock_client):
     """Test that freeze_with sets auto_renew_account to operator when not explicitly set."""
     tx = TopicCreateTransaction(memo="test topic")
@@ -614,7 +600,7 @@ def test_freeze_with_uses_transaction_id_account_when_set(mock_client):
     """Test that freeze_with uses transaction_id.account_id when transaction_id is set."""
     tx_account = AccountId(0, 0, 5555)
     tx = TopicCreateTransaction(memo="test topic")
-    tx.transaction_id = _generate_transaction_id(tx_account)
+    tx.transaction_id = TransactionId.generate(tx_account)
     frozen_tx = tx.freeze_with(mock_client)
     body = frozen_tx.build_transaction_body()
 
@@ -636,7 +622,7 @@ def test_freeze_with_leaves_auto_renew_account_unset_without_operator(mock_clien
     """Test that freeze_with leaves auto_renew_account unset when operator_account_id is None."""
     mock_client.operator_account_id = None
     tx = TopicCreateTransaction(memo="test topic")
-    tx.transaction_id = _generate_transaction_id(AccountId(0, 0, 1234))
+    tx.transaction_id = TransactionId.generate(AccountId(0, 0, 1234))
     frozen_tx = tx.freeze_with(mock_client)
     body = frozen_tx.build_transaction_body()
 


### PR DESCRIPTION
**Description**:
This pull request enhances the handling of the `auto_renew_account` field in the `TopicCreateTransaction` class to ensure it is set to a sensible default if not explicitly provided. It introduces a new `freeze_with` method that sets `auto_renew_account` based on the transaction or client context, removes redundant logic from the TCK handler, and adds comprehensive unit tests to verify the new behavior.

**Enhancements to `TopicCreateTransaction` auto-renew account logic:**

* Added a `freeze_with` method to `TopicCreateTransaction` that automatically sets `auto_renew_account` to the transaction's `account_id` (if `transaction_id` is set) or falls back to the client's `operator_account_id` if not explicitly set. This ensures that the field is always populated with a valid value before freezing the transaction.
* Removed redundant logic from the TCK handler (`tck/handlers/topic.py`) that previously set the `auto_renew_account`, as this is now handled within the transaction itself.

**Testing improvements:**

* Added multiple unit tests to `tests/unit/topic_create_transaction_test.py` to verify that `freeze_with` sets or preserves the `auto_renew_account` field correctly in various scenarios, including when set explicitly, via setter, or derived from the transaction ID or client.
* Introduced a helper function `_generate_transaction_id` in the test suite to facilitate testing scenarios involving transaction IDs.

**Codebase maintainability:**

* Added `TYPE_CHECKING` imports to avoid circular dependencies and improve type hinting in `topic_create_transaction.py`. [[1]](diffhunk://#diff-f88080d83a7889986c701b0d443e3a68e260f4d294b6cff712dd5a98d5de60bdR12-R13) [[2]](diffhunk://#diff-f88080d83a7889986c701b0d443e3a68e260f4d294b6cff712dd5a98d5de60bdR28-R31)
* Included missing import for `TransactionId` in the unit test file to support new test cases.
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #2299 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
