### PR TITLE
chore: Remove ref option from checkout step in on-review workflow

### DIFF
--- a/.github/workflows/on-review.yml
+++ b/.github/workflows/on-review.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.ref }}
           persist-credentials: false
 
       - name: Run Add Reviewers as Assignees


### PR DESCRIPTION
**Description**:
This pull request makes a small update to the GitHub Actions workflow configuration by removing the explicit `ref` parameter from the repository checkout step. This change simplifies the workflow and relies on the default behavior for determining which commit to check out.
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #2366 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
