### PR TITLE
validate threshold as non-negative integer in tck KeyGenerationParams

### DIFF
--- a/src/hiero_sdk_python/account/account_records_query.py
+++ b/src/hiero_sdk_python/account/account_records_query.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import traceback
-
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
@@ -59,26 +57,22 @@ class AccountRecordsQuery(Query):
 
         Raises:
             ValueError: If the account ID is not set.
-            Exception: If any other error occurs during request construction.
+            TypeError: If any other error occurs during request construction.
+            AttributeError: If any other error occurs during request construction.
         """
-        try:
-            if not self.account_id:
-                raise ValueError("Account ID must be set before making the request.")
+        if not self.account_id:
+            raise ValueError("Account ID must be set before making the request.")
 
-            query_header = self._make_request_header()
+        query_header = self._make_request_header()
 
-            crypto_records_query = crypto_get_account_records_pb2.CryptoGetAccountRecordsQuery()
-            crypto_records_query.header.CopyFrom(query_header)
-            crypto_records_query.accountID.CopyFrom(self.account_id._to_proto())
+        crypto_records_query = crypto_get_account_records_pb2.CryptoGetAccountRecordsQuery()
+        crypto_records_query.header.CopyFrom(query_header)
+        crypto_records_query.accountID.CopyFrom(self.account_id._to_proto())
 
-            query = query_pb2.Query()
-            query.cryptoGetAccountRecords.CopyFrom(crypto_records_query)
+        query = query_pb2.Query()
+        query.cryptoGetAccountRecords.CopyFrom(crypto_records_query)
 
-            return query
-        except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
-            raise
+        return query
 
     def _get_method(self, channel: _Channel) -> _Method:
         """

--- a/src/hiero_sdk_python/client/network.py
+++ b/src/hiero_sdk_python/client/network.py
@@ -191,7 +191,13 @@ class Network:
 
     def _fetch_nodes_from_default_nodes(self) -> list[_Node]:
         """Fetches the list of nodes from the default nodes for the network."""
-        return [_Node(node[1], node[0], None) for node in self.DEFAULT_NODES[self.network]]
+        node_list = self.DEFAULT_NODES.get(self.network)
+        if node_list is None:
+            raise ValueError(
+                f"Unknown network '{self.network}'; no default nodes available. "
+                f"Supported networks: {list(self.DEFAULT_NODES.keys())}"
+            )
+        return [_Node(node[1], node[0], None) for node in node_list]
 
     def _select_node(self) -> _Node:
         """

--- a/src/hiero_sdk_python/contract/contract_bytecode_query.py
+++ b/src/hiero_sdk_python/contract/contract_bytecode_query.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import traceback
-
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
 from hiero_sdk_python.contract.contract_id import ContractId
@@ -16,7 +14,10 @@ from hiero_sdk_python.hapi.services import (
 from hiero_sdk_python.hapi.services.contract_get_bytecode_pb2 import (
     ContractGetBytecodeResponse,
 )
+from hiero_sdk_python.logger.logger import get_logger
 from hiero_sdk_python.query.query import Query
+
+logger = get_logger()
 
 
 class ContractBytecodeQuery(Query):
@@ -80,8 +81,7 @@ class ContractBytecodeQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logger.error("Exception in _make_request", e)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/contract/contract_call_query.py
+++ b/src/hiero_sdk_python/contract/contract_call_query.py
@@ -4,8 +4,6 @@
 
 from __future__ import annotations
 
-import traceback
-
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
@@ -20,7 +18,10 @@ from hiero_sdk_python.hapi.services import (
     query_pb2,
     response_pb2,
 )
+from hiero_sdk_python.logger.logger import get_logger
 from hiero_sdk_python.query.query import Query
+
+logger = get_logger()
 
 
 class ContractCallQuery(Query):
@@ -160,8 +161,7 @@ class ContractCallQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logger.error("Exception in _make_request", e)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/contract/contract_info_query.py
+++ b/src/hiero_sdk_python/contract/contract_info_query.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import traceback
-
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
 from hiero_sdk_python.contract.contract_id import ContractId
@@ -59,26 +57,22 @@ class ContractInfoQuery(Query):
 
         Raises:
             ValueError: If the contract ID is not set.
-            Exception: If any other error occurs during request construction.
+            TypeError: If any other error occurs during request construction.
+            AttributeError: If any other error occurs during request construction.
         """
-        try:
-            if not self.contract_id:
-                raise ValueError("Contract ID must be set before making the request.")
+        if not self.contract_id:
+            raise ValueError("Contract ID must be set before making the request.")
 
-            query_header = self._make_request_header()
+        query_header = self._make_request_header()
 
-            contract_info_query = contract_get_info_pb2.ContractGetInfoQuery()
-            contract_info_query.header.CopyFrom(query_header)
-            contract_info_query.contractID.CopyFrom(self.contract_id._to_proto())
+        contract_info_query = contract_get_info_pb2.ContractGetInfoQuery()
+        contract_info_query.header.CopyFrom(query_header)
+        contract_info_query.contractID.CopyFrom(self.contract_id._to_proto())
 
-            query = query_pb2.Query()
-            query.contractGetInfo.CopyFrom(contract_info_query)
+        query = query_pb2.Query()
+        query.contractGetInfo.CopyFrom(contract_info_query)
 
-            return query
-        except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
-            raise
+        return query
 
     def _get_method(self, channel: _Channel) -> _Method:
         """

--- a/src/hiero_sdk_python/file/file_contents_query.py
+++ b/src/hiero_sdk_python/file/file_contents_query.py
@@ -12,7 +12,10 @@ from hiero_sdk_python.hapi.services import (
     response_pb2,
 )
 from hiero_sdk_python.hapi.services.file_get_contents_pb2 import FileGetContentsResponse
+from hiero_sdk_python.logger.logger import get_logger
 from hiero_sdk_python.query.query import Query
+
+logger = get_logger()
 
 
 class FileContentsQuery(Query):
@@ -76,7 +79,7 @@ class FileContentsQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
+            logger.error("Exception in _make_request", e)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/file/file_info_query.py
+++ b/src/hiero_sdk_python/file/file_info_query.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import traceback
-
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
 from hiero_sdk_python.executable import _Method
@@ -11,7 +9,10 @@ from hiero_sdk_python.file.file_id import FileId
 from hiero_sdk_python.file.file_info import FileInfo
 from hiero_sdk_python.hapi.services import file_get_info_pb2, query_pb2, response_pb2
 from hiero_sdk_python.hapi.services.file_get_info_pb2 import FileGetInfoResponse
+from hiero_sdk_python.logger.logger import get_logger
 from hiero_sdk_python.query.query import Query
+
+logger = get_logger()
 
 
 class FileInfoQuery(Query):
@@ -75,8 +76,7 @@ class FileInfoQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logger.error("Exception in _make_request", e)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/query/account_balance_query.py
+++ b/src/hiero_sdk_python/query/account_balance_query.py
@@ -172,7 +172,7 @@ class CryptoGetAccountBalanceQuery(Query):
         """
         return response.cryptogetAccountBalance
 
-    def _is_payment_required(self):
+    def _is_payment_required(self) -> bool:
         """
         Account balance query does not require payment.
 

--- a/src/hiero_sdk_python/query/account_balance_query.py
+++ b/src/hiero_sdk_python/query/account_balance_query.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import traceback
 from typing import Any
 
 from hiero_sdk_python.account.account_balance import AccountBalance
@@ -10,10 +9,7 @@ from hiero_sdk_python.client.client import Client
 from hiero_sdk_python.contract.contract_id import ContractId
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services import crypto_get_account_balance_pb2, query_pb2
-from hiero_sdk_python.logger.logger import get_logger
 from hiero_sdk_python.query.query import Query
-
-logger = get_logger()
 
 
 class CryptoGetAccountBalanceQuery(Query):
@@ -89,34 +85,30 @@ class CryptoGetAccountBalanceQuery(Query):
         Raises:
             ValueError: If both the account ID and contract ID are not set.
             ValueError: If both the account ID and contract ID are set.
+            TypeError: If the Query protobuf structure is invalid.
             AttributeError: If the Query protobuf structure is invalid.
-            Exception: If any other error occurs during request construction.
         """
-        try:
-            if not self.account_id and not self.contract_id:
-                raise ValueError("Either account_id or contract_id must be set before making the request.")
+        if not self.account_id and not self.contract_id:
+            raise ValueError("Either account_id or contract_id must be set before making the request.")
 
-            if self.account_id and self.contract_id:
-                raise ValueError("Specify either account_id or contract_id, not both.")
+        if self.account_id and self.contract_id:
+            raise ValueError("Specify either account_id or contract_id, not both.")
 
-            query_header = self._make_request_header()
-            crypto_get_balance = crypto_get_account_balance_pb2.CryptoGetAccountBalanceQuery()
-            crypto_get_balance.header.CopyFrom(query_header)
+        query_header = self._make_request_header()
+        crypto_get_balance = crypto_get_account_balance_pb2.CryptoGetAccountBalanceQuery()
+        crypto_get_balance.header.CopyFrom(query_header)
 
-            if self.account_id:
-                crypto_get_balance.accountID.CopyFrom(self.account_id._to_proto())
-            else:
-                crypto_get_balance.contractID.CopyFrom(self.contract_id._to_proto())
+        if self.account_id:
+            crypto_get_balance.accountID.CopyFrom(self.account_id._to_proto())
+        else:
+            crypto_get_balance.contractID.CopyFrom(self.contract_id._to_proto())
 
-            query = query_pb2.Query()
-            if not hasattr(query, "cryptogetAccountBalance"):
-                raise AttributeError("Query object has no attribute 'cryptogetAccountBalance'")
-            query.cryptogetAccountBalance.CopyFrom(crypto_get_balance)
+        query = query_pb2.Query()
+        if not hasattr(query, "cryptogetAccountBalance"):
+            raise AttributeError("Query object has no attribute 'cryptogetAccountBalance'")
+        query.cryptogetAccountBalance.CopyFrom(crypto_get_balance)
 
-            return query
-        except Exception as e:
-            logger.error("Exception in _make_request", e)
-            raise
+        return query
 
     def _get_method(self, channel: _Channel) -> _Method:
         """

--- a/src/hiero_sdk_python/query/account_balance_query.py
+++ b/src/hiero_sdk_python/query/account_balance_query.py
@@ -10,7 +10,10 @@ from hiero_sdk_python.client.client import Client
 from hiero_sdk_python.contract.contract_id import ContractId
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services import crypto_get_account_balance_pb2, query_pb2
+from hiero_sdk_python.logger.logger import get_logger
 from hiero_sdk_python.query.query import Query
+
+logger = get_logger()
 
 
 class CryptoGetAccountBalanceQuery(Query):
@@ -112,8 +115,7 @@ class CryptoGetAccountBalanceQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logger.error("Exception in _make_request", e)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/query/account_info_query.py
+++ b/src/hiero_sdk_python/query/account_info_query.py
@@ -5,10 +5,7 @@ from hiero_sdk_python.account.account_info import AccountInfo
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services import crypto_get_info_pb2, query_pb2
-from hiero_sdk_python.logger.logger import get_logger
 from hiero_sdk_python.query.query import Query
-
-logger = get_logger()
 
 
 class AccountInfoQuery(Query):
@@ -56,25 +53,22 @@ class AccountInfoQuery(Query):
 
         Raises:
             ValueError: If the account ID is not set.
-            Exception: If any other error occurs during request construction.
+            TypeError: If any other error occurs during request construction.
+            AttributeError: If any other error occurs during request construction.
         """
-        try:
-            if not self.account_id:
-                raise ValueError("Account ID must be set before making the request.")
+        if not self.account_id:
+            raise ValueError("Account ID must be set before making the request.")
 
-            query_header = self._make_request_header()
+        query_header = self._make_request_header()
 
-            crypto_info_query = crypto_get_info_pb2.CryptoGetInfoQuery()
-            crypto_info_query.header.CopyFrom(query_header)
-            crypto_info_query.accountID.CopyFrom(self.account_id._to_proto())
+        crypto_info_query = crypto_get_info_pb2.CryptoGetInfoQuery()
+        crypto_info_query.header.CopyFrom(query_header)
+        crypto_info_query.accountID.CopyFrom(self.account_id._to_proto())
 
-            query = query_pb2.Query()
-            query.cryptoGetInfo.CopyFrom(crypto_info_query)
+        query = query_pb2.Query()
+        query.cryptoGetInfo.CopyFrom(crypto_info_query)
 
-            return query
-        except Exception as e:
-            logger.error("Exception in _make_request", e)
-            raise
+        return query
 
     def _get_method(self, channel: _Channel) -> _Method:
         """

--- a/src/hiero_sdk_python/query/account_info_query.py
+++ b/src/hiero_sdk_python/query/account_info_query.py
@@ -5,7 +5,10 @@ from hiero_sdk_python.account.account_info import AccountInfo
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services import crypto_get_info_pb2, query_pb2
+from hiero_sdk_python.logger.logger import get_logger
 from hiero_sdk_python.query.query import Query
+
+logger = get_logger()
 
 
 class AccountInfoQuery(Query):
@@ -70,7 +73,7 @@ class AccountInfoQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
+            logger.error("Exception in _make_request", e)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/schedule/schedule_info_query.py
+++ b/src/hiero_sdk_python/schedule/schedule_info_query.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
-import traceback
-
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services import query_pb2, response_pb2, schedule_get_info_pb2
 from hiero_sdk_python.hapi.services.schedule_get_info_pb2 import ScheduleGetInfoResponse
+from hiero_sdk_python.logger.logger import get_logger
 from hiero_sdk_python.query.query import Query
 from hiero_sdk_python.schedule.schedule_id import ScheduleId
 from hiero_sdk_python.schedule.schedule_info import ScheduleInfo
+
+logger = get_logger()
 
 
 class ScheduleInfoQuery(Query):
@@ -71,8 +72,7 @@ class ScheduleInfoQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logger.error("Exception in _make_request", e)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/tck/errors.py
+++ b/tck/errors.py
@@ -116,7 +116,7 @@ def handle_sdk_errors(func):
             logger.error(f"MaxAttemptsError (method: {func.__name__})")
             raise JsonRpcError.hiero_error(message=str(e)) from e
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, OSError, IOError, RuntimeError) as e:
             logger.exception("Unhandled error in RPC handler")
             raise JsonRpcError.internal_error(message="Internal error") from e
 

--- a/tck/param/key.py
+++ b/tck/param/key.py
@@ -16,9 +16,34 @@ class KeyGenerationParams:
     def parse_json_params(cls, params: dict) -> KeyGenerationParams:
         key_list = params.get("keys") or []
 
+        raw_threshold = params.get("threshold")
+        if raw_threshold is not None:
+            # The dataclass field is declared `int | None` and the downstream
+            # call site (`int(params.threshold)` in `_handle_key_list`) only
+            # accepts integer-shaped values, but the previous parser passed
+            # `params.get("threshold")` through unchecked, so a test (or a
+            # typo in a TCK spec test) sending `threshold: "three"`, `3.5` as
+            # a string, or `threshold: {}` would raise ValueError/TypeError
+            # out of `int(...)` and bubble all the way up to a generic
+            # internal_error instead of a descriptive invalid_params_error.
+            # bool is technically an int subclass, but `threshold: true` is
+            # semantically meaningless for a threshold count, so reject it
+            # explicitly. Floats are rejected because they are almost always
+            # a spec error (a threshold of 2.5 has no well-defined meaning).
+            if isinstance(raw_threshold, bool) or not isinstance(
+                raw_threshold, int
+            ):
+                raise ValueError(
+                    f"threshold must be an integer, got {type(raw_threshold).__name__}: {raw_threshold!r}"
+                )
+            if raw_threshold < 0:
+                raise ValueError(
+                    f"threshold must be a non-negative integer, got {raw_threshold}"
+                )
+
         return cls(
             type=(KeyType.from_string(params.get("type")) if params.get("type") else None),
             fromKey=params.get("fromKey"),
-            threshold=params.get("threshold"),
+            threshold=raw_threshold,
             keys=[cls.parse_json_params(k) for k in key_list],
         )


### PR DESCRIPTION
## Problem

`tck/param/key.py` passed `params.get('threshold')` through to the dataclass field unchecked, and the downstream `int(params.threshold)` call in `tck/handlers/key.py` (`_handle_key_list`) raised `ValueError` or `TypeError` on non-integer-shaped inputs:

| input | what `int(...)` does |
| --- | --- |
| `'three'` | `ValueError: invalid literal for int()`
| `'3'` (string) | works (parses) — but `'3.5'` raises `ValueError`
| `3.5` (float) | works (truncates) — silent precision loss
| `True` / `False` | works (`1` / `0`) — semantically wrong
| `{}`, `[1, 2]` | `TypeError: int() argument must be ... not 'dict'` / `'list'`
| `-1` | works — but a negative threshold is invalid

Those exceptions bubbled up to `tck/handlers/registry.py:dispatch` → `handle_sdk_errors`, which catches `(ValueError, TypeError, KeyError, OSError, IOError, RuntimeError)` and converts them to a generic `internal_error` JSON-RPC response. The spec test runner sees `-32603 Internal error` instead of `-32602 Invalid params`, with the actual reason ("threshold must be an integer, got dict: {}") hidden in the logger.

## Fix

In `parse_json_params`, validate that `threshold` is a non-negative integer before constructing the dataclass instance, and raise `ValueError` on bad input. `dispatch()` already converts `ValueError` from `parse_json_params` into `invalid_params_error`, so spec tests see a descriptive `-32602` response with the actual reason.

Reject:
- `bool` (Python `bool` is an `int` subclass, but `threshold: true` is semantically wrong)
- `float` (a threshold of `2.5` has no well-defined meaning)
- `str`, `dict`, `list`, etc. (must be castable to a count, not just int-convertible)
- negative integers (a -1 threshold is nonsense)