### PR TITLE
Mnemonic clean

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pycryptodome>=3.18.0,<4",
     "eth-abi>=5.1.0,<6",
     "python-dotenv>=1.2.1,<3",
+    "mnemonic>=0.21,<1",
 ]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/src/hiero_sdk_python/__init__.py
+++ b/src/hiero_sdk_python/__init__.py
@@ -39,6 +39,7 @@ from .contract.ethereum_transaction import EthereumTransaction
 
 # Crypto
 from .crypto.evm_address import EvmAddress
+from .crypto.mnemonic import MnemonicPhrase
 from .crypto.private_key import PrivateKey
 from .crypto.public_key import PublicKey
 
@@ -172,6 +173,7 @@ __all__ = [
     "AccountRecordsQuery",
     # Crypto
     "PrivateKey",
+    "MnemonicPhrase",
     "PublicKey",
     "EvmAddress",
     # Tokens

--- a/src/hiero_sdk_python/crypto/__init__.py
+++ b/src/hiero_sdk_python/crypto/__init__.py
@@ -1,0 +1,8 @@
+from hiero_sdk_python.crypto.key import Key
+from hiero_sdk_python.crypto.key_list import KeyList
+from hiero_sdk_python.crypto.mnemonic import MnemonicPhrase
+from hiero_sdk_python.crypto.private_key import PrivateKey
+from hiero_sdk_python.crypto.public_key import PublicKey
+
+
+__all__ = ["Key", "KeyList", "MnemonicPhrase", "PrivateKey", "PublicKey"]

--- a/src/hiero_sdk_python/crypto/mnemonic.py
+++ b/src/hiero_sdk_python/crypto/mnemonic.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mnemonic import Mnemonic
+
+from hiero_sdk_python.crypto.private_key import PrivateKey
+
+
+@dataclass(frozen=True)
+class MnemonicPhrase:
+    """BIP-39 mnemonic utilities for deterministic wallet workflows."""
+
+    phrase: str
+
+    @classmethod
+    def generate(cls, strength: int = 256) -> MnemonicPhrase:
+        """Generate a valid English BIP-39 mnemonic phrase."""
+        return cls(Mnemonic("english").generate(strength=strength))
+
+    @classmethod
+    def from_phrase(cls, phrase: str) -> MnemonicPhrase:
+        """Construct and validate a BIP-39 mnemonic phrase."""
+        mnemonic = Mnemonic("english")
+        normalized = " ".join(phrase.strip().split())
+        if not mnemonic.check(normalized):
+            raise ValueError("Invalid BIP-39 mnemonic phrase.")
+        return cls(normalized)
+
+    def is_valid(self) -> bool:
+        """Check whether the phrase has valid BIP-39 checksum and words."""
+        return Mnemonic("english").check(self.phrase)
+
+    def to_seed(self, passphrase: str = "") -> bytes:
+        """Convert mnemonic phrase to BIP-39 seed bytes."""
+        return Mnemonic.to_seed(self.phrase, passphrase=passphrase)
+
+    def to_private_key_ed25519(self, passphrase: str = "") -> PrivateKey:
+        """Derive an Ed25519 private key from the first 32 bytes of BIP-39 seed.
+
+        This provides deterministic key material suitable for local development
+        and reproducible testing workflows.
+        """
+        seed = self.to_seed(passphrase=passphrase)
+        return PrivateKey.from_bytes_ed25519(seed[:32])

--- a/tests/unit/mnemonic_test.py
+++ b/tests/unit/mnemonic_test.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pytest
+
+from hiero_sdk_python.crypto.mnemonic import MnemonicPhrase
+from hiero_sdk_python.crypto.private_key import PrivateKey
+
+
+def test_generate_is_valid_default_24_words():
+    """Generated default mnemonic should be valid and contain 24 words."""
+    phrase = MnemonicPhrase.generate()
+    assert phrase.is_valid()
+    assert len(phrase.phrase.split()) == 24
+
+
+def test_generate_with_128_strength_returns_12_words():
+    """128-bit entropy should generate a valid 12-word mnemonic."""
+    phrase = MnemonicPhrase.generate(strength=128)
+
+    assert isinstance(phrase, MnemonicPhrase)
+    assert phrase.is_valid()
+    assert len(phrase.phrase.split()) == 12
+
+
+def test_from_phrase_normalizes_and_validates():
+    """Input phrase should be whitespace-normalized and pass checksum validation."""
+    phrase = MnemonicPhrase.from_phrase(
+        "  abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about  "
+    )
+
+    assert isinstance(phrase, MnemonicPhrase)
+    assert (
+        phrase.phrase == "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+    )
+
+
+def test_invalid_phrase_raises_value_error():
+    """Invalid checksum mnemonic should raise ValueError during construction."""
+    invalid = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon"
+
+    with pytest.raises(ValueError, match="Invalid BIP-39 mnemonic phrase."):
+        MnemonicPhrase.from_phrase(invalid)
+
+
+def test_seed_and_ed25519_key_derivation_is_deterministic():
+    """Known mnemonic+passphrase should produce deterministic seed and Ed25519 key bytes."""
+    phrase = MnemonicPhrase.from_phrase(
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+    )
+
+    seed = phrase.to_seed(passphrase="TREZOR")
+
+    assert isinstance(seed, bytes)
+    assert seed.hex().startswith("c55257c360c07c72029aebc1b53c05ed")
+
+    private_key = phrase.to_private_key_ed25519(passphrase="TREZOR")
+
+    assert isinstance(private_key, PrivateKey)
+    assert private_key.to_string_ed25519_raw() == seed[:32].hex()
+
+
+def test_to_seed_without_passphrase_is_deterministic():
+    """Mnemonic seed derivation should work with default empty passphrase."""
+    phrase = MnemonicPhrase.from_phrase(
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+    )
+
+    seed = phrase.to_seed()
+
+    assert isinstance(seed, bytes)
+    assert seed.hex().startswith("5eb00bbddcf069084889a8ab91555681")


### PR DESCRIPTION
**Description**:

Add BIP-39 mnemonic phrase support to the SDK for deterministic wallet recovery and developer onboarding workflows.

This PR introduces a new `MnemonicPhrase` crypto utility that supports phrase generation, validation/normalization, seed derivation, and deterministic Ed25519 private key derivation from mnemonic seeds.

* Add `MnemonicPhrase` utility for BIP-39 workflows
* Add mnemonic phrase generation with 24-word default
* Add phrase normalization and validation helpers
* Add seed derivation with optional passphrase support
* Add deterministic Ed25519 private key derivation from seed bytes
* Export `MnemonicPhrase` from crypto package and top-level SDK exports
* Add `mnemonic` dependency for BIP-39 support
* Add unit tests for generation, validation, checksum rejection, and deterministic derivation flows

**Related issue(s)**:

Fixes #2315 

**Notes for reviewer**:

Current implementation supports English BIP-39 phrases via the `mnemonic` package.

`to_private_key_ed25519()` currently derives the key from the first 32 bytes of the generated seed for deterministic workflows. Full HD derivation path support (e.g. SLIP-10/BIP44 child derivation) is not included in this PR and can be added in a future enhancement.

Test coverage includes:

* Valid 24-word mnemonic generation
* Phrase normalization + validation
* Invalid checksum rejection
* Deterministic seed/private key derivation using known mnemonic + passphrase combinations

**Checklist**

* [x] Documented (Code comments, README, etc.)
* [x] Tested (unit, integration, etc.)

