### PR TITLE
chore: update CODEOWNERS to remove Python-specific roles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 ##### Global Protection Rule ######
 ###################################
 # Catch-all rule for all files not covered by more specific rules.
-*                                              @hiero-ledger/hiero-sdk-python-maintainers
+*                                              @hiero-ledger/hiero-sdk-maintainers
 
 
 ############################
@@ -10,17 +10,17 @@
 ############################
 
 # Python source
-/src/**                                        @hiero-ledger/hiero-sdk-python-committers @hiero-ledger/hiero-sdk-python-maintainers
+/src/**                                        @hiero-ledger/hiero-sdk-committers @hiero-ledger/hiero-sdk-maintainers
 
 # Tests
-/tests/**                                      @hiero-ledger/hiero-sdk-python-committers @hiero-ledger/hiero-sdk-python-maintainers
+/tests/**                                      @hiero-ledger/hiero-sdk-committers @hiero-ledger/hiero-sdk-maintainers
 
 # Examples & docs
-/examples/**                                   @hiero-ledger/hiero-sdk-python-committers @hiero-ledger/hiero-sdk-python-maintainers
-/docs/**                                       @hiero-ledger/hiero-sdk-python-committers @hiero-ledger/hiero-sdk-python-maintainers
+/examples/**                                   @hiero-ledger/hiero-sdk-committers @hiero-ledger/hiero-sdk-maintainers
+/docs/**                                       @hiero-ledger/hiero-sdk-committers @hiero-ledger/hiero-sdk-maintainers
 
 # Workflow
-/CONTRIBUTING.md                               @hiero-ledger/hiero-sdk-python-committers @hiero-ledger/hiero-sdk-python-maintainers
+/CONTRIBUTING.md                               @hiero-ledger/hiero-sdk-committers @hiero-ledger/hiero-sdk-maintainers
 
 #########################
 #####  Core Files  ######
@@ -28,28 +28,28 @@
 # Must be placed last to ensure enforcement over all other rules
 
 # GitHub configuration and workflows
-/.github/**                                    @hiero-ledger/hiero-sdk-python-maintainers @hiero-ledger/github-maintainers
-/.github/ISSUE_TEMPLATE/**                     @hiero-ledger/hiero-sdk-python-maintainers @hiero-ledger/github-maintainers
-/.github/scripts/**                            @hiero-ledger/hiero-sdk-python-maintainers @hiero-ledger/github-maintainers
-/.github/workflows/**                          @hiero-ledger/hiero-sdk-python-maintainers @hiero-ledger/github-maintainers
+/.github/**                                    @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/github-maintainers
+/.github/ISSUE_TEMPLATE/**                     @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/github-maintainers
+/.github/scripts/**                            @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/github-maintainers
+/.github/workflows/**                          @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/github-maintainers
 
 # Python packaging & build system
-/pyproject.toml                                @hiero-ledger/hiero-sdk-python-maintainers @hiero-ledger/github-maintainers @hiero-ledger/tsc
+/pyproject.toml                                @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/github-maintainers @hiero-ledger/tsc
 
 # Tooling
-/mypy.ini                                      @hiero-ledger/hiero-sdk-python-maintainers
-/pytest.ini                                    @hiero-ledger/hiero-sdk-python-maintainers
-/codecov.yml                                   @hiero-ledger/hiero-sdk-python-maintainers
+/mypy.ini                                      @hiero-ledger/hiero-sdk-maintainers
+/pytest.ini                                    @hiero-ledger/hiero-sdk-maintainers
+/codecov.yml                                   @hiero-ledger/hiero-sdk-maintainers
 
 # Self-protection
-/MAINTAINERS.md                                @hiero-ledger/hiero-sdk-python-maintainers
-/.github/CODEOWNERS                            @hiero-ledger/hiero-sdk-python-maintainers @hiero-ledger/github-maintainers
+/MAINTAINERS.md                                @hiero-ledger/hiero-sdk-maintainers
+/.github/CODEOWNERS                            @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/github-maintainers
 /CODEOWNERS                                    @hiero-ledger/github-maintainers
 
 # Documentation & legal
-/README.md                                     @hiero-ledger/hiero-sdk-python-maintainers
-/LICENSE                                       @hiero-ledger/hiero-sdk-python-maintainers @hiero-ledger/github-maintainers @hiero-ledger/tsc
+/README.md                                     @hiero-ledger/hiero-sdk-maintainers
+/LICENSE                                       @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/github-maintainers @hiero-ledger/tsc
 
 # Git ignore definitions
-**/.gitignore                                  @hiero-ledger/hiero-sdk-python-maintainers @hiero-ledger/github-maintainers
-**/.gitignore.*                                @hiero-ledger/hiero-sdk-python-maintainers @hiero-ledger/github-maintainers
+**/.gitignore                                  @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/github-maintainers
+**/.gitignore.*                                @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/github-maintainers


### PR DESCRIPTION
Please read hiero-ledger/governance#642

This change depends on
hiero-ledger/governance#649

**Description**:
Individual SDK teams in config.yaml should be merged into a single team

**Related issue(s)**:
Fixes hiero-ledger/governance#642


