### PR TITLE
refactor: use set_key_with_alias in EVM alias example

### DIFF
--- a/examples/account/account_create_transaction_evm_alias.py
+++ b/examples/account/account_create_transaction_evm_alias.py
@@ -23,7 +23,6 @@ from hiero_sdk_python import (
     AccountInfo,
     AccountInfoQuery,
     Client,
-    EvmAddress,
     Hbar,
     PrivateKey,
     PublicKey,
@@ -40,19 +39,21 @@ def setup_client() -> Client:
     return client
 
 
-def generate_alias_key() -> tuple[PrivateKey, PublicKey, EvmAddress]:
+def generate_alias_key() -> tuple[PrivateKey, PublicKey]:
     """
 
-    Generate a new ECDSA key pair and derive its EVM-style alias address.
+    Generate a new ECDSA key pair for the account.
 
     EVM aliases on Hedera must be derived from an ECDSA (secp256k1) key pair.
     The EVM address is the last 20 bytes of the keccak256 hash of the public key.
+    The alias itself is derived automatically by
+    ``AccountCreateTransaction.set_key_with_alias`` in the next step, so this
+    helper only needs to return the key pair.
 
     Returns:
-        tuple: A 3-tuple of:
+        tuple: A 2-tuple of:
             - private_key: The newly generated ECDSA private key.
             - public_key: The public key corresponding to the private key.
-            - evm_address (EvmAddress): The derived EVM address to be used as an alias.
     """
     print("\nSTEP 1: Generating a new ECDSA key pair for the account alias...")
 
@@ -60,7 +61,8 @@ def generate_alias_key() -> tuple[PrivateKey, PublicKey, EvmAddress]:
     private_key = PrivateKey.generate("ecdsa")
     public_key = private_key.public_key()
 
-    # Compute the EVM address from the public key
+    # Validate that the key is ECDSA-compatible by deriving the EVM address.
+    # The actual alias will be derived by set_key_with_alias() in the next step.
     try:
         evm_address = public_key.to_evm_address()
     except ValueError as e:
@@ -68,15 +70,17 @@ def generate_alias_key() -> tuple[PrivateKey, PublicKey, EvmAddress]:
         sys.exit(1)
 
     print(f"✅ Generated new ECDSA key pair. EVM Address (alias): {evm_address}")
-    return private_key, public_key, evm_address
+    return private_key, public_key
 
 
-def create_account_with_alias(
-    client: Client, private_key: PrivateKey, public_key: PublicKey, evm_address: EvmAddress
-) -> AccountId:
+def create_account_with_alias(client: Client, private_key: PrivateKey, public_key: PublicKey) -> AccountId:
     """
 
-    Create a new Hedera account using the provided EVM-style alias.
+    Create a new Hedera account using an EVM-style alias.
+
+    ``set_key_with_alias`` sets the account key and derives the EVM-address alias
+    from the same public key in a single call, replacing the deprecated pairing
+    of ``set_key`` and ``set_alias``.
 
     Important: When creating an account with an alias, the transaction must be
     signed by the private key corresponding to that alias. This proves ownership
@@ -87,9 +91,7 @@ def create_account_with_alias(
         private_key: The newly generated `PrivateKey` corresponding to the
             alias public key, used to sign the transaction.
         public_key: The public key associated with `private_key`, which is
-            set as the new account's key.
-        evm_address: The EVM-style alias (derived from `public_key`) to assign
-            to the new account.
+            set as the new account's key and used to derive the alias.
 
     Returns:
         The `AccountId` of the newly created account.
@@ -97,7 +99,7 @@ def create_account_with_alias(
     """
     print("\nSTEP 2: Creating the account with the EVM address alias...")
 
-    transaction = AccountCreateTransaction().set_key(public_key).set_initial_balance(Hbar(5)).set_alias(evm_address)
+    transaction = AccountCreateTransaction().set_key_with_alias(public_key).set_initial_balance(Hbar(5))
 
     # Sign with new key (required for alias)
     # The client.execute() call below will attach the operator signature automatically.
@@ -136,9 +138,9 @@ def main():
     """Orchestrate the example workflow."""
     client = setup_client()
     try:
-        private_key, public_key, evm_address = generate_alias_key()
+        private_key, public_key = generate_alias_key()
 
-        new_account_id = create_account_with_alias(client, private_key, public_key, evm_address)
+        new_account_id = create_account_with_alias(client, private_key, public_key)
 
         account_info = fetch_account_info(client, new_account_id)
 


### PR DESCRIPTION
## Description

Refactors `examples/account/account_create_transaction_evm_alias.py` to replace the **deprecated** `set_key(...)` + `set_alias(...)` pairing with the unified `set_key_with_alias(...)` method, as requested in #2327.

`set_key_with_alias` sets the account key **and** derives the EVM-address alias from the same public key in a single call, so the example no longer needs to derive and pass the alias around manually.

## Changes

- `generate_alias_key()` now returns only the `(private_key, public_key)` pair. The EVM address is still derived locally to validate the key is ECDSA and to print it for the user, mirroring the pattern already used in the sibling `account_create_transaction_with_fallback_alias.py` example.
- `create_account_with_alias()` drops the `evm_address` parameter and builds the transaction with `AccountCreateTransaction().set_key_with_alias(public_key).set_initial_balance(Hbar(5))`.
- `main()` updated to the new signatures.
- Removed the now-unused `EvmAddress` import.
- Updated docstrings accordingly.

## Verification

- `ruff check` — passes
- `ruff format --check` — clean
- **Behavior-preserving:** building the transaction the old way (`set_key` + `set_alias`) and the new way (`set_key_with_alias`) yields an identical account key and alias, and the alias equals `public_key.to_evm_address()`. Confirmed locally:

  ```
  key equal      : True
  alias equal    : True
  balance equal  : True
  new.alias==evm : True
  ```

Closes #2327

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)