### PR TITLE
strip surrounding whitespace in EvmAddress.from_string

### DIFF
--- a/src/hiero_sdk_python/account/account_records_query.py
+++ b/src/hiero_sdk_python/account/account_records_query.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import traceback
-
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
@@ -59,26 +57,22 @@ class AccountRecordsQuery(Query):
 
         Raises:
             ValueError: If the account ID is not set.
-            Exception: If any other error occurs during request construction.
+            TypeError: If any other error occurs during request construction.
+            AttributeError: If any other error occurs during request construction.
         """
-        try:
-            if not self.account_id:
-                raise ValueError("Account ID must be set before making the request.")
+        if not self.account_id:
+            raise ValueError("Account ID must be set before making the request.")
 
-            query_header = self._make_request_header()
+        query_header = self._make_request_header()
 
-            crypto_records_query = crypto_get_account_records_pb2.CryptoGetAccountRecordsQuery()
-            crypto_records_query.header.CopyFrom(query_header)
-            crypto_records_query.accountID.CopyFrom(self.account_id._to_proto())
+        crypto_records_query = crypto_get_account_records_pb2.CryptoGetAccountRecordsQuery()
+        crypto_records_query.header.CopyFrom(query_header)
+        crypto_records_query.accountID.CopyFrom(self.account_id._to_proto())
 
-            query = query_pb2.Query()
-            query.cryptoGetAccountRecords.CopyFrom(crypto_records_query)
+        query = query_pb2.Query()
+        query.cryptoGetAccountRecords.CopyFrom(crypto_records_query)
 
-            return query
-        except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
-            raise
+        return query
 
     def _get_method(self, channel: _Channel) -> _Method:
         """

--- a/src/hiero_sdk_python/client/network.py
+++ b/src/hiero_sdk_python/client/network.py
@@ -191,7 +191,13 @@ class Network:
 
     def _fetch_nodes_from_default_nodes(self) -> list[_Node]:
         """Fetches the list of nodes from the default nodes for the network."""
-        return [_Node(node[1], node[0], None) for node in self.DEFAULT_NODES[self.network]]
+        node_list = self.DEFAULT_NODES.get(self.network)
+        if node_list is None:
+            raise ValueError(
+                f"Unknown network '{self.network}'; no default nodes available. "
+                f"Supported networks: {list(self.DEFAULT_NODES.keys())}"
+            )
+        return [_Node(node[1], node[0], None) for node in node_list]
 
     def _select_node(self) -> _Node:
         """

--- a/src/hiero_sdk_python/contract/contract_bytecode_query.py
+++ b/src/hiero_sdk_python/contract/contract_bytecode_query.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import traceback
-
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
 from hiero_sdk_python.contract.contract_id import ContractId
@@ -16,7 +14,10 @@ from hiero_sdk_python.hapi.services import (
 from hiero_sdk_python.hapi.services.contract_get_bytecode_pb2 import (
     ContractGetBytecodeResponse,
 )
+from hiero_sdk_python.logger.logger import get_logger
 from hiero_sdk_python.query.query import Query
+
+logger = get_logger()
 
 
 class ContractBytecodeQuery(Query):
@@ -80,8 +81,7 @@ class ContractBytecodeQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logger.error("Exception in _make_request", e)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/contract/contract_call_query.py
+++ b/src/hiero_sdk_python/contract/contract_call_query.py
@@ -4,8 +4,6 @@
 
 from __future__ import annotations
 
-import traceback
-
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
@@ -20,7 +18,10 @@ from hiero_sdk_python.hapi.services import (
     query_pb2,
     response_pb2,
 )
+from hiero_sdk_python.logger.logger import get_logger
 from hiero_sdk_python.query.query import Query
+
+logger = get_logger()
 
 
 class ContractCallQuery(Query):
@@ -160,8 +161,7 @@ class ContractCallQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logger.error("Exception in _make_request", e)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/contract/contract_info_query.py
+++ b/src/hiero_sdk_python/contract/contract_info_query.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import traceback
-
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
 from hiero_sdk_python.contract.contract_id import ContractId
@@ -59,26 +57,22 @@ class ContractInfoQuery(Query):
 
         Raises:
             ValueError: If the contract ID is not set.
-            Exception: If any other error occurs during request construction.
+            TypeError: If any other error occurs during request construction.
+            AttributeError: If any other error occurs during request construction.
         """
-        try:
-            if not self.contract_id:
-                raise ValueError("Contract ID must be set before making the request.")
+        if not self.contract_id:
+            raise ValueError("Contract ID must be set before making the request.")
 
-            query_header = self._make_request_header()
+        query_header = self._make_request_header()
 
-            contract_info_query = contract_get_info_pb2.ContractGetInfoQuery()
-            contract_info_query.header.CopyFrom(query_header)
-            contract_info_query.contractID.CopyFrom(self.contract_id._to_proto())
+        contract_info_query = contract_get_info_pb2.ContractGetInfoQuery()
+        contract_info_query.header.CopyFrom(query_header)
+        contract_info_query.contractID.CopyFrom(self.contract_id._to_proto())
 
-            query = query_pb2.Query()
-            query.contractGetInfo.CopyFrom(contract_info_query)
+        query = query_pb2.Query()
+        query.contractGetInfo.CopyFrom(contract_info_query)
 
-            return query
-        except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
-            raise
+        return query
 
     def _get_method(self, channel: _Channel) -> _Method:
         """

--- a/src/hiero_sdk_python/crypto/evm_address.py
+++ b/src/hiero_sdk_python/crypto/evm_address.py
@@ -27,6 +27,7 @@ class EvmAddress(Key):
         if not isinstance(evm_address, str):
             raise TypeError("evm_address must be a of type string.")
 
+        evm_address = evm_address.strip()
         address = evm_address[2:] if evm_address.startswith("0x") else evm_address
 
         if len(address) == 40:

--- a/src/hiero_sdk_python/file/file_contents_query.py
+++ b/src/hiero_sdk_python/file/file_contents_query.py
@@ -12,7 +12,10 @@ from hiero_sdk_python.hapi.services import (
     response_pb2,
 )
 from hiero_sdk_python.hapi.services.file_get_contents_pb2 import FileGetContentsResponse
+from hiero_sdk_python.logger.logger import get_logger
 from hiero_sdk_python.query.query import Query
+
+logger = get_logger()
 
 
 class FileContentsQuery(Query):
@@ -76,7 +79,7 @@ class FileContentsQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
+            logger.error("Exception in _make_request", e)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/file/file_info_query.py
+++ b/src/hiero_sdk_python/file/file_info_query.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import traceback
-
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
 from hiero_sdk_python.executable import _Method
@@ -11,7 +9,10 @@ from hiero_sdk_python.file.file_id import FileId
 from hiero_sdk_python.file.file_info import FileInfo
 from hiero_sdk_python.hapi.services import file_get_info_pb2, query_pb2, response_pb2
 from hiero_sdk_python.hapi.services.file_get_info_pb2 import FileGetInfoResponse
+from hiero_sdk_python.logger.logger import get_logger
 from hiero_sdk_python.query.query import Query
+
+logger = get_logger()
 
 
 class FileInfoQuery(Query):
@@ -75,8 +76,7 @@ class FileInfoQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logger.error("Exception in _make_request", e)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/query/account_balance_query.py
+++ b/src/hiero_sdk_python/query/account_balance_query.py
@@ -172,7 +172,7 @@ class CryptoGetAccountBalanceQuery(Query):
         """
         return response.cryptogetAccountBalance
 
-    def _is_payment_required(self):
+    def _is_payment_required(self) -> bool:
         """
         Account balance query does not require payment.
 

--- a/src/hiero_sdk_python/query/account_balance_query.py
+++ b/src/hiero_sdk_python/query/account_balance_query.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import traceback
 from typing import Any
 
 from hiero_sdk_python.account.account_balance import AccountBalance
@@ -10,10 +9,7 @@ from hiero_sdk_python.client.client import Client
 from hiero_sdk_python.contract.contract_id import ContractId
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services import crypto_get_account_balance_pb2, query_pb2
-from hiero_sdk_python.logger.logger import get_logger
 from hiero_sdk_python.query.query import Query
-
-logger = get_logger()
 
 
 class CryptoGetAccountBalanceQuery(Query):
@@ -89,34 +85,30 @@ class CryptoGetAccountBalanceQuery(Query):
         Raises:
             ValueError: If both the account ID and contract ID are not set.
             ValueError: If both the account ID and contract ID are set.
+            TypeError: If the Query protobuf structure is invalid.
             AttributeError: If the Query protobuf structure is invalid.
-            Exception: If any other error occurs during request construction.
         """
-        try:
-            if not self.account_id and not self.contract_id:
-                raise ValueError("Either account_id or contract_id must be set before making the request.")
+        if not self.account_id and not self.contract_id:
+            raise ValueError("Either account_id or contract_id must be set before making the request.")
 
-            if self.account_id and self.contract_id:
-                raise ValueError("Specify either account_id or contract_id, not both.")
+        if self.account_id and self.contract_id:
+            raise ValueError("Specify either account_id or contract_id, not both.")
 
-            query_header = self._make_request_header()
-            crypto_get_balance = crypto_get_account_balance_pb2.CryptoGetAccountBalanceQuery()
-            crypto_get_balance.header.CopyFrom(query_header)
+        query_header = self._make_request_header()
+        crypto_get_balance = crypto_get_account_balance_pb2.CryptoGetAccountBalanceQuery()
+        crypto_get_balance.header.CopyFrom(query_header)
 
-            if self.account_id:
-                crypto_get_balance.accountID.CopyFrom(self.account_id._to_proto())
-            else:
-                crypto_get_balance.contractID.CopyFrom(self.contract_id._to_proto())
+        if self.account_id:
+            crypto_get_balance.accountID.CopyFrom(self.account_id._to_proto())
+        else:
+            crypto_get_balance.contractID.CopyFrom(self.contract_id._to_proto())
 
-            query = query_pb2.Query()
-            if not hasattr(query, "cryptogetAccountBalance"):
-                raise AttributeError("Query object has no attribute 'cryptogetAccountBalance'")
-            query.cryptogetAccountBalance.CopyFrom(crypto_get_balance)
+        query = query_pb2.Query()
+        if not hasattr(query, "cryptogetAccountBalance"):
+            raise AttributeError("Query object has no attribute 'cryptogetAccountBalance'")
+        query.cryptogetAccountBalance.CopyFrom(crypto_get_balance)
 
-            return query
-        except Exception as e:
-            logger.error("Exception in _make_request", e)
-            raise
+        return query
 
     def _get_method(self, channel: _Channel) -> _Method:
         """

--- a/src/hiero_sdk_python/query/account_balance_query.py
+++ b/src/hiero_sdk_python/query/account_balance_query.py
@@ -10,7 +10,10 @@ from hiero_sdk_python.client.client import Client
 from hiero_sdk_python.contract.contract_id import ContractId
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services import crypto_get_account_balance_pb2, query_pb2
+from hiero_sdk_python.logger.logger import get_logger
 from hiero_sdk_python.query.query import Query
+
+logger = get_logger()
 
 
 class CryptoGetAccountBalanceQuery(Query):
@@ -112,8 +115,7 @@ class CryptoGetAccountBalanceQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logger.error("Exception in _make_request", e)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/query/account_info_query.py
+++ b/src/hiero_sdk_python/query/account_info_query.py
@@ -5,10 +5,7 @@ from hiero_sdk_python.account.account_info import AccountInfo
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services import crypto_get_info_pb2, query_pb2
-from hiero_sdk_python.logger.logger import get_logger
 from hiero_sdk_python.query.query import Query
-
-logger = get_logger()
 
 
 class AccountInfoQuery(Query):
@@ -56,25 +53,22 @@ class AccountInfoQuery(Query):
 
         Raises:
             ValueError: If the account ID is not set.
-            Exception: If any other error occurs during request construction.
+            TypeError: If any other error occurs during request construction.
+            AttributeError: If any other error occurs during request construction.
         """
-        try:
-            if not self.account_id:
-                raise ValueError("Account ID must be set before making the request.")
+        if not self.account_id:
+            raise ValueError("Account ID must be set before making the request.")
 
-            query_header = self._make_request_header()
+        query_header = self._make_request_header()
 
-            crypto_info_query = crypto_get_info_pb2.CryptoGetInfoQuery()
-            crypto_info_query.header.CopyFrom(query_header)
-            crypto_info_query.accountID.CopyFrom(self.account_id._to_proto())
+        crypto_info_query = crypto_get_info_pb2.CryptoGetInfoQuery()
+        crypto_info_query.header.CopyFrom(query_header)
+        crypto_info_query.accountID.CopyFrom(self.account_id._to_proto())
 
-            query = query_pb2.Query()
-            query.cryptoGetInfo.CopyFrom(crypto_info_query)
+        query = query_pb2.Query()
+        query.cryptoGetInfo.CopyFrom(crypto_info_query)
 
-            return query
-        except Exception as e:
-            logger.error("Exception in _make_request", e)
-            raise
+        return query
 
     def _get_method(self, channel: _Channel) -> _Method:
         """

--- a/src/hiero_sdk_python/query/account_info_query.py
+++ b/src/hiero_sdk_python/query/account_info_query.py
@@ -5,7 +5,10 @@ from hiero_sdk_python.account.account_info import AccountInfo
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services import crypto_get_info_pb2, query_pb2
+from hiero_sdk_python.logger.logger import get_logger
 from hiero_sdk_python.query.query import Query
+
+logger = get_logger()
 
 
 class AccountInfoQuery(Query):
@@ -70,7 +73,7 @@ class AccountInfoQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
+            logger.error("Exception in _make_request", e)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/schedule/schedule_info_query.py
+++ b/src/hiero_sdk_python/schedule/schedule_info_query.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
-import traceback
-
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services import query_pb2, response_pb2, schedule_get_info_pb2
 from hiero_sdk_python.hapi.services.schedule_get_info_pb2 import ScheduleGetInfoResponse
+from hiero_sdk_python.logger.logger import get_logger
 from hiero_sdk_python.query.query import Query
 from hiero_sdk_python.schedule.schedule_id import ScheduleId
 from hiero_sdk_python.schedule.schedule_info import ScheduleInfo
+
+logger = get_logger()
 
 
 class ScheduleInfoQuery(Query):
@@ -71,8 +72,7 @@ class ScheduleInfoQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logger.error("Exception in _make_request", e)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/tck/errors.py
+++ b/tck/errors.py
@@ -116,7 +116,7 @@ def handle_sdk_errors(func):
             logger.error(f"MaxAttemptsError (method: {func.__name__})")
             raise JsonRpcError.hiero_error(message=str(e)) from e
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, OSError, IOError, RuntimeError) as e:
             logger.exception("Unhandled error in RPC handler")
             raise JsonRpcError.internal_error(message="Internal error") from e
 

--- a/tests/unit/evm_address_test.py
+++ b/tests/unit/evm_address_test.py
@@ -42,6 +42,16 @@ def test_from_string_invalid_hex_characters():
         EvmAddress.from_string("0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ")
 
 
+def test_from_string_with_surrounding_whitespace():
+    """Surrounding whitespace (from .env, JSON config, shell vars) should be stripped, not rejected."""
+    hex_no_prefix = "1234567890abcdef1234567890abcdef12345678"
+    hex_with_prefix = "0x1234567890abcdef1234567890abcdef12345678"
+
+    assert EvmAddress.from_string(f"  {hex_no_prefix}  ").to_string() == hex_no_prefix
+    assert EvmAddress.from_string(f"\n{hex_with_prefix}\n").to_string() == hex_no_prefix
+    assert EvmAddress.from_string(f"\t{hex_with_prefix}\t").to_string() == hex_no_prefix
+
+
 def test_from_bytes_valid():
     """Test creating EvmAddress from 20 bytes."""
     raw = bytes(range(20))


### PR DESCRIPTION
## What

`EvmAddress.from_string(evm_address)` is the entry point for any user-supplied EVM address string. The previous code passed the input straight to `evm_address.startswith('0x')` and `bytes.fromhex`, both of which raise on whitespace in the middle, and the user got the unhelpful `"Invalid hex string for evm_address"` ValueError.

Added `evm_address = evm_address.strip()` before processing.

## Why

In practice the string usually comes from one of: a hardcoded literal, a JSON config file, a `.env` entry read via `os.getenv` or `python-dotenv`, or a CLI argument. All of those paths frequently introduce surrounding whitespace that the caller does not see:

- A trailing newline from `os.getenv` (POSIX shells don't strip newlines, so `ADDRESS=$(cat file)` keeps one).
- A leading space from a YAML field that uses loose quoting.
- A tab from a copy-paste of a hex address from a block explorer.

`str.strip()` handles all three before any parsing. Internal whitespace is still rejected by `bytes.fromhex`, which is the desired behaviour — a hex address with a space in the middle is genuinely wrong.

## Tests

Added `test_from_string_with_surrounding_whitespace` in `tests/unit/evm_address_test.py` that asserts:
- `  <hex_no_prefix>  ` round-trips to the same hex.
- `\n<hex_with_prefix>\n` round-trips.
- `\t<hex_with_prefix>\t` round-trips.