### PR TITLE
fix: enabled open to community review for bot-authored PRs

### DIFF
--- a/.github/scripts/review-sync/helpers/labels.js
+++ b/.github/scripts/review-sync/helpers/labels.js
@@ -179,7 +179,7 @@ async function syncLabel(github, owner, repo, pr, dryRun) {
   );
 
   const isHuman = pr.user && pr.user.type !== 'Bot';
-  const needsCommunityReview = isHuman && !currentLabels.includes(COMMUNITY_REVIEW.name);
+  const needsCommunityReview = !currentLabels.includes(COMMUNITY_REVIEW.name);
 
   // Check if the correct labels are already present AND there are no stale labels to remove
   if (currentLabels.includes(correctLabel.name) && staleLabels.length === 0 && !needsCommunityReview) {

--- a/.github/scripts/review-sync/helpers/labels.js
+++ b/.github/scripts/review-sync/helpers/labels.js
@@ -178,12 +178,11 @@ async function syncLabel(github, owner, repo, pr, dryRun) {
     (name) => ALL_QUEUE_LABEL_NAMES.includes(name) && name !== correctLabel.name
   );
 
-  const isHuman = pr.user && pr.user.type !== 'Bot';
   const needsCommunityReview = !currentLabels.includes(COMMUNITY_REVIEW.name);
 
   // Check if the correct labels are already present AND there are no stale labels to remove
   if (currentLabels.includes(correctLabel.name) && staleLabels.length === 0 && !needsCommunityReview) {
-    console.log(`    ✓ Already has "${correctLabel.name}"${isHuman ? ` and "${COMMUNITY_REVIEW.name}"` : ''}. No change needed.`);
+    console.log(`    ✓ Already has "${correctLabel.name}" and "${COMMUNITY_REVIEW.name}". No change needed.`);
     return false;
   }
 

--- a/.github/scripts/review-sync/tests/test-labels.js
+++ b/.github/scripts/review-sync/tests/test-labels.js
@@ -157,7 +157,7 @@ const unitTests = [
       const mock = createMockGithub({ roles: {}, reviews: [] });
       const pr = { number: 1, labels: [{ name: 'queue:junior-committer' }], head: { sha: '123' }, user: { type: 'Bot' } };
       const changed = await syncLabel(mock, 'o', 'r', pr, false);
-      // Already has junior-committer, and being a Bot means it shouldn't add community review
+      // Already has junior-committer; missing COMMUNITY_REVIEW should be added for bot PRs too
       return changed === true && mock.calls.labelsAdded.includes(COMMUNITY_REVIEW.name);
     },
   },

--- a/.github/scripts/review-sync/tests/test-labels.js
+++ b/.github/scripts/review-sync/tests/test-labels.js
@@ -113,7 +113,7 @@ const unitTests = [
     name: 'syncLabel: already correct, no stale → returns false',
     test: async () => {
       const mock = createMockGithub({ roles: {}, reviews: [] });
-      const changed = await syncLabel(mock, 'o', 'r', { number: 1, labels: [{ name: 'queue:junior-committer' }], head: { sha: '123' }, user: { type: 'Bot' } }, false);
+      const changed = await syncLabel(mock, 'o', 'r', { number: 1, labels: [{ name: 'queue:junior-committer' }, { name: COMMUNITY_REVIEW.name }], head: { sha: '123' }, user: { type: 'Bot' } }, false);
       return changed === false && mock.calls.labelsAdded.length === 0;
     },
   },
@@ -152,13 +152,13 @@ const unitTests = [
     },
   },
   {
-    name: 'syncLabel: bot PR does NOT receive community review label',
+    name: 'syncLabel: bot PR receives community review label if missing',
     test: async () => {
       const mock = createMockGithub({ roles: {}, reviews: [] });
       const pr = { number: 1, labels: [{ name: 'queue:junior-committer' }], head: { sha: '123' }, user: { type: 'Bot' } };
       const changed = await syncLabel(mock, 'o', 'r', pr, false);
       // Already has junior-committer, and being a Bot means it shouldn't add community review
-      return changed === false && mock.calls.labelsAdded.length === 0;
+      return changed === true && mock.calls.labelsAdded.includes(COMMUNITY_REVIEW.name);
     },
   },
   {

--- a/.github/workflows/request-triage-review.yml
+++ b/.github/workflows/request-triage-review.yml
@@ -18,7 +18,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'Good First Issue') ||
       contains(github.event.pull_request.labels.*.name, 'skill: beginner') ||
       contains(github.event.pull_request.labels.*.name, 'beginner')
-    runs-on: [self-hosted, hl-sdk-py-lin-md]
+    runs-on: hl-sdk-py-lin-md
 
     steps:
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
**Description**:
Enabled "open to community review" for bot-authored PRs.

Changes `needCommunityReview` logic to allow community review for bot-authored PRs. Updated unit tests `syncLabel: bot PR does NOT receive community review label` and `syncLabel: already correct, no stale → returns false` logics to expect the label to be added.

Fixes #2272 
