### PR TITLE
feat: implement _from_protobuf deserialization for all transaction types

### DIFF
--- a/src/hiero_sdk_python/account/account_allowance_approve_transaction.py
+++ b/src/hiero_sdk_python/account/account_allowance_approve_transaction.py
@@ -366,3 +366,13 @@ class AccountAllowanceApproveTransaction(Transaction):
             _Method: An object containing the transaction function to approve allowances.
         """
         return _Method(transaction_func=channel.crypto.approveAllowances, query_func=None)
+
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("cryptoApproveAllowance"):
+            body = transaction_body.cryptoApproveAllowance
+            transaction.hbar_allowances = [HbarAllowance._from_proto(a) for a in body.cryptoAllowances]
+            transaction.token_allowances = [TokenAllowance._from_proto(a) for a in body.tokenAllowances]
+            transaction.nft_allowances = [TokenNftAllowance._from_proto(a) for a in body.nftAllowances]
+        return transaction

--- a/src/hiero_sdk_python/account/account_allowance_delete_transaction.py
+++ b/src/hiero_sdk_python/account/account_allowance_delete_transaction.py
@@ -131,3 +131,11 @@ class AccountAllowanceDeleteTransaction(Transaction):
             _Method: An object containing the transaction function to delete allowances.
         """
         return _Method(transaction_func=channel.crypto.deleteAllowances, query_func=None)
+
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("cryptoDeleteAllowance"):
+            body = transaction_body.cryptoDeleteAllowance
+            transaction.nft_wipe = [TokenNftAllowance._from_wipe_proto(a) for a in body.nftAllowances]
+        return transaction

--- a/src/hiero_sdk_python/account/account_create_transaction.py
+++ b/src/hiero_sdk_python/account/account_create_transaction.py
@@ -319,7 +319,7 @@ class AccountCreateTransaction(Transaction):
             # triggers an INVALID_INITIAL_BALANCE pre-check error instead of a local error.
             initialBalance=ctypes.c_uint64(initial_balance_tinybars).value,
             receiverSigRequired=self.receiver_signature_required,
-            autoRenewPeriod=duration_pb2.Duration(seconds=self.auto_renew_period.seconds),
+            autoRenewPeriod=(duration_pb2.Duration(seconds=self.auto_renew_period.seconds) if self.auto_renew_period else None),
             memo=self.account_memo,
             max_automatic_token_associations=self.max_automatic_token_associations,
             alias=self.alias.address_bytes if self.alias else None,
@@ -382,6 +382,7 @@ class AccountCreateTransaction(Transaction):
                 transaction.key = Key.from_proto_key(body.key)
             transaction.initial_balance = body.initialBalance
             transaction.receiver_signature_required = body.receiverSigRequired
+            transaction.auto_renew_period = None
             if body.HasField("autoRenewPeriod"):
                 transaction.auto_renew_period = Duration._from_proto(body.autoRenewPeriod)
             transaction.account_memo = body.memo if body.memo else None

--- a/src/hiero_sdk_python/account/account_create_transaction.py
+++ b/src/hiero_sdk_python/account/account_create_transaction.py
@@ -10,7 +10,6 @@ from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.crypto.evm_address import EvmAddress
 from hiero_sdk_python.crypto.key import Key
 from hiero_sdk_python.crypto.private_key import PrivateKey
-from hiero_sdk_python.crypto.public_key import PublicKey
 from hiero_sdk_python.Duration import Duration
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services import crypto_create_pb2, duration_pb2, transaction_pb2
@@ -380,7 +379,7 @@ class AccountCreateTransaction(Transaction):
         if transaction_body.HasField("cryptoCreateAccount"):
             body = transaction_body.cryptoCreateAccount
             if body.HasField("key"):
-                transaction.key = PublicKey._from_proto(body.key)
+                transaction.key = Key.from_proto_key(body.key)
             transaction.initial_balance = body.initialBalance
             transaction.receiver_signature_required = body.receiverSigRequired
             if body.HasField("autoRenewPeriod"):

--- a/src/hiero_sdk_python/account/account_create_transaction.py
+++ b/src/hiero_sdk_python/account/account_create_transaction.py
@@ -10,6 +10,7 @@ from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.crypto.evm_address import EvmAddress
 from hiero_sdk_python.crypto.key import Key
 from hiero_sdk_python.crypto.private_key import PrivateKey
+from hiero_sdk_python.crypto.public_key import PublicKey
 from hiero_sdk_python.Duration import Duration
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services import crypto_create_pb2, duration_pb2, transaction_pb2
@@ -374,7 +375,6 @@ class AccountCreateTransaction(Transaction):
 
     @classmethod
     def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
-        from hiero_sdk_python.crypto.public_key import PublicKey
 
         transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
         if transaction_body.HasField("cryptoCreateAccount"):

--- a/src/hiero_sdk_python/account/account_create_transaction.py
+++ b/src/hiero_sdk_python/account/account_create_transaction.py
@@ -371,3 +371,27 @@ class AccountCreateTransaction(Transaction):
             _Method: An instance of _Method containing the transaction and query functions.
         """
         return _Method(transaction_func=channel.crypto.createAccount, query_func=None)
+
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        from hiero_sdk_python.crypto.public_key import PublicKey
+
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("cryptoCreateAccount"):
+            body = transaction_body.cryptoCreateAccount
+            if body.HasField("key"):
+                transaction.key = PublicKey._from_proto(body.key)
+            transaction.initial_balance = body.initialBalance
+            transaction.receiver_signature_required = body.receiverSigRequired
+            if body.HasField("autoRenewPeriod"):
+                transaction.auto_renew_period = Duration._from_proto(body.autoRenewPeriod)
+            transaction.account_memo = body.memo if body.memo else None
+            transaction.max_automatic_token_associations = body.max_automatic_token_associations
+            transaction.alias = EvmAddress.from_bytes(body.alias) if body.alias else None
+            transaction.decline_staking_reward = body.decline_reward
+            staked_id = body.WhichOneof("staked_id")
+            if staked_id == "staked_account_id":
+                transaction.staked_account_id = AccountId._from_proto(body.staked_account_id)
+            elif staked_id == "staked_node_id":
+                transaction.staked_node_id = body.staked_node_id
+        return transaction

--- a/src/hiero_sdk_python/account/account_create_transaction.py
+++ b/src/hiero_sdk_python/account/account_create_transaction.py
@@ -319,7 +319,9 @@ class AccountCreateTransaction(Transaction):
             # triggers an INVALID_INITIAL_BALANCE pre-check error instead of a local error.
             initialBalance=ctypes.c_uint64(initial_balance_tinybars).value,
             receiverSigRequired=self.receiver_signature_required,
-            autoRenewPeriod=(duration_pb2.Duration(seconds=self.auto_renew_period.seconds) if self.auto_renew_period else None),
+            autoRenewPeriod=(
+                duration_pb2.Duration(seconds=self.auto_renew_period.seconds) if self.auto_renew_period else None
+            ),
             memo=self.account_memo,
             max_automatic_token_associations=self.max_automatic_token_associations,
             alias=self.alias.address_bytes if self.alias else None,

--- a/src/hiero_sdk_python/account/account_delete_transaction.py
+++ b/src/hiero_sdk_python/account/account_delete_transaction.py
@@ -128,3 +128,14 @@ class AccountDeleteTransaction(Transaction):
                 delete accounts.
         """
         return _Method(transaction_func=channel.crypto.cryptoDelete, query_func=None)
+
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("cryptoDelete"):
+            body = transaction_body.cryptoDelete
+            if body.HasField("deleteAccountID"):
+                transaction.account_id = AccountId._from_proto(body.deleteAccountID)
+            if body.HasField("transferAccountID"):
+                transaction.transfer_account_id = AccountId._from_proto(body.transferAccountID)
+        return transaction

--- a/src/hiero_sdk_python/account/account_update_transaction.py
+++ b/src/hiero_sdk_python/account/account_update_transaction.py
@@ -356,7 +356,6 @@ class AccountUpdateTransaction(Transaction):
     @classmethod
     def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
         from hiero_sdk_python.crypto.public_key import PublicKey
-        from hiero_sdk_python.hapi.services.crypto_update_pb2 import CryptoUpdateTransactionBody
 
         transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
         if transaction_body.HasField("cryptoUpdateAccount"):

--- a/src/hiero_sdk_python/account/account_update_transaction.py
+++ b/src/hiero_sdk_python/account/account_update_transaction.py
@@ -354,7 +354,7 @@ class AccountUpdateTransaction(Transaction):
         return _Method(transaction_func=channel.crypto.updateAccount, query_func=None)
 
     @classmethod
-    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):  # noqa: PLR0912
         from hiero_sdk_python.crypto.public_key import PublicKey
 
         transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)

--- a/src/hiero_sdk_python/account/account_update_transaction.py
+++ b/src/hiero_sdk_python/account/account_update_transaction.py
@@ -10,6 +10,7 @@ from google.protobuf.wrappers_pb2 import BoolValue, Int32Value, StringValue
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.crypto.key import Key
+from hiero_sdk_python.crypto.public_key import PublicKey
 from hiero_sdk_python.Duration import Duration
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services.crypto_update_pb2 import CryptoUpdateTransactionBody
@@ -355,8 +356,6 @@ class AccountUpdateTransaction(Transaction):
 
     @classmethod
     def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):  # noqa: PLR0912
-        from hiero_sdk_python.crypto.public_key import PublicKey
-
         transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
         if transaction_body.HasField("cryptoUpdateAccount"):
             body = transaction_body.cryptoUpdateAccount

--- a/src/hiero_sdk_python/account/account_update_transaction.py
+++ b/src/hiero_sdk_python/account/account_update_transaction.py
@@ -352,3 +352,34 @@ class AccountUpdateTransaction(Transaction):
             _Method: An object containing the transaction function to update an account.
         """
         return _Method(transaction_func=channel.crypto.updateAccount, query_func=None)
+
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        from hiero_sdk_python.crypto.public_key import PublicKey
+        from hiero_sdk_python.hapi.services.crypto_update_pb2 import CryptoUpdateTransactionBody
+
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("cryptoUpdateAccount"):
+            body = transaction_body.cryptoUpdateAccount
+            if body.HasField("accountIDToUpdate"):
+                transaction.account_id = AccountId._from_proto(body.accountIDToUpdate)
+            if body.HasField("key"):
+                transaction.key = PublicKey._from_proto(body.key)
+            if body.HasField("autoRenewPeriod"):
+                transaction.auto_renew_period = Duration._from_proto(body.autoRenewPeriod)
+            if body.HasField("memo"):
+                transaction.account_memo = body.memo.value
+            if body.HasField("expirationTime"):
+                transaction.expiration_time = Timestamp._from_protobuf(body.expirationTime)
+            if body.HasField("receiverSigRequiredWrapper"):
+                transaction.receiver_signature_required = body.receiverSigRequiredWrapper.value
+            if body.HasField("max_automatic_token_associations"):
+                transaction.max_automatic_token_associations = body.max_automatic_token_associations.value
+            if body.HasField("decline_reward"):
+                transaction.decline_staking_reward = body.decline_reward.value
+            staked_id = body.WhichOneof("staked_id")
+            if staked_id == "staked_account_id":
+                transaction.staked_account_id = AccountId._from_proto(body.staked_account_id)
+            elif staked_id == "staked_node_id":
+                transaction.staked_node_id = body.staked_node_id
+        return transaction

--- a/src/hiero_sdk_python/account/account_update_transaction.py
+++ b/src/hiero_sdk_python/account/account_update_transaction.py
@@ -10,7 +10,6 @@ from google.protobuf.wrappers_pb2 import BoolValue, Int32Value, StringValue
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.crypto.key import Key
-from hiero_sdk_python.crypto.public_key import PublicKey
 from hiero_sdk_python.Duration import Duration
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services.crypto_update_pb2 import CryptoUpdateTransactionBody
@@ -362,7 +361,7 @@ class AccountUpdateTransaction(Transaction):
             if body.HasField("accountIDToUpdate"):
                 transaction.account_id = AccountId._from_proto(body.accountIDToUpdate)
             if body.HasField("key"):
-                transaction.key = PublicKey._from_proto(body.key)
+                transaction.key = Key.from_proto_key(body.key)
             if body.HasField("autoRenewPeriod"):
                 transaction.auto_renew_period = Duration._from_proto(body.autoRenewPeriod)
             if body.HasField("memo"):

--- a/src/hiero_sdk_python/consensus/topic_create_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_create_transaction.py
@@ -296,6 +296,6 @@ class TopicCreateTransaction(Transaction):
                 transaction.auto_renew_account = AccountId._from_proto(body.autoRenewAccount)
             if body.HasField("fee_schedule_key"):
                 transaction.fee_schedule_key = PublicKey._from_proto(body.fee_schedule_key)
-            transaction.custom_fees = [CustomFixedFee._from_proto(f) for f in body.custom_fees]
+            transaction.custom_fees = [CustomFixedFee._from_topic_fee_proto(f) for f in body.custom_fees]
             transaction.fee_exempt_keys = [PublicKey._from_proto(k) for k in body.fee_exempt_key_list]
         return transaction

--- a/src/hiero_sdk_python/consensus/topic_create_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_create_transaction.py
@@ -21,7 +21,6 @@ from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
     SchedulableTransactionBody,
 )
 from hiero_sdk_python.tokens.custom_fixed_fee import CustomFixedFee
-from hiero_sdk_python.crypto.public_key import PublicKey
 from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.utils.key_utils import key_to_proto
 
@@ -287,15 +286,15 @@ class TopicCreateTransaction(Transaction):
             body = transaction_body.consensusCreateTopic
             transaction.memo = body.memo if body.memo else ""
             if body.HasField("adminKey"):
-                transaction.admin_key = PublicKey._from_proto(body.adminKey)
+                transaction.admin_key = Key.from_proto_key(body.adminKey)
             if body.HasField("submitKey"):
-                transaction.submit_key = PublicKey._from_proto(body.submitKey)
+                transaction.submit_key = Key.from_proto_key(body.submitKey)
             if body.HasField("autoRenewPeriod"):
                 transaction.auto_renew_period = Duration._from_proto(body.autoRenewPeriod)
             if body.HasField("autoRenewAccount"):
                 transaction.auto_renew_account = AccountId._from_proto(body.autoRenewAccount)
             if body.HasField("fee_schedule_key"):
-                transaction.fee_schedule_key = PublicKey._from_proto(body.fee_schedule_key)
+                transaction.fee_schedule_key = Key.from_proto_key(body.fee_schedule_key)
             transaction.custom_fees = [CustomFixedFee._from_topic_fee_proto(f) for f in body.custom_fees]
-            transaction.fee_exempt_keys = [PublicKey._from_proto(k) for k in body.fee_exempt_key_list]
+            transaction.fee_exempt_keys = [Key.from_proto_key(k) for k in body.fee_exempt_key_list]
         return transaction

--- a/src/hiero_sdk_python/consensus/topic_create_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_create_transaction.py
@@ -280,7 +280,7 @@ class TopicCreateTransaction(Transaction):
         return _Method(transaction_func=channel.topic.createTopic, query_func=None)
 
     @classmethod
-    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):  # noqa: PLR0912
         from hiero_sdk_python.crypto.public_key import PublicKey
 
         transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)

--- a/src/hiero_sdk_python/consensus/topic_create_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_create_transaction.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.channels import _Channel
+from hiero_sdk_python.crypto.key import Key
 from hiero_sdk_python.Duration import Duration
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services import consensus_create_topic_pb2, transaction_pb2
@@ -21,7 +22,6 @@ from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
 )
 from hiero_sdk_python.tokens.custom_fixed_fee import CustomFixedFee
 from hiero_sdk_python.transaction.transaction import Transaction
-from hiero_sdk_python.crypto.key import Key
 from hiero_sdk_python.utils.key_utils import key_to_proto
 
 

--- a/src/hiero_sdk_python/consensus/topic_create_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_create_transaction.py
@@ -278,3 +278,25 @@ class TopicCreateTransaction(Transaction):
             _Method: The method for executing the transaction.
         """
         return _Method(transaction_func=channel.topic.createTopic, query_func=None)
+
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        from hiero_sdk_python.crypto.public_key import PublicKey
+
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("consensusCreateTopic"):
+            body = transaction_body.consensusCreateTopic
+            transaction.memo = body.memo if body.memo else ""
+            if body.HasField("adminKey"):
+                transaction.admin_key = PublicKey._from_proto(body.adminKey)
+            if body.HasField("submitKey"):
+                transaction.submit_key = PublicKey._from_proto(body.submitKey)
+            if body.HasField("autoRenewPeriod"):
+                transaction.auto_renew_period = Duration._from_proto(body.autoRenewPeriod)
+            if body.HasField("autoRenewAccount"):
+                transaction.auto_renew_account = AccountId._from_proto(body.autoRenewAccount)
+            if body.HasField("fee_schedule_key"):
+                transaction.fee_schedule_key = PublicKey._from_proto(body.fee_schedule_key)
+            transaction.custom_fees = [CustomFixedFee._from_proto(f) for f in body.custom_fees]
+            transaction.fee_exempt_keys = [PublicKey._from_proto(k) for k in body.fee_exempt_key_list]
+        return transaction

--- a/src/hiero_sdk_python/consensus/topic_create_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_create_transaction.py
@@ -21,6 +21,7 @@ from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
     SchedulableTransactionBody,
 )
 from hiero_sdk_python.tokens.custom_fixed_fee import CustomFixedFee
+from hiero_sdk_python.crypto.public_key import PublicKey
 from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.utils.key_utils import key_to_proto
 
@@ -281,8 +282,6 @@ class TopicCreateTransaction(Transaction):
 
     @classmethod
     def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):  # noqa: PLR0912
-        from hiero_sdk_python.crypto.public_key import PublicKey
-
         transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
         if transaction_body.HasField("consensusCreateTopic"):
             body = transaction_body.consensusCreateTopic

--- a/src/hiero_sdk_python/consensus/topic_create_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_create_transaction.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING
 
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.channels import _Channel
-from hiero_sdk_python.crypto.key import Key
 from hiero_sdk_python.Duration import Duration
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services import consensus_create_topic_pb2, transaction_pb2
@@ -22,6 +21,7 @@ from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
 )
 from hiero_sdk_python.tokens.custom_fixed_fee import CustomFixedFee
 from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.crypto.key import Key
 from hiero_sdk_python.utils.key_utils import key_to_proto
 
 

--- a/src/hiero_sdk_python/consensus/topic_delete_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_delete_transaction.py
@@ -94,3 +94,12 @@ class TopicDeleteTransaction(Transaction):
             _Method: The method to execute the transaction.
         """
         return _Method(transaction_func=channel.topic.deleteTopic, query_func=None)
+
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("consensusDeleteTopic"):
+            body = transaction_body.consensusDeleteTopic
+            if body.HasField("topicID"):
+                transaction.topic_id = TopicId._from_proto(body.topicID)
+        return transaction

--- a/src/hiero_sdk_python/consensus/topic_message_submit_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_message_submit_transaction.py
@@ -249,6 +249,17 @@ class TopicMessageSubmitTransaction(Transaction):
         """
         return _Method(transaction_func=channel.topic.submitMessage, query_func=None)
 
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("consensusSubmitMessage"):
+            body = transaction_body.consensusSubmitMessage
+            if body.HasField("topicID"):
+                transaction.topic_id = TopicId._from_proto(body.topicID)
+            transaction.message = body.message.decode("utf-8") if body.message else None
+            transaction._total_chunks = transaction.get_required_chunks()
+        return transaction
+
     def freeze_with(self, client: Client) -> TopicMessageSubmitTransaction:
         if self._transaction_body_bytes:
             return self

--- a/src/hiero_sdk_python/consensus/topic_update_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_update_transaction.py
@@ -335,7 +335,7 @@ class TopicUpdateTransaction(Transaction):
             if body.HasField("fee_schedule_key"):
                 transaction.fee_schedule_key = PublicKey._from_proto(body.fee_schedule_key)
             if body.HasField("custom_fees"):
-                transaction.custom_fees = [CustomFixedFee._from_proto(f) for f in body.custom_fees.fees]
+                transaction.custom_fees = [CustomFixedFee._from_topic_fee_proto(f) for f in body.custom_fees.fees]
             if body.HasField("fee_exempt_key_list"):
                 transaction.fee_exempt_keys = [PublicKey._from_proto(k) for k in body.fee_exempt_key_list.keys]
         return transaction

--- a/src/hiero_sdk_python/consensus/topic_update_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_update_transaction.py
@@ -312,3 +312,30 @@ class TopicUpdateTransaction(Transaction):
             _Method: The method to execute the transaction.
         """
         return _Method(transaction_func=channel.topic.updateTopic, query_func=None)
+
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("consensusUpdateTopic"):
+            body = transaction_body.consensusUpdateTopic
+            if body.HasField("topicID"):
+                transaction.topic_id = TopicId._from_proto(body.topicID)
+            if body.HasField("memo"):
+                transaction.memo = body.memo.value
+            if body.HasField("adminKey"):
+                transaction.admin_key = PublicKey._from_proto(body.adminKey)
+            if body.HasField("submitKey"):
+                transaction.submit_key = PublicKey._from_proto(body.submitKey)
+            if body.HasField("autoRenewPeriod"):
+                transaction.auto_renew_period = Duration._from_proto(body.autoRenewPeriod)
+            if body.HasField("autoRenewAccount"):
+                transaction.auto_renew_account = AccountId._from_proto(body.autoRenewAccount)
+            if body.HasField("expirationTime"):
+                transaction.expiration_time = Timestamp._from_protobuf(body.expirationTime)
+            if body.HasField("fee_schedule_key"):
+                transaction.fee_schedule_key = PublicKey._from_proto(body.fee_schedule_key)
+            if body.HasField("custom_fees"):
+                transaction.custom_fees = [CustomFixedFee._from_proto(f) for f in body.custom_fees.fees]
+            if body.HasField("fee_exempt_key_list"):
+                transaction.fee_exempt_keys = [PublicKey._from_proto(k) for k in body.fee_exempt_key_list.keys]
+        return transaction

--- a/src/hiero_sdk_python/consensus/topic_update_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_update_transaction.py
@@ -314,7 +314,7 @@ class TopicUpdateTransaction(Transaction):
         return _Method(transaction_func=channel.topic.updateTopic, query_func=None)
 
     @classmethod
-    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):  # noqa: PLR0912
         transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
         if transaction_body.HasField("consensusUpdateTopic"):
             body = transaction_body.consensusUpdateTopic

--- a/src/hiero_sdk_python/consensus/topic_update_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_update_transaction.py
@@ -325,9 +325,9 @@ class TopicUpdateTransaction(Transaction):
             if body.HasField("memo"):
                 transaction.memo = body.memo.value
             if body.HasField("adminKey"):
-                transaction.admin_key = CryptoKey.from_proto_key(body.adminKey)
+                transaction.admin_key = Key.from_proto_key(body.adminKey)
             if body.HasField("submitKey"):
-                transaction.submit_key = CryptoKey.from_proto_key(body.submitKey)
+                transaction.submit_key = Key.from_proto_key(body.submitKey)
             if body.HasField("autoRenewPeriod"):
                 transaction.auto_renew_period = Duration._from_proto(body.autoRenewPeriod)
             if body.HasField("autoRenewAccount"):
@@ -335,9 +335,9 @@ class TopicUpdateTransaction(Transaction):
             if body.HasField("expirationTime"):
                 transaction.expiration_time = Timestamp._from_protobuf(body.expirationTime)
             if body.HasField("fee_schedule_key"):
-                transaction.fee_schedule_key = CryptoKey.from_proto_key(body.fee_schedule_key)
+                transaction.fee_schedule_key = Key.from_proto_key(body.fee_schedule_key)
             if body.HasField("custom_fees"):
                 transaction.custom_fees = [CustomFixedFee._from_topic_fee_proto(f) for f in body.custom_fees.fees]
             if body.HasField("fee_exempt_key_list"):
-                transaction.fee_exempt_keys = [CryptoKey.from_proto_key(k) for k in body.fee_exempt_key_list.keys]
+                transaction.fee_exempt_keys = [Key.from_proto_key(k) for k in body.fee_exempt_key_list.keys]
         return transaction

--- a/src/hiero_sdk_python/consensus/topic_update_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_update_transaction.py
@@ -33,7 +33,7 @@ class TopicUpdateTransaction(Transaction):
         memo: str | None = None,
         admin_key: Key | None = None,
         submit_key: Key | None = None,
-        auto_renew_period: Duration | None = Duration(7890000),
+        auto_renew_period: Duration | None = None,
         auto_renew_account: AccountId | None = None,
         expiration_time: Timestamp | None = None,
         custom_fees: list[CustomFixedFee] | None = None,
@@ -57,7 +57,7 @@ class TopicUpdateTransaction(Transaction):
         """
         super().__init__()
         self.topic_id: TopicId | None = topic_id
-        self.memo: str = memo or ""
+        self.memo: str | None = memo
         self.admin_key: Key | None = admin_key
         self.submit_key: Key | None = submit_key
         self.auto_renew_period: Duration | None = auto_renew_period
@@ -318,14 +318,16 @@ class TopicUpdateTransaction(Transaction):
         transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
         if transaction_body.HasField("consensusUpdateTopic"):
             body = transaction_body.consensusUpdateTopic
+            transaction.memo = None
+            transaction.auto_renew_period = None
             if body.HasField("topicID"):
                 transaction.topic_id = TopicId._from_proto(body.topicID)
             if body.HasField("memo"):
                 transaction.memo = body.memo.value
             if body.HasField("adminKey"):
-                transaction.admin_key = PublicKey._from_proto(body.adminKey)
+                transaction.admin_key = CryptoKey.from_proto_key(body.adminKey)
             if body.HasField("submitKey"):
-                transaction.submit_key = PublicKey._from_proto(body.submitKey)
+                transaction.submit_key = CryptoKey.from_proto_key(body.submitKey)
             if body.HasField("autoRenewPeriod"):
                 transaction.auto_renew_period = Duration._from_proto(body.autoRenewPeriod)
             if body.HasField("autoRenewAccount"):
@@ -333,9 +335,9 @@ class TopicUpdateTransaction(Transaction):
             if body.HasField("expirationTime"):
                 transaction.expiration_time = Timestamp._from_protobuf(body.expirationTime)
             if body.HasField("fee_schedule_key"):
-                transaction.fee_schedule_key = PublicKey._from_proto(body.fee_schedule_key)
+                transaction.fee_schedule_key = CryptoKey.from_proto_key(body.fee_schedule_key)
             if body.HasField("custom_fees"):
                 transaction.custom_fees = [CustomFixedFee._from_topic_fee_proto(f) for f in body.custom_fees.fees]
             if body.HasField("fee_exempt_key_list"):
-                transaction.fee_exempt_keys = [PublicKey._from_proto(k) for k in body.fee_exempt_key_list.keys]
+                transaction.fee_exempt_keys = [CryptoKey.from_proto_key(k) for k in body.fee_exempt_key_list.keys]
         return transaction

--- a/src/hiero_sdk_python/contract/contract_create_transaction.py
+++ b/src/hiero_sdk_python/contract/contract_create_transaction.py
@@ -10,6 +10,7 @@ from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.contract.contract_function_parameters import (
     ContractFunctionParameters,
 )
+from hiero_sdk_python.crypto.key import Key
 from hiero_sdk_python.crypto.public_key import PublicKey
 from hiero_sdk_python.Duration import Duration
 from hiero_sdk_python.executable import _Method
@@ -386,6 +387,38 @@ class ContractCreateTransaction(Transaction):
         schedulable_body = self.build_base_scheduled_body()
         schedulable_body.contractCreateInstance.CopyFrom(contract_create_body)
         return schedulable_body
+
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("contractCreateInstance"):
+            body = transaction_body.contractCreateInstance
+            if body.HasField("adminKey"):
+                transaction.admin_key = Key.from_proto_key(body.adminKey)
+            transaction.gas = body.gas
+            transaction.initial_balance = body.initialBalance if body.initialBalance else None
+            if body.HasField("proxyAccountID"):
+                transaction.proxy_account_id = AccountId._from_proto(body.proxyAccountID)
+            transaction.auto_renew_period = (
+                Duration._from_proto(body.autoRenewPeriod) if body.HasField("autoRenewPeriod") else Duration(DEFAULT_AUTO_RENEW_PERIOD)
+            )
+            transaction.parameters = body.constructorParameters if body.constructorParameters else None
+            transaction.contract_memo = body.memo if body.memo else None
+            transaction.max_automatic_token_associations = body.max_automatic_token_associations
+            if body.HasField("auto_renew_account_id"):
+                transaction.auto_renew_account_id = AccountId._from_proto(body.auto_renew_account_id)
+            transaction.decline_reward = body.decline_reward if body.decline_reward else None
+            initcode_source = body.WhichOneof("initcodeSource")
+            if initcode_source == "fileID":
+                transaction.bytecode_file_id = FileId._from_proto(body.fileID)
+            elif initcode_source == "initcode":
+                transaction.bytecode = body.initcode
+            staked_id = body.WhichOneof("staked_id")
+            if staked_id == "staked_account_id":
+                transaction.staked_account_id = AccountId._from_proto(body.staked_account_id)
+            elif staked_id == "staked_node_id":
+                transaction.staked_node_id = body.staked_node_id
+        return transaction
 
     def _get_method(self, channel: _Channel) -> _Method:
         """

--- a/src/hiero_sdk_python/contract/contract_create_transaction.py
+++ b/src/hiero_sdk_python/contract/contract_create_transaction.py
@@ -396,7 +396,7 @@ class ContractCreateTransaction(Transaction):
             if body.HasField("adminKey"):
                 transaction.admin_key = Key.from_proto_key(body.adminKey)
             transaction.gas = body.gas
-            transaction.initial_balance = body.initialBalance if body.initialBalance else None
+            transaction.initial_balance = body.initialBalance
             if body.HasField("proxyAccountID"):
                 transaction.proxy_account_id = AccountId._from_proto(body.proxyAccountID)
             transaction.auto_renew_period = (
@@ -409,7 +409,7 @@ class ContractCreateTransaction(Transaction):
             transaction.max_automatic_token_associations = body.max_automatic_token_associations
             if body.HasField("auto_renew_account_id"):
                 transaction.auto_renew_account_id = AccountId._from_proto(body.auto_renew_account_id)
-            transaction.decline_reward = body.decline_reward if body.decline_reward else None
+            transaction.decline_reward = body.decline_reward
             initcode_source = body.WhichOneof("initcodeSource")
             if initcode_source == "fileID":
                 transaction.bytecode_file_id = FileId._from_proto(body.fileID)

--- a/src/hiero_sdk_python/contract/contract_create_transaction.py
+++ b/src/hiero_sdk_python/contract/contract_create_transaction.py
@@ -400,7 +400,9 @@ class ContractCreateTransaction(Transaction):
             if body.HasField("proxyAccountID"):
                 transaction.proxy_account_id = AccountId._from_proto(body.proxyAccountID)
             transaction.auto_renew_period = (
-                Duration._from_proto(body.autoRenewPeriod) if body.HasField("autoRenewPeriod") else Duration(DEFAULT_AUTO_RENEW_PERIOD)
+                Duration._from_proto(body.autoRenewPeriod)
+                if body.HasField("autoRenewPeriod")
+                else Duration(DEFAULT_AUTO_RENEW_PERIOD)
             )
             transaction.parameters = body.constructorParameters if body.constructorParameters else None
             transaction.contract_memo = body.memo if body.memo else None

--- a/src/hiero_sdk_python/contract/contract_delete_transaction.py
+++ b/src/hiero_sdk_python/contract/contract_delete_transaction.py
@@ -153,6 +153,21 @@ class ContractDeleteTransaction(Transaction):
         transaction_body.contractDeleteInstance.CopyFrom(contract_delete_body)
         return transaction_body
 
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("contractDeleteInstance"):
+            body = transaction_body.contractDeleteInstance
+            if body.HasField("contractID"):
+                transaction.contract_id = ContractId._from_proto(body.contractID)
+            transaction.permanent_removal = body.permanent_removal if body.permanent_removal else None
+            obtainers = body.WhichOneof("obtainers")
+            if obtainers == "transferAccountID":
+                transaction.transfer_account_id = AccountId._from_proto(body.transferAccountID)
+            elif obtainers == "transferContractID":
+                transaction.transfer_contract_id = ContractId._from_proto(body.transferContractID)
+        return transaction
+
     def _get_method(self, channel: _Channel) -> _Method:
         """
         Gets the method to execute the contract delete transaction.

--- a/src/hiero_sdk_python/contract/contract_execute_transaction.py
+++ b/src/hiero_sdk_python/contract/contract_execute_transaction.py
@@ -163,6 +163,18 @@ class ContractExecuteTransaction(Transaction):
         schedulable_body.contractCall.CopyFrom(contract_execute_body)
         return schedulable_body
 
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("contractCall"):
+            body = transaction_body.contractCall
+            if body.HasField("contractID"):
+                transaction.contract_id = ContractId._from_proto(body.contractID)
+            transaction.gas = body.gas if body.gas else None
+            transaction.amount = body.amount if body.amount else None
+            transaction.function_parameters = body.functionParameters if body.functionParameters else None
+        return transaction
+
     def _get_method(self, channel: _Channel) -> _Method:
         """
         Returns the appropriate gRPC method for the contract execute transaction.

--- a/src/hiero_sdk_python/contract/contract_update_transaction.py
+++ b/src/hiero_sdk_python/contract/contract_update_transaction.py
@@ -11,6 +11,7 @@ from google.protobuf.wrappers_pb2 import BoolValue, Int32Value, StringValue
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.contract.contract_id import ContractId
+from hiero_sdk_python.crypto.key import Key
 from hiero_sdk_python.crypto.public_key import PublicKey
 from hiero_sdk_python.Duration import Duration
 from hiero_sdk_python.executable import _Method
@@ -301,6 +302,37 @@ class ContractUpdateTransaction(Transaction):
         schedulable_body = self.build_base_scheduled_body()
         schedulable_body.contractUpdateInstance.CopyFrom(contract_update_body)
         return schedulable_body
+
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("contractUpdateInstance"):
+            body = transaction_body.contractUpdateInstance
+            if body.HasField("contractID"):
+                transaction.contract_id = ContractId._from_proto(body.contractID)
+            if body.HasField("expirationTime"):
+                transaction.expiration_time = Timestamp._from_protobuf(body.expirationTime)
+            if body.HasField("adminKey"):
+                transaction.admin_key = Key.from_proto_key(body.adminKey)
+            if body.HasField("autoRenewPeriod"):
+                transaction.auto_renew_period = Duration._from_proto(body.autoRenewPeriod)
+            memo_field = body.WhichOneof("memoField")
+            if memo_field == "memoWrapper":
+                transaction.contract_memo = body.memoWrapper.value
+            elif memo_field == "memo":
+                transaction.contract_memo = body.memo if body.memo else None
+            if body.HasField("max_automatic_token_associations"):
+                transaction.max_automatic_token_associations = body.max_automatic_token_associations.value
+            if body.HasField("auto_renew_account_id"):
+                transaction.auto_renew_account_id = AccountId._from_proto(body.auto_renew_account_id)
+            if body.HasField("decline_reward"):
+                transaction.decline_reward = body.decline_reward.value
+            staked_id = body.WhichOneof("staked_id")
+            if staked_id == "staked_account_id":
+                transaction.staked_account_id = AccountId._from_proto(body.staked_account_id)
+            elif staked_id == "staked_node_id":
+                transaction.staked_node_id = body.staked_node_id
+        return transaction
 
     def _get_method(self, channel: _Channel) -> _Method:
         """

--- a/src/hiero_sdk_python/contract/ethereum_transaction.py
+++ b/src/hiero_sdk_python/contract/ethereum_transaction.py
@@ -122,6 +122,17 @@ class EthereumTransaction(Transaction):
         """
         raise ValueError("Cannot schedule an EthereumTransaction")
 
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("ethereumTransaction"):
+            body = transaction_body.ethereumTransaction
+            transaction.ethereum_data = body.ethereum_data if body.ethereum_data else None
+            if body.HasField("call_data"):
+                transaction.call_data = FileId._from_proto(body.call_data)
+            transaction.max_gas_allowed = body.max_gas_allowance if body.max_gas_allowance else None
+        return transaction
+
     def _get_method(self, channel: _Channel) -> _Method:
         """
         Returns the appropriate gRPC method for the ethereum transaction.

--- a/src/hiero_sdk_python/file/file_append_transaction.py
+++ b/src/hiero_sdk_python/file/file_append_transaction.py
@@ -259,8 +259,8 @@ class FileAppendTransaction(Transaction):
         Returns:
             FileAppendTransaction: This transaction instance.
         """
-        self.file_id = FileId._from_proto(proto.fileID) if proto.fileID else None
-        self.contents = proto.contents
+        self.file_id = FileId._from_proto(proto.fileID) if proto.HasField("fileID") else None
+        self.contents = proto.contents if proto.contents else None
         self._total_chunks = self._calculate_total_chunks()
         return self
 

--- a/src/hiero_sdk_python/file/file_append_transaction.py
+++ b/src/hiero_sdk_python/file/file_append_transaction.py
@@ -242,6 +242,13 @@ class FileAppendTransaction(Transaction):
 
         return _Method(transaction_func=channel.file.appendContent, query_func=None)
 
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("fileAppend"):
+            transaction._from_proto(transaction_body.fileAppend)
+        return transaction
+
     def _from_proto(self, proto: file_append_pb2.FileAppendTransactionBody) -> FileAppendTransaction:
         """
         Initializes a new FileAppendTransaction instance from a protobuf object.

--- a/src/hiero_sdk_python/file/file_create_transaction.py
+++ b/src/hiero_sdk_python/file/file_create_transaction.py
@@ -182,6 +182,13 @@ class FileCreateTransaction(Transaction):
         """
         return _Method(transaction_func=channel.file.createFile, query_func=None)
 
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("fileCreate"):
+            transaction._from_proto(transaction_body.fileCreate)
+        return transaction
+
     def _from_proto(self, proto: file_create_pb2.FileCreateTransactionBody) -> FileCreateTransaction:
         """
         Initializes a new FileCreateTransaction instance from a protobuf object.

--- a/src/hiero_sdk_python/file/file_delete_transaction.py
+++ b/src/hiero_sdk_python/file/file_delete_transaction.py
@@ -104,3 +104,12 @@ class FileDeleteTransaction(Transaction):
             _Method: An object containing the transaction function to delete a file.
         """
         return _Method(transaction_func=channel.file.deleteFile, query_func=None)
+
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("fileDelete"):
+            body = transaction_body.fileDelete
+            if body.HasField("fileID"):
+                transaction.file_id = FileId._from_proto(body.fileID)
+        return transaction

--- a/src/hiero_sdk_python/file/file_update_transaction.py
+++ b/src/hiero_sdk_python/file/file_update_transaction.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from google.protobuf.wrappers_pb2 import StringValue
 
 from hiero_sdk_python.channels import _Channel
+from hiero_sdk_python.crypto.key import Key
 from hiero_sdk_python.crypto.public_key import PublicKey
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.file.file_id import FileId
@@ -222,7 +223,7 @@ class FileUpdateTransaction(Transaction):
             body = transaction_body.fileUpdate
             if body.HasField("fileID"):
                 transaction.file_id = FileId._from_proto(body.fileID)
-            transaction.keys = [PublicKey._from_proto(k) for k in body.keys.keys] if body.keys.keys else None
+            transaction.keys = [Key.from_proto_key(k) for k in body.keys.keys] if body.keys.keys else None
             transaction.contents = body.contents if body.contents else None
             if body.HasField("expirationTime"):
                 transaction.expiration_time = Timestamp._from_protobuf(body.expirationTime)

--- a/src/hiero_sdk_python/file/file_update_transaction.py
+++ b/src/hiero_sdk_python/file/file_update_transaction.py
@@ -214,3 +214,18 @@ class FileUpdateTransaction(Transaction):
             _Method: An object containing the transaction function to update a file.
         """
         return _Method(transaction_func=channel.file.updateFile, query_func=None)
+
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("fileUpdate"):
+            body = transaction_body.fileUpdate
+            if body.HasField("fileID"):
+                transaction.file_id = FileId._from_proto(body.fileID)
+            transaction.keys = [PublicKey._from_proto(k) for k in body.keys.keys] if body.keys.keys else None
+            transaction.contents = body.contents if body.contents else None
+            if body.HasField("expirationTime"):
+                transaction.expiration_time = Timestamp._from_protobuf(body.expirationTime)
+            if body.HasField("memo"):
+                transaction.file_memo = body.memo.value
+        return transaction

--- a/src/hiero_sdk_python/nodes/node_create_transaction.py
+++ b/src/hiero_sdk_python/nodes/node_create_transaction.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.address_book.endpoint import Endpoint
 from hiero_sdk_python.channels import _Channel
+from hiero_sdk_python.crypto.key import Key
 from hiero_sdk_python.crypto.public_key import PublicKey
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services.node_create_pb2 import NodeCreateTransactionBody
@@ -284,6 +285,25 @@ class NodeCreateTransaction(Transaction):
         scheduled_body = self.build_base_scheduled_body()
         scheduled_body.nodeCreate.CopyFrom(node_create_body)
         return scheduled_body
+
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("nodeCreate"):
+            body = transaction_body.nodeCreate
+            if body.HasField("account_id"):
+                transaction.account_id = AccountId._from_proto(body.account_id)
+            transaction.description = body.description if body.description else None
+            transaction.gossip_endpoints = [Endpoint._from_proto(ep) for ep in body.gossip_endpoint]
+            transaction.service_endpoints = [Endpoint._from_proto(ep) for ep in body.service_endpoint]
+            transaction.gossip_ca_certificate = body.gossip_ca_certificate if body.gossip_ca_certificate else None
+            transaction.grpc_certificate_hash = body.grpc_certificate_hash if body.grpc_certificate_hash else None
+            if body.HasField("admin_key"):
+                transaction.admin_key = Key.from_proto_key(body.admin_key)
+            transaction.decline_reward = body.decline_reward if body.decline_reward else None
+            if body.HasField("grpc_proxy_endpoint"):
+                transaction.grpc_web_proxy_endpoint = Endpoint._from_proto(body.grpc_proxy_endpoint)
+        return transaction
 
     def _get_method(self, channel: _Channel) -> _Method:
         """

--- a/src/hiero_sdk_python/nodes/node_create_transaction.py
+++ b/src/hiero_sdk_python/nodes/node_create_transaction.py
@@ -286,25 +286,6 @@ class NodeCreateTransaction(Transaction):
         scheduled_body.nodeCreate.CopyFrom(node_create_body)
         return scheduled_body
 
-    @classmethod
-    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
-        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
-        if transaction_body.HasField("nodeCreate"):
-            body = transaction_body.nodeCreate
-            if body.HasField("account_id"):
-                transaction.account_id = AccountId._from_proto(body.account_id)
-            transaction.description = body.description if body.description else None
-            transaction.gossip_endpoints = [Endpoint._from_proto(ep) for ep in body.gossip_endpoint]
-            transaction.service_endpoints = [Endpoint._from_proto(ep) for ep in body.service_endpoint]
-            transaction.gossip_ca_certificate = body.gossip_ca_certificate if body.gossip_ca_certificate else None
-            transaction.grpc_certificate_hash = body.grpc_certificate_hash if body.grpc_certificate_hash else None
-            if body.HasField("admin_key"):
-                transaction.admin_key = Key.from_proto_key(body.admin_key)
-            transaction.decline_reward = body.decline_reward if body.decline_reward else None
-            if body.HasField("grpc_proxy_endpoint"):
-                transaction.grpc_web_proxy_endpoint = Endpoint._from_proto(body.grpc_proxy_endpoint)
-        return transaction
-
     def _get_method(self, channel: _Channel) -> _Method:
         """
         Gets the method to execute the node create transaction.
@@ -337,7 +318,7 @@ class NodeCreateTransaction(Transaction):
             if pb.grpc_certificate_hash:
                 transaction.grpc_certificate_hash = pb.grpc_certificate_hash
             if pb.HasField("admin_key"):
-                transaction.admin_key = PublicKey._from_proto(pb.admin_key)
+                transaction.admin_key = Key.from_proto_key(pb.admin_key)
             if pb.decline_reward:
                 transaction.decline_reward = pb.decline_reward
             if pb.HasField("grpc_proxy_endpoint"):

--- a/src/hiero_sdk_python/nodes/node_delete_transaction.py
+++ b/src/hiero_sdk_python/nodes/node_delete_transaction.py
@@ -92,6 +92,14 @@ class NodeDeleteTransaction(Transaction):
         scheduled_body.nodeDelete.CopyFrom(node_delete_body)
         return scheduled_body
 
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("nodeDelete"):
+            body = transaction_body.nodeDelete
+            transaction.node_id = body.node_id if body.node_id else None
+        return transaction
+
     def _get_method(self, channel: _Channel) -> _Method:
         """
         Gets the method to execute the node delete transaction.

--- a/src/hiero_sdk_python/nodes/node_delete_transaction.py
+++ b/src/hiero_sdk_python/nodes/node_delete_transaction.py
@@ -97,7 +97,7 @@ class NodeDeleteTransaction(Transaction):
         transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
         if transaction_body.HasField("nodeDelete"):
             body = transaction_body.nodeDelete
-            transaction.node_id = body.node_id if body.node_id else None
+            transaction.node_id = body.node_id
         return transaction
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/nodes/node_update_transaction.py
+++ b/src/hiero_sdk_python/nodes/node_update_transaction.py
@@ -366,7 +366,7 @@ class NodeUpdateTransaction(Transaction):
 
         if transaction_body.HasField("nodeUpdate"):
             pb = transaction_body.nodeUpdate
-            transaction.node_id = pb.node_id if pb.node_id else None
+            transaction.node_id = pb.node_id
             if pb.HasField("account_id"):
                 transaction.account_id = AccountId._from_proto(pb.account_id)
             if pb.HasField("description"):

--- a/src/hiero_sdk_python/nodes/node_update_transaction.py
+++ b/src/hiero_sdk_python/nodes/node_update_transaction.py
@@ -10,6 +10,7 @@ from google.protobuf.wrappers_pb2 import BoolValue, BytesValue, StringValue
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.address_book.endpoint import Endpoint
 from hiero_sdk_python.channels import _Channel
+from hiero_sdk_python.crypto.key import Key
 from hiero_sdk_python.crypto.public_key import PublicKey
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services.node_update_pb2 import (
@@ -343,6 +344,30 @@ class NodeUpdateTransaction(Transaction):
         scheduled_body = self.build_base_scheduled_body()
         scheduled_body.nodeUpdate.CopyFrom(node_update_body)
         return scheduled_body
+
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("nodeUpdate"):
+            body = transaction_body.nodeUpdate
+            transaction.node_id = body.node_id if body.node_id else None
+            if body.HasField("account_id"):
+                transaction.account_id = AccountId._from_proto(body.account_id)
+            if body.HasField("description"):
+                transaction.description = body.description.value
+            transaction.gossip_endpoints = [Endpoint._from_proto(ep) for ep in body.gossip_endpoint]
+            transaction.service_endpoints = [Endpoint._from_proto(ep) for ep in body.service_endpoint]
+            if body.HasField("gossip_ca_certificate"):
+                transaction.gossip_ca_certificate = body.gossip_ca_certificate.value
+            if body.HasField("grpc_certificate_hash"):
+                transaction.grpc_certificate_hash = body.grpc_certificate_hash.value
+            if body.HasField("admin_key"):
+                transaction.admin_key = Key.from_proto_key(body.admin_key)
+            if body.HasField("decline_reward"):
+                transaction.decline_reward = body.decline_reward.value
+            if body.HasField("grpc_proxy_endpoint"):
+                transaction.grpc_web_proxy_endpoint = Endpoint._from_proto(body.grpc_proxy_endpoint)
+        return transaction
 
     def _get_method(self, channel: _Channel) -> _Method:
         """

--- a/src/hiero_sdk_python/nodes/node_update_transaction.py
+++ b/src/hiero_sdk_python/nodes/node_update_transaction.py
@@ -345,30 +345,6 @@ class NodeUpdateTransaction(Transaction):
         scheduled_body.nodeUpdate.CopyFrom(node_update_body)
         return scheduled_body
 
-    @classmethod
-    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
-        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
-        if transaction_body.HasField("nodeUpdate"):
-            body = transaction_body.nodeUpdate
-            transaction.node_id = body.node_id if body.node_id else None
-            if body.HasField("account_id"):
-                transaction.account_id = AccountId._from_proto(body.account_id)
-            if body.HasField("description"):
-                transaction.description = body.description.value
-            transaction.gossip_endpoints = [Endpoint._from_proto(ep) for ep in body.gossip_endpoint]
-            transaction.service_endpoints = [Endpoint._from_proto(ep) for ep in body.service_endpoint]
-            if body.HasField("gossip_ca_certificate"):
-                transaction.gossip_ca_certificate = body.gossip_ca_certificate.value
-            if body.HasField("grpc_certificate_hash"):
-                transaction.grpc_certificate_hash = body.grpc_certificate_hash.value
-            if body.HasField("admin_key"):
-                transaction.admin_key = Key.from_proto_key(body.admin_key)
-            if body.HasField("decline_reward"):
-                transaction.decline_reward = body.decline_reward.value
-            if body.HasField("grpc_proxy_endpoint"):
-                transaction.grpc_web_proxy_endpoint = Endpoint._from_proto(body.grpc_proxy_endpoint)
-        return transaction
-
     def _get_method(self, channel: _Channel) -> _Method:
         """
         Gets the method to execute the node update transaction.
@@ -390,7 +366,7 @@ class NodeUpdateTransaction(Transaction):
 
         if transaction_body.HasField("nodeUpdate"):
             pb = transaction_body.nodeUpdate
-            transaction.node_id = pb.node_id
+            transaction.node_id = pb.node_id if pb.node_id else None
             if pb.HasField("account_id"):
                 transaction.account_id = AccountId._from_proto(pb.account_id)
             if pb.HasField("description"):
@@ -402,7 +378,7 @@ class NodeUpdateTransaction(Transaction):
             if pb.HasField("grpc_certificate_hash"):
                 transaction.grpc_certificate_hash = pb.grpc_certificate_hash.value
             if pb.HasField("admin_key"):
-                transaction.admin_key = PublicKey._from_proto(pb.admin_key)
+                transaction.admin_key = Key.from_proto_key(pb.admin_key)
             if pb.HasField("decline_reward"):
                 transaction.decline_reward = pb.decline_reward.value
             if pb.HasField("grpc_proxy_endpoint"):

--- a/src/hiero_sdk_python/prng_transaction.py
+++ b/src/hiero_sdk_python/prng_transaction.py
@@ -74,6 +74,14 @@ class PrngTransaction(Transaction):
         transaction_body.util_prng.CopyFrom(prng_body)
         return transaction_body
 
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("util_prng"):
+            body = transaction_body.util_prng
+            transaction.range = body.range if body.range else None
+        return transaction
+
     def _get_method(self, channel: _Channel) -> _Method:
         """
         Returns the appropriate gRPC method for the prng transaction.

--- a/src/hiero_sdk_python/schedule/schedule_create_transaction.py
+++ b/src/hiero_sdk_python/schedule/schedule_create_transaction.py
@@ -241,8 +241,8 @@ class ScheduleCreateTransaction(Transaction):
                 transaction.admin_key = PublicKey._from_proto(body.adminKey)
             if body.HasField("scheduledTransactionBody"):
                 transaction.schedulable_body = body.scheduledTransactionBody
-            transaction.schedule_memo = body.memo if body.memo else None
+            transaction.schedule_memo = body.memo
             if body.HasField("expiration_time"):
                 transaction.expiration_time = Timestamp._from_protobuf(body.expiration_time)
-            transaction.wait_for_expiry = body.wait_for_expiry if body.wait_for_expiry else None
+            transaction.wait_for_expiry = body.wait_for_expiry
         return transaction

--- a/src/hiero_sdk_python/schedule/schedule_create_transaction.py
+++ b/src/hiero_sdk_python/schedule/schedule_create_transaction.py
@@ -229,3 +229,20 @@ class ScheduleCreateTransaction(Transaction):
             _Method: An object containing the transaction function to create a schedule.
         """
         return _Method(transaction_func=channel.schedule.createSchedule, query_func=None)
+
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("scheduleCreate"):
+            body = transaction_body.scheduleCreate
+            if body.HasField("payerAccountID"):
+                transaction.payer_account_id = AccountId._from_proto(body.payerAccountID)
+            if body.HasField("adminKey"):
+                transaction.admin_key = PublicKey._from_proto(body.adminKey)
+            if body.HasField("scheduledTransactionBody"):
+                transaction.schedulable_body = body.scheduledTransactionBody
+            transaction.schedule_memo = body.memo if body.memo else None
+            if body.HasField("expiration_time"):
+                transaction.expiration_time = Timestamp._from_protobuf(body.expiration_time)
+            transaction.wait_for_expiry = body.wait_for_expiry if body.wait_for_expiry else None
+        return transaction

--- a/src/hiero_sdk_python/schedule/schedule_delete_transaction.py
+++ b/src/hiero_sdk_python/schedule/schedule_delete_transaction.py
@@ -103,3 +103,12 @@ class ScheduleDeleteTransaction(Transaction):
             _Method: An object containing the transaction function to delete a schedule.
         """
         return _Method(transaction_func=channel.schedule.deleteSchedule, query_func=None)
+
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("scheduleDelete"):
+            body = transaction_body.scheduleDelete
+            if body.HasField("scheduleID"):
+                transaction.schedule_id = ScheduleId._from_proto(body.scheduleID)
+        return transaction

--- a/src/hiero_sdk_python/schedule/schedule_sign_transaction.py
+++ b/src/hiero_sdk_python/schedule/schedule_sign_transaction.py
@@ -109,3 +109,12 @@ class ScheduleSignTransaction(Transaction):
             _Method: An object containing the transaction function to sign a schedule.
         """
         return _Method(transaction_func=channel.schedule.signSchedule, query_func=None)
+
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("scheduleSign"):
+            body = transaction_body.scheduleSign
+            if body.HasField("scheduleID"):
+                transaction.schedule_id = ScheduleId._from_proto(body.scheduleID)
+        return transaction

--- a/src/hiero_sdk_python/system/freeze_transaction.py
+++ b/src/hiero_sdk_python/system/freeze_transaction.py
@@ -156,3 +156,16 @@ class FreezeTransaction(Transaction):
             _Method: An object containing the transaction function to freeze the network.
         """
         return _Method(transaction_func=channel.freeze.freeze, query_func=None)
+
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("freeze"):
+            body = transaction_body.freeze
+            if body.HasField("start_time"):
+                transaction.start_time = Timestamp._from_protobuf(body.start_time)
+            if body.HasField("update_file"):
+                transaction.file_id = FileId._from_proto(body.update_file)
+            transaction.file_hash = body.file_hash if body.file_hash else None
+            transaction.freeze_type = FreezeType._from_proto(body.freeze_type)
+        return transaction

--- a/src/hiero_sdk_python/tokens/custom_fixed_fee.py
+++ b/src/hiero_sdk_python/tokens/custom_fixed_fee.py
@@ -283,6 +283,27 @@ class CustomFixedFee(CustomFee):
             all_collectors_are_exempt=collectors_are_exempt,
         )
 
+    @classmethod
+    def _from_topic_fee_proto(cls, proto_fee: custom_fees_pb2.FixedCustomFee) -> CustomFixedFee:
+        """Creates a CustomFixedFee from a FixedCustomFee protobuf (used for topic fees)."""
+        from hiero_sdk_python.tokens.token_id import TokenId
+
+        fixed_fee_proto = proto_fee.fixed_fee
+
+        denominating_token_id = None
+        if fixed_fee_proto.HasField("denominating_token_id"):
+            denominating_token_id = TokenId._from_proto(fixed_fee_proto.denominating_token_id)
+
+        fee_collector_account_id = None
+        if proto_fee.HasField("fee_collector_account_id"):
+            fee_collector_account_id = AccountId._from_proto(proto_fee.fee_collector_account_id)
+
+        return cls(
+            amount=fixed_fee_proto.amount,
+            denominating_token_id=denominating_token_id,
+            fee_collector_account_id=fee_collector_account_id,
+        )
+
     def __eq__(self, other: CustomFixedFee) -> bool:
         """Compares this CustomFixedFee instance with another object for equality.
 

--- a/src/hiero_sdk_python/tokens/custom_fixed_fee.py
+++ b/src/hiero_sdk_python/tokens/custom_fixed_fee.py
@@ -264,6 +264,8 @@ class CustomFixedFee(CustomFee):
         Raises:
             ValueError: If the `fixed_fee` field is not set in the protobuf message.
         """
+        if not proto_fee.HasField("fixed_fee"):
+            raise ValueError("fixed_fee is required in CustomFee proto")
         fixed_fee_proto = proto_fee.fixed_fee
 
         denominating_token_id = None
@@ -288,6 +290,8 @@ class CustomFixedFee(CustomFee):
         """Creates a CustomFixedFee from a FixedCustomFee protobuf (used for topic fees)."""
         from hiero_sdk_python.tokens.token_id import TokenId
 
+        if not proto_fee.HasField("fixed_fee"):
+            raise ValueError("fixed_fee is required in FixedCustomFee proto")
         fixed_fee_proto = proto_fee.fixed_fee
 
         denominating_token_id = None

--- a/src/hiero_sdk_python/tokens/token_airdrop_claim.py
+++ b/src/hiero_sdk_python/tokens/token_airdrop_claim.py
@@ -116,7 +116,7 @@ class TokenClaimAirdropTransaction(Transaction):
         ]
 
     @classmethod
-    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):  # noqa: PLR0912
         transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
         if transaction_body.HasField("tokenClaimAirdrop"):
             body = transaction_body.tokenClaimAirdrop

--- a/src/hiero_sdk_python/tokens/token_airdrop_claim.py
+++ b/src/hiero_sdk_python/tokens/token_airdrop_claim.py
@@ -123,6 +123,7 @@ class TokenClaimAirdropTransaction(Transaction):
             transaction._pending_airdrop_ids = [
                 PendingAirdropId._from_proto(a) for a in body.pending_airdrops
             ]
+            transaction._validate_all(transaction._pending_airdrop_ids)
         return transaction
 
     @classmethod

--- a/src/hiero_sdk_python/tokens/token_airdrop_claim.py
+++ b/src/hiero_sdk_python/tokens/token_airdrop_claim.py
@@ -116,6 +116,16 @@ class TokenClaimAirdropTransaction(Transaction):
         ]
 
     @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("tokenClaimAirdrop"):
+            body = transaction_body.tokenClaimAirdrop
+            transaction._pending_airdrop_ids = [
+                PendingAirdropId._from_proto(a) for a in body.pending_airdrops
+            ]
+        return transaction
+
+    @classmethod
     def _from_proto(cls, proto: TokenClaimAirdropTransactionBody) -> TokenClaimAirdropTransaction:
         """Construct a TokenClaimAirdropTransaction from a TokenClaimAirdropTransactionBody.
 

--- a/src/hiero_sdk_python/tokens/token_airdrop_claim.py
+++ b/src/hiero_sdk_python/tokens/token_airdrop_claim.py
@@ -120,9 +120,7 @@ class TokenClaimAirdropTransaction(Transaction):
         transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
         if transaction_body.HasField("tokenClaimAirdrop"):
             body = transaction_body.tokenClaimAirdrop
-            transaction._pending_airdrop_ids = [
-                PendingAirdropId._from_proto(a) for a in body.pending_airdrops
-            ]
+            transaction._pending_airdrop_ids = [PendingAirdropId._from_proto(a) for a in body.pending_airdrops]
             transaction._validate_all(transaction._pending_airdrop_ids)
         return transaction
 

--- a/src/hiero_sdk_python/tokens/token_airdrop_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_airdrop_transaction.py
@@ -63,6 +63,37 @@ class TokenAirdropTransaction(AbstractTokenTransferTransaction["TokenAirdropTran
         return token_airdrop_pb2.TokenAirdropTransactionBody(token_transfers=token_transfers)
 
     @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        from hiero_sdk_python.account.account_id import AccountId
+        from hiero_sdk_python.tokens.token_id import TokenId
+        from hiero_sdk_python.tokens.token_nft_transfer import TokenNftTransfer
+        from hiero_sdk_python.tokens.token_transfer import TokenTransfer
+
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("tokenAirdrop"):
+            for transfer in transaction_body.tokenAirdrop.token_transfers:
+                if not transfer.HasField("token"):
+                    continue
+                token_id = TokenId._from_proto(transfer.token)
+                for t in transfer.transfers:
+                    if not t.HasField("accountID"):
+                        continue
+                    account_id = AccountId._from_proto(t.accountID)
+                    expected_decimals = transfer.expected_decimals.value if transfer.HasField("expected_decimals") else None
+                    transaction.token_transfers[token_id].append(
+                        TokenTransfer(token_id, account_id, t.amount, expected_decimals, t.is_approval)
+                    )
+                for n in transfer.nftTransfers:
+                    if not n.HasField("senderAccountID") or not n.HasField("receiverAccountID"):
+                        continue
+                    sender_id = AccountId._from_proto(n.senderAccountID)
+                    receiver_id = AccountId._from_proto(n.receiverAccountID)
+                    transaction.nft_transfers[token_id].append(
+                        TokenNftTransfer(token_id, sender_id, receiver_id, n.serialNumber, n.is_approval)
+                    )
+        return transaction
+
+    @classmethod
     def _from_proto(cls, proto: token_airdrop_pb2.TokenAirdropTransactionBody) -> TokenAirdropTransaction:
         """
         Construct an instance of TokenAirdropTransaction from protobuf TokenAirdropTransactionBody.

--- a/src/hiero_sdk_python/tokens/token_airdrop_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_airdrop_transaction.py
@@ -9,6 +9,7 @@ Hedera Token Service (HTS) airdrop functionality.
 
 from __future__ import annotations
 
+from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services import token_airdrop_pb2, transaction_pb2
@@ -16,6 +17,7 @@ from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
     SchedulableTransactionBody,
 )
 from hiero_sdk_python.tokens.abstract_token_transfer_transaction import AbstractTokenTransferTransaction
+from hiero_sdk_python.tokens.token_id import TokenId
 from hiero_sdk_python.tokens.token_nft_transfer import TokenNftTransfer
 from hiero_sdk_python.tokens.token_transfer import TokenTransfer
 
@@ -64,11 +66,6 @@ class TokenAirdropTransaction(AbstractTokenTransferTransaction["TokenAirdropTran
 
     @classmethod
     def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
-        from hiero_sdk_python.account.account_id import AccountId
-        from hiero_sdk_python.tokens.token_id import TokenId
-        from hiero_sdk_python.tokens.token_nft_transfer import TokenNftTransfer
-        from hiero_sdk_python.tokens.token_transfer import TokenTransfer
-
         transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
         if transaction_body.HasField("tokenAirdrop"):
             for transfer in transaction_body.tokenAirdrop.token_transfers:

--- a/src/hiero_sdk_python/tokens/token_airdrop_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_airdrop_transaction.py
@@ -76,7 +76,9 @@ class TokenAirdropTransaction(AbstractTokenTransferTransaction["TokenAirdropTran
                     if not t.HasField("accountID"):
                         continue
                     account_id = AccountId._from_proto(t.accountID)
-                    expected_decimals = transfer.expected_decimals.value if transfer.HasField("expected_decimals") else None
+                    expected_decimals = (
+                        transfer.expected_decimals.value if transfer.HasField("expected_decimals") else None
+                    )
                     transaction.token_transfers[token_id].append(
                         TokenTransfer(token_id, account_id, t.amount, expected_decimals, t.is_approval)
                     )

--- a/src/hiero_sdk_python/tokens/token_airdrop_transaction_cancel.py
+++ b/src/hiero_sdk_python/tokens/token_airdrop_transaction_cancel.py
@@ -100,5 +100,15 @@ class TokenCancelAirdropTransaction(Transaction):
         schedulable_body.tokenCancelAirdrop.CopyFrom(token_airdrop_cancel_body)
         return schedulable_body
 
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("tokenCancelAirdrop"):
+            body = transaction_body.tokenCancelAirdrop
+            transaction.pending_airdrops = [
+                PendingAirdropId._from_proto(a) for a in body.pending_airdrops
+            ]
+        return transaction
+
     def _get_method(self, channel):
         return _Method(transaction_func=channel.token.cancelAirdrop, query_func=None)

--- a/src/hiero_sdk_python/tokens/token_airdrop_transaction_cancel.py
+++ b/src/hiero_sdk_python/tokens/token_airdrop_transaction_cancel.py
@@ -105,9 +105,7 @@ class TokenCancelAirdropTransaction(Transaction):
         transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
         if transaction_body.HasField("tokenCancelAirdrop"):
             body = transaction_body.tokenCancelAirdrop
-            transaction.pending_airdrops = [
-                PendingAirdropId._from_proto(a) for a in body.pending_airdrops
-            ]
+            transaction.pending_airdrops = [PendingAirdropId._from_proto(a) for a in body.pending_airdrops]
         return transaction
 
     def _get_method(self, channel):

--- a/src/hiero_sdk_python/tokens/token_associate_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_associate_transaction.py
@@ -103,6 +103,16 @@ class TokenAssociateTransaction(Transaction):
         )
 
     @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("tokenAssociate"):
+            body = transaction_body.tokenAssociate
+            if body.HasField("account"):
+                transaction.account_id = AccountId._from_proto(body.account)
+            transaction.token_ids = [TokenId._from_proto(t) for t in body.tokens]
+        return transaction
+
+    @classmethod
     def _from_proto(cls, body: token_associate_pb2.TokenAssociateTransactionBody) -> TokenAssociateTransaction:
         """Construct a TokenAssociateTransaction from its protobuf."""
         account_id = AccountId._from_proto(body.account)

--- a/src/hiero_sdk_python/tokens/token_burn_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_burn_transaction.py
@@ -160,6 +160,17 @@ class TokenBurnTransaction(Transaction):
         """
         return _Method(transaction_func=channel.token.burnToken, query_func=None)
 
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("tokenBurn"):
+            body = transaction_body.tokenBurn
+            if body.HasField("token"):
+                transaction.token_id = TokenId._from_proto(body.token)
+            transaction.amount = body.amount if body.amount else None
+            transaction.serials = list(body.serialNumbers)
+        return transaction
+
     def _from_proto(self, proto: TokenBurnTransactionBody) -> TokenBurnTransaction:
         """
         Deserializes a TokenBurnTransactionBody from a protobuf object.

--- a/src/hiero_sdk_python/tokens/token_create_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_create_transaction.py
@@ -458,3 +458,48 @@ class TokenCreateTransaction(Transaction):
 
     def _get_method(self, channel: _Channel) -> _Method:
         return _Method(transaction_func=channel.token.createToken, query_func=None)
+
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        from hiero_sdk_python.crypto.public_key import PublicKey
+
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("tokenCreation"):
+            body = transaction_body.tokenCreation
+            transaction._token_params.token_name = body.name
+            transaction._token_params.token_symbol = body.symbol
+            transaction._token_params.decimals = body.decimals
+            transaction._token_params.initial_supply = body.initialSupply
+            transaction._token_params.token_type = TokenType(body.tokenType)
+            transaction._token_params.supply_type = SupplyType(body.supplyType)
+            transaction._token_params.max_supply = body.maxSupply
+            transaction._token_params.freeze_default = body.freezeDefault
+            if body.HasField("treasury"):
+                transaction._token_params.treasury_account_id = AccountId._from_proto(body.treasury)
+            if body.HasField("expiry"):
+                transaction._token_params.expiration_time = Timestamp._from_protobuf(body.expiry)
+                transaction._token_params.auto_renew_period = None
+            if body.HasField("autoRenewAccount"):
+                transaction._token_params.auto_renew_account_id = AccountId._from_proto(body.autoRenewAccount)
+            if body.HasField("autoRenewPeriod"):
+                transaction._token_params.auto_renew_period = Duration._from_proto(body.autoRenewPeriod)
+            transaction._token_params.memo = body.memo if body.memo else None
+            transaction._token_params.metadata = body.metadata if body.metadata else None
+            transaction._token_params.custom_fees = [CustomFee._from_proto(f) for f in body.custom_fees]
+            if body.HasField("adminKey"):
+                transaction._keys.admin_key = PublicKey._from_proto(body.adminKey)
+            if body.HasField("kycKey"):
+                transaction._keys.kyc_key = PublicKey._from_proto(body.kycKey)
+            if body.HasField("freezeKey"):
+                transaction._keys.freeze_key = PublicKey._from_proto(body.freezeKey)
+            if body.HasField("wipeKey"):
+                transaction._keys.wipe_key = PublicKey._from_proto(body.wipeKey)
+            if body.HasField("supplyKey"):
+                transaction._keys.supply_key = PublicKey._from_proto(body.supplyKey)
+            if body.HasField("fee_schedule_key"):
+                transaction._keys.fee_schedule_key = PublicKey._from_proto(body.fee_schedule_key)
+            if body.HasField("pause_key"):
+                transaction._keys.pause_key = PublicKey._from_proto(body.pause_key)
+            if body.HasField("metadata_key"):
+                transaction._keys.metadata_key = PublicKey._from_proto(body.metadata_key)
+        return transaction

--- a/src/hiero_sdk_python/tokens/token_create_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_create_transaction.py
@@ -474,13 +474,17 @@ class TokenCreateTransaction(Transaction):
             transaction._token_params.freeze_default = body.freezeDefault
             if body.HasField("treasury"):
                 transaction._token_params.treasury_account_id = AccountId._from_proto(body.treasury)
+            else:
+                transaction._token_params.treasury_account_id = None
             if body.HasField("expiry"):
                 transaction._token_params.expiration_time = Timestamp._from_protobuf(body.expiry)
                 transaction._token_params.auto_renew_period = None
+            elif body.HasField("autoRenewPeriod"):
+                transaction._token_params.auto_renew_period = Duration._from_proto(body.autoRenewPeriod)
+            else:
+                transaction._token_params.auto_renew_period = None
             if body.HasField("autoRenewAccount"):
                 transaction._token_params.auto_renew_account_id = AccountId._from_proto(body.autoRenewAccount)
-            if body.HasField("autoRenewPeriod"):
-                transaction._token_params.auto_renew_period = Duration._from_proto(body.autoRenewPeriod)
             transaction._token_params.memo = body.memo if body.memo else None
             transaction._token_params.metadata = body.metadata if body.metadata else None
             transaction._token_params.custom_fees = [CustomFee._from_proto(f) for f in body.custom_fees]

--- a/src/hiero_sdk_python/tokens/token_create_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_create_transaction.py
@@ -460,7 +460,7 @@ class TokenCreateTransaction(Transaction):
         return _Method(transaction_func=channel.token.createToken, query_func=None)
 
     @classmethod
-    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):  # noqa: PLR0912
         from hiero_sdk_python.crypto.public_key import PublicKey
 
         transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)

--- a/src/hiero_sdk_python/tokens/token_create_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_create_transaction.py
@@ -28,7 +28,6 @@ from hiero_sdk_python.timestamp import Timestamp
 from hiero_sdk_python.tokens.custom_fee import CustomFee
 from hiero_sdk_python.tokens.supply_type import SupplyType
 from hiero_sdk_python.tokens.token_type import TokenType
-from hiero_sdk_python.crypto.public_key import PublicKey
 from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.utils.key_utils import key_to_proto
 
@@ -486,19 +485,19 @@ class TokenCreateTransaction(Transaction):
             transaction._token_params.metadata = body.metadata if body.metadata else None
             transaction._token_params.custom_fees = [CustomFee._from_proto(f) for f in body.custom_fees]
             if body.HasField("adminKey"):
-                transaction._keys.admin_key = PublicKey._from_proto(body.adminKey)
+                transaction._keys.admin_key = Key.from_proto_key(body.adminKey)
             if body.HasField("kycKey"):
-                transaction._keys.kyc_key = PublicKey._from_proto(body.kycKey)
+                transaction._keys.kyc_key = Key.from_proto_key(body.kycKey)
             if body.HasField("freezeKey"):
-                transaction._keys.freeze_key = PublicKey._from_proto(body.freezeKey)
+                transaction._keys.freeze_key = Key.from_proto_key(body.freezeKey)
             if body.HasField("wipeKey"):
-                transaction._keys.wipe_key = PublicKey._from_proto(body.wipeKey)
+                transaction._keys.wipe_key = Key.from_proto_key(body.wipeKey)
             if body.HasField("supplyKey"):
-                transaction._keys.supply_key = PublicKey._from_proto(body.supplyKey)
+                transaction._keys.supply_key = Key.from_proto_key(body.supplyKey)
             if body.HasField("fee_schedule_key"):
-                transaction._keys.fee_schedule_key = PublicKey._from_proto(body.fee_schedule_key)
+                transaction._keys.fee_schedule_key = Key.from_proto_key(body.fee_schedule_key)
             if body.HasField("pause_key"):
-                transaction._keys.pause_key = PublicKey._from_proto(body.pause_key)
+                transaction._keys.pause_key = Key.from_proto_key(body.pause_key)
             if body.HasField("metadata_key"):
-                transaction._keys.metadata_key = PublicKey._from_proto(body.metadata_key)
+                transaction._keys.metadata_key = Key.from_proto_key(body.metadata_key)
         return transaction

--- a/src/hiero_sdk_python/tokens/token_create_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_create_transaction.py
@@ -28,6 +28,7 @@ from hiero_sdk_python.timestamp import Timestamp
 from hiero_sdk_python.tokens.custom_fee import CustomFee
 from hiero_sdk_python.tokens.supply_type import SupplyType
 from hiero_sdk_python.tokens.token_type import TokenType
+from hiero_sdk_python.crypto.public_key import PublicKey
 from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.utils.key_utils import key_to_proto
 
@@ -461,8 +462,6 @@ class TokenCreateTransaction(Transaction):
 
     @classmethod
     def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):  # noqa: PLR0912
-        from hiero_sdk_python.crypto.public_key import PublicKey
-
         transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
         if transaction_body.HasField("tokenCreation"):
             body = transaction_body.tokenCreation

--- a/src/hiero_sdk_python/tokens/token_delete_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_delete_transaction.py
@@ -94,3 +94,12 @@ class TokenDeleteTransaction(Transaction):
 
     def _get_method(self, channel: _Channel) -> _Method:
         return _Method(transaction_func=channel.token.deleteToken, query_func=None)
+
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("tokenDeletion"):
+            body = transaction_body.tokenDeletion
+            if body.HasField("token"):
+                transaction.token_id = TokenId._from_proto(body.token)
+        return transaction

--- a/src/hiero_sdk_python/tokens/token_dissociate_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_dissociate_transaction.py
@@ -78,6 +78,16 @@ class TokenDissociateTransaction(Transaction):
                 token_id.validate_checksum(client)
 
     @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("tokenDissociate"):
+            body = transaction_body.tokenDissociate
+            if body.HasField("account"):
+                transaction.account_id = AccountId._from_proto(body.account)
+            transaction.token_ids = [TokenId._from_proto(t) for t in body.tokens]
+        return transaction
+
+    @classmethod
     def _from_proto(cls, proto: token_dissociate_pb2.TokenDissociateTransactionBody) -> TokenDissociateTransaction:
         """
         Creates a TokenDissociateTransaction instance from a protobuf

--- a/src/hiero_sdk_python/tokens/token_fee_schedule_update_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_fee_schedule_update_transaction.py
@@ -90,6 +90,16 @@ class TokenFeeScheduleUpdateTransaction(Transaction):
         """Gets the gRPC method for this transaction."""
         return _Method(transaction_func=channel.token.updateTokenFeeSchedule)
 
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("token_fee_schedule_update"):
+            body = transaction_body.token_fee_schedule_update
+            if body.HasField("token_id"):
+                transaction.token_id = TokenId._from_proto(body.token_id)
+            transaction.custom_fees = [CustomFee._from_proto(f) for f in body.custom_fees]
+        return transaction
+
     def __repr__(self):
         """Readable representation for debugging."""
         return f"<TokenFeeScheduleUpdateTransaction token_id={self.token_id} fees={len(self.custom_fees)}>"

--- a/src/hiero_sdk_python/tokens/token_freeze_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_freeze_transaction.py
@@ -108,3 +108,14 @@ class TokenFreezeTransaction(Transaction):
 
     def _get_method(self, channel: _Channel) -> _Method:
         return _Method(transaction_func=channel.token.freezeTokenAccount, query_func=None)
+
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("tokenFreeze"):
+            body = transaction_body.tokenFreeze
+            if body.HasField("token"):
+                transaction.token_id = TokenId._from_proto(body.token)
+            if body.HasField("account"):
+                transaction.account_id = AccountId._from_proto(body.account)
+        return transaction

--- a/src/hiero_sdk_python/tokens/token_grant_kyc_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_grant_kyc_transaction.py
@@ -127,6 +127,17 @@ class TokenGrantKycTransaction(Transaction):
         """
         return _Method(transaction_func=channel.token.grantKycToTokenAccount, query_func=None)
 
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("tokenGrantKyc"):
+            body = transaction_body.tokenGrantKyc
+            if body.HasField("token"):
+                transaction.token_id = TokenId._from_proto(body.token)
+            if body.HasField("account"):
+                transaction.account_id = AccountId._from_proto(body.account)
+        return transaction
+
     def _from_proto(self, proto: token_grant_kyc_pb2.TokenGrantKycTransactionBody) -> TokenGrantKycTransaction:
         """
         Initializes a new TokenGrantKycTransaction instance from a protobuf object.

--- a/src/hiero_sdk_python/tokens/token_mint_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_mint_transaction.py
@@ -136,3 +136,14 @@ class TokenMintTransaction(Transaction):
 
     def _get_method(self, channel: _Channel) -> _Method:
         return _Method(transaction_func=channel.token.mintToken, query_func=None)
+
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("tokenMint"):
+            body = transaction_body.tokenMint
+            if body.HasField("token"):
+                transaction.token_id = TokenId._from_proto(body.token)
+            transaction.amount = body.amount if body.amount else None
+            transaction.metadata = list(body.metadata) if body.metadata else None
+        return transaction

--- a/src/hiero_sdk_python/tokens/token_mint_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_mint_transaction.py
@@ -145,5 +145,5 @@ class TokenMintTransaction(Transaction):
             if body.HasField("token"):
                 transaction.token_id = TokenId._from_proto(body.token)
             transaction.amount = body.amount if body.amount else None
-            transaction.metadata = list(body.metadata) if body.metadata else None
+            transaction.metadata = list(body.metadata)
         return transaction

--- a/src/hiero_sdk_python/tokens/token_pause_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_pause_transaction.py
@@ -93,6 +93,15 @@ class TokenPauseTransaction(Transaction):
     def _get_method(self, channel: _Channel) -> _Method:
         return _Method(transaction_func=channel.token.pauseToken, query_func=None)
 
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("token_pause"):
+            body = transaction_body.token_pause
+            if body.HasField("token"):
+                transaction.token_id = TokenId._from_proto(body.token)
+        return transaction
+
     def _from_proto(self, proto: token_pause_pb2.TokenPauseTransactionBody) -> TokenPauseTransaction:
         """
         Deserializes a TokenPauseTransactionBody from a protobuf object.

--- a/src/hiero_sdk_python/tokens/token_reject_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_reject_transaction.py
@@ -128,6 +128,21 @@ class TokenRejectTransaction(Transaction):
         """
         return _Method(transaction_func=channel.token.rejectToken, query_func=None)
 
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("tokenReject"):
+            body = transaction_body.tokenReject
+            if body.HasField("owner"):
+                transaction.owner_id = AccountId._from_proto(body.owner)
+            transaction.token_ids = [
+                TokenId._from_proto(e.fungible_token) for e in body.rejections if e.HasField("fungible_token")
+            ]
+            transaction.nft_ids = [
+                NftId._from_proto(e.nft) for e in body.rejections if e.HasField("nft")
+            ]
+        return transaction
+
     def _from_proto(self, proto: TokenRejectTransactionBody) -> TokenRejectTransaction:
         """
         Deserializes a TokenRejectTransactionBody from a protobuf object.

--- a/src/hiero_sdk_python/tokens/token_reject_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_reject_transaction.py
@@ -138,9 +138,7 @@ class TokenRejectTransaction(Transaction):
             transaction.token_ids = [
                 TokenId._from_proto(e.fungible_token) for e in body.rejections if e.HasField("fungible_token")
             ]
-            transaction.nft_ids = [
-                NftId._from_proto(e.nft) for e in body.rejections if e.HasField("nft")
-            ]
+            transaction.nft_ids = [NftId._from_proto(e.nft) for e in body.rejections if e.HasField("nft")]
         return transaction
 
     def _from_proto(self, proto: TokenRejectTransactionBody) -> TokenRejectTransaction:

--- a/src/hiero_sdk_python/tokens/token_revoke_kyc_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_revoke_kyc_transaction.py
@@ -128,6 +128,17 @@ class TokenRevokeKycTransaction(Transaction):
         """
         return _Method(transaction_func=channel.token.revokeKycFromTokenAccount, query_func=None)
 
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("tokenRevokeKyc"):
+            body = transaction_body.tokenRevokeKyc
+            if body.HasField("token"):
+                transaction.token_id = TokenId._from_proto(body.token)
+            if body.HasField("account"):
+                transaction.account_id = AccountId._from_proto(body.account)
+        return transaction
+
     def _from_proto(self, proto: token_revoke_kyc_pb2.TokenRevokeKycTransactionBody) -> TokenRevokeKycTransaction:
         """
         Initializes a new TokenRevokeKycTransaction instance from a protobuf object.

--- a/src/hiero_sdk_python/tokens/token_unfreeze_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_unfreeze_transaction.py
@@ -116,3 +116,14 @@ class TokenUnfreezeTransaction(Transaction):
 
     def _get_method(self, channel: _Channel) -> _Method:
         return _Method(transaction_func=channel.token.unfreezeTokenAccount, query_func=None)
+
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("tokenUnfreeze"):
+            body = transaction_body.tokenUnfreeze
+            if body.HasField("token"):
+                transaction.token_id = TokenId._from_proto(body.token)
+            if body.HasField("account"):
+                transaction.account_id = AccountId._from_proto(body.account)
+        return transaction

--- a/src/hiero_sdk_python/tokens/token_unpause_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_unpause_transaction.py
@@ -72,6 +72,15 @@ class TokenUnpauseTransaction(Transaction):
             self.token_id.validate_checksum(client)
 
     @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("token_unpause"):
+            body = transaction_body.token_unpause
+            if body.HasField("token"):
+                transaction.token_id = TokenId._from_proto(body.token)
+        return transaction
+
+    @classmethod
     def _from_proto(cls, proto: TokenUnpauseTransactionBody) -> TokenUnpauseTransaction:
         """
         Construct TokenUnpauseTransaction from TokenUnpauseTransactionBody.

--- a/src/hiero_sdk_python/tokens/token_update_nfts_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_update_nfts_transaction.py
@@ -155,6 +155,17 @@ class TokenUpdateNftsTransaction(Transaction):
         """
         return _Method(transaction_func=channel.token.updateNfts, query_func=None)
 
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("token_update_nfts"):
+            body = transaction_body.token_update_nfts
+            if body.HasField("token"):
+                transaction.token_id = TokenId._from_proto(body.token)
+            transaction.serial_numbers = list(body.serial_numbers)
+            transaction.metadata = body.metadata.value if body.HasField("metadata") else None
+        return transaction
+
     def _from_proto(self, proto: token_update_nfts_pb2.TokenUpdateNftsTransactionBody) -> TokenUpdateNftsTransaction:
         """
         Deserializes a TokenUpdateNftsTransactionBody from a protobuf object.

--- a/src/hiero_sdk_python/tokens/token_update_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_update_transaction.py
@@ -472,7 +472,7 @@ class TokenUpdateTransaction(Transaction):
         return _Method(transaction_func=channel.token.updateToken, query_func=None)
 
     @classmethod
-    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):  # noqa: PLR0912
         from hiero_sdk_python.crypto.public_key import PublicKey
 
         transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)

--- a/src/hiero_sdk_python/tokens/token_update_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_update_transaction.py
@@ -25,7 +25,6 @@ from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.timestamp import Timestamp
 from hiero_sdk_python.tokens.token_id import TokenId
 from hiero_sdk_python.tokens.token_key_validation import TokenKeyValidation
-from hiero_sdk_python.crypto.public_key import PublicKey
 from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.utils.key_utils import key_to_proto
 

--- a/src/hiero_sdk_python/tokens/token_update_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_update_transaction.py
@@ -25,6 +25,7 @@ from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.timestamp import Timestamp
 from hiero_sdk_python.tokens.token_id import TokenId
 from hiero_sdk_python.tokens.token_key_validation import TokenKeyValidation
+from hiero_sdk_python.crypto.public_key import PublicKey
 from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.utils.key_utils import key_to_proto
 
@@ -473,8 +474,6 @@ class TokenUpdateTransaction(Transaction):
 
     @classmethod
     def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):  # noqa: PLR0912
-        from hiero_sdk_python.crypto.public_key import PublicKey
-
         transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
         if transaction_body.HasField("tokenUpdate"):
             body = transaction_body.tokenUpdate

--- a/src/hiero_sdk_python/tokens/token_update_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_update_transaction.py
@@ -493,21 +493,21 @@ class TokenUpdateTransaction(Transaction):
                 transaction.auto_renew_period = Duration._from_proto(body.autoRenewPeriod)
             transaction.token_key_verification_mode = TokenKeyValidation._from_proto(body.key_verification_mode)
             if body.HasField("adminKey"):
-                transaction.admin_key = PublicKey._from_proto(body.adminKey)
+                transaction.admin_key = Key.from_proto_key(body.adminKey)
             if body.HasField("freezeKey"):
-                transaction.freeze_key = PublicKey._from_proto(body.freezeKey)
+                transaction.freeze_key = Key.from_proto_key(body.freezeKey)
             if body.HasField("wipeKey"):
-                transaction.wipe_key = PublicKey._from_proto(body.wipeKey)
+                transaction.wipe_key = Key.from_proto_key(body.wipeKey)
             if body.HasField("supplyKey"):
-                transaction.supply_key = PublicKey._from_proto(body.supplyKey)
+                transaction.supply_key = Key.from_proto_key(body.supplyKey)
             if body.HasField("metadata_key"):
-                transaction.metadata_key = PublicKey._from_proto(body.metadata_key)
+                transaction.metadata_key = Key.from_proto_key(body.metadata_key)
             if body.HasField("pause_key"):
-                transaction.pause_key = PublicKey._from_proto(body.pause_key)
+                transaction.pause_key = Key.from_proto_key(body.pause_key)
             if body.HasField("kycKey"):
-                transaction.kyc_key = PublicKey._from_proto(body.kycKey)
+                transaction.kyc_key = Key.from_proto_key(body.kycKey)
             if body.HasField("fee_schedule_key"):
-                transaction.fee_schedule_key = PublicKey._from_proto(body.fee_schedule_key)
+                transaction.fee_schedule_key = Key.from_proto_key(body.fee_schedule_key)
         return transaction
 
     def _set_keys_to_proto(self, token_update_body: token_update_pb2.TokenUpdateTransactionBody) -> None:

--- a/src/hiero_sdk_python/tokens/token_update_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_update_transaction.py
@@ -471,6 +471,46 @@ class TokenUpdateTransaction(Transaction):
         """
         return _Method(transaction_func=channel.token.updateToken, query_func=None)
 
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        from hiero_sdk_python.crypto.public_key import PublicKey
+
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("tokenUpdate"):
+            body = transaction_body.tokenUpdate
+            if body.HasField("token"):
+                transaction.token_id = TokenId._from_proto(body.token)
+            if body.HasField("treasury"):
+                transaction.treasury_account_id = AccountId._from_proto(body.treasury)
+            transaction.token_name = body.name if body.name else None
+            transaction.token_symbol = body.symbol if body.symbol else None
+            transaction.token_memo = body.memo.value if body.HasField("memo") else None
+            transaction.metadata = body.metadata.value if body.HasField("metadata") else None
+            if body.HasField("expiry"):
+                transaction.expiration_time = Timestamp._from_protobuf(body.expiry)
+            if body.HasField("autoRenewAccount"):
+                transaction.auto_renew_account_id = AccountId._from_proto(body.autoRenewAccount)
+            if body.HasField("autoRenewPeriod"):
+                transaction.auto_renew_period = Duration._from_proto(body.autoRenewPeriod)
+            transaction.token_key_verification_mode = TokenKeyValidation._from_proto(body.key_verification_mode)
+            if body.HasField("adminKey"):
+                transaction.admin_key = PublicKey._from_proto(body.adminKey)
+            if body.HasField("freezeKey"):
+                transaction.freeze_key = PublicKey._from_proto(body.freezeKey)
+            if body.HasField("wipeKey"):
+                transaction.wipe_key = PublicKey._from_proto(body.wipeKey)
+            if body.HasField("supplyKey"):
+                transaction.supply_key = PublicKey._from_proto(body.supplyKey)
+            if body.HasField("metadata_key"):
+                transaction.metadata_key = PublicKey._from_proto(body.metadata_key)
+            if body.HasField("pause_key"):
+                transaction.pause_key = PublicKey._from_proto(body.pause_key)
+            if body.HasField("kycKey"):
+                transaction.kyc_key = PublicKey._from_proto(body.kycKey)
+            if body.HasField("fee_schedule_key"):
+                transaction.fee_schedule_key = PublicKey._from_proto(body.fee_schedule_key)
+        return transaction
+
     def _set_keys_to_proto(self, token_update_body: token_update_pb2.TokenUpdateTransactionBody) -> None:
         """Sets the keys to the protobuf transaction body."""
         if self.admin_key:

--- a/src/hiero_sdk_python/tokens/token_wipe_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_wipe_transaction.py
@@ -149,6 +149,19 @@ class TokenWipeTransaction(Transaction):
     def _get_method(self, channel: _Channel) -> _Method:
         return _Method(transaction_func=channel.token.wipeTokenAccount, query_func=None)
 
+    @classmethod
+    def _from_protobuf(cls, transaction_body, body_bytes: bytes, sig_map):
+        transaction = super()._from_protobuf(transaction_body, body_bytes, sig_map)
+        if transaction_body.HasField("tokenWipe"):
+            body = transaction_body.tokenWipe
+            if body.HasField("token"):
+                transaction.token_id = TokenId._from_proto(body.token)
+            if body.HasField("account"):
+                transaction.account_id = AccountId._from_proto(body.account)
+            transaction.amount = body.amount if body.amount else None
+            transaction.serial = list(body.serialNumbers)
+        return transaction
+
     def _from_proto(self, proto: TokenWipeAccountTransactionBody) -> TokenWipeTransaction:
         """
         Deserializes a TokenWipeAccountTransactionBody from a protobuf object.

--- a/src/hiero_sdk_python/tokens/token_wipe_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_wipe_transaction.py
@@ -158,7 +158,7 @@ class TokenWipeTransaction(Transaction):
                 transaction.token_id = TokenId._from_proto(body.token)
             if body.HasField("account"):
                 transaction.account_id = AccountId._from_proto(body.account)
-            transaction.amount = body.amount if body.amount else None
+            transaction.amount = body.amount
             transaction.serial = list(body.serialNumbers)
         return transaction
 

--- a/src/hiero_sdk_python/tokens/token_wipe_transaction.py
+++ b/src/hiero_sdk_python/tokens/token_wipe_transaction.py
@@ -158,7 +158,7 @@ class TokenWipeTransaction(Transaction):
                 transaction.token_id = TokenId._from_proto(body.token)
             if body.HasField("account"):
                 transaction.account_id = AccountId._from_proto(body.account)
-            transaction.amount = body.amount
+            transaction.amount = body.amount if body.amount else None
             transaction.serial = list(body.serialNumbers)
         return transaction
 

--- a/src/hiero_sdk_python/transaction/transaction.py
+++ b/src/hiero_sdk_python/transaction/transaction.py
@@ -476,7 +476,7 @@ class Transaction(_Executable):
         transaction_body.transactionValidDuration.seconds = self.transaction_valid_duration
         transaction_body.generateRecord = self.generate_record
         transaction_body.high_volume = self._high_volume
-        transaction_body.memo = self.memo
+        transaction_body.memo = self.memo if self.memo is not None else ""
         custom_fee_limits = [custom_fee._to_proto() for custom_fee in self.custom_fee_limits]
         transaction_body.max_custom_fees.extend(custom_fee_limits)
 
@@ -501,7 +501,7 @@ class Transaction(_Executable):
         else:
             schedulable_body.transactionFee = int(fee)
 
-        schedulable_body.memo = self.memo
+        schedulable_body.memo = self.memo if self.memo is not None else ""
         custom_fee_limits = [custom_fee._to_proto() for custom_fee in self.custom_fee_limits]
         schedulable_body.max_custom_fees.extend(custom_fee_limits)
 

--- a/src/hiero_sdk_python/transaction/transaction.py
+++ b/src/hiero_sdk_python/transaction/transaction.py
@@ -28,6 +28,65 @@ if TYPE_CHECKING:
     from hiero_sdk_python.transaction.custom_fee_limit import CustomFeeLimit
 
 
+_TRANSACTION_TYPE_MAP: dict[str, str | None] = {
+    "cryptoTransfer": "hiero_sdk_python.transaction.transfer_transaction.TransferTransaction",
+    "contractCall": "hiero_sdk_python.contract.contract_execute_transaction.ContractExecuteTransaction",
+    "contractCreateInstance": "hiero_sdk_python.contract.contract_create_transaction.ContractCreateTransaction",
+    "contractUpdateInstance": "hiero_sdk_python.contract.contract_update_transaction.ContractUpdateTransaction",
+    "contractDeleteInstance": "hiero_sdk_python.contract.contract_delete_transaction.ContractDeleteTransaction",
+    "ethereumTransaction": "hiero_sdk_python.contract.ethereum_transaction.EthereumTransaction",
+    "cryptoAddLiveHash": None,  # Not implemented in SDK
+    "cryptoApproveAllowance": "hiero_sdk_python.account.account_allowance_approve_transaction.AccountAllowanceApproveTransaction",
+    "cryptoDeleteAllowance": "hiero_sdk_python.account.account_allowance_delete_transaction.AccountAllowanceDeleteTransaction",
+    "cryptoCreateAccount": "hiero_sdk_python.account.account_create_transaction.AccountCreateTransaction",
+    "cryptoDelete": "hiero_sdk_python.account.account_delete_transaction.AccountDeleteTransaction",
+    "cryptoDeleteLiveHash": None,  # Not implemented in SDK
+    "cryptoUpdateAccount": "hiero_sdk_python.account.account_update_transaction.AccountUpdateTransaction",
+    "fileAppend": "hiero_sdk_python.file.file_append_transaction.FileAppendTransaction",
+    "fileCreate": "hiero_sdk_python.file.file_create_transaction.FileCreateTransaction",
+    "fileDelete": "hiero_sdk_python.file.file_delete_transaction.FileDeleteTransaction",
+    "fileUpdate": "hiero_sdk_python.file.file_update_transaction.FileUpdateTransaction",
+    "systemDelete": None,  # Admin transaction
+    "systemUndelete": None,  # Admin transaction
+    "freeze": "hiero_sdk_python.system.freeze_transaction.FreezeTransaction",
+    "consensusCreateTopic": "hiero_sdk_python.consensus.topic_create_transaction.TopicCreateTransaction",
+    "consensusUpdateTopic": "hiero_sdk_python.consensus.topic_update_transaction.TopicUpdateTransaction",
+    "consensusDeleteTopic": "hiero_sdk_python.consensus.topic_delete_transaction.TopicDeleteTransaction",
+    "consensusSubmitMessage": "hiero_sdk_python.consensus.topic_message_submit_transaction.TopicMessageSubmitTransaction",
+    "tokenCreation": "hiero_sdk_python.tokens.token_create_transaction.TokenCreateTransaction",
+    "tokenFreeze": "hiero_sdk_python.tokens.token_freeze_transaction.TokenFreezeTransaction",
+    "tokenUnfreeze": "hiero_sdk_python.tokens.token_unfreeze_transaction.TokenUnfreezeTransaction",
+    "tokenGrantKyc": "hiero_sdk_python.tokens.token_grant_kyc_transaction.TokenGrantKycTransaction",
+    "tokenRevokeKyc": "hiero_sdk_python.tokens.token_revoke_kyc_transaction.TokenRevokeKycTransaction",
+    "tokenDeletion": "hiero_sdk_python.tokens.token_delete_transaction.TokenDeleteTransaction",
+    "tokenUpdate": "hiero_sdk_python.tokens.token_update_transaction.TokenUpdateTransaction",
+    "tokenMint": "hiero_sdk_python.tokens.token_mint_transaction.TokenMintTransaction",
+    "tokenBurn": "hiero_sdk_python.tokens.token_burn_transaction.TokenBurnTransaction",
+    "tokenWipe": "hiero_sdk_python.tokens.token_wipe_transaction.TokenWipeTransaction",
+    "tokenAssociate": "hiero_sdk_python.tokens.token_associate_transaction.TokenAssociateTransaction",
+    "tokenDissociate": "hiero_sdk_python.tokens.token_dissociate_transaction.TokenDissociateTransaction",
+    "token_pause": "hiero_sdk_python.tokens.token_pause_transaction.TokenPauseTransaction",
+    "token_unpause": "hiero_sdk_python.tokens.token_unpause_transaction.TokenUnpauseTransaction",
+    "scheduleCreate": "hiero_sdk_python.schedule.schedule_create_transaction.ScheduleCreateTransaction",
+    "scheduleDelete": "hiero_sdk_python.schedule.schedule_delete_transaction.ScheduleDeleteTransaction",
+    "scheduleSign": "hiero_sdk_python.schedule.schedule_sign_transaction.ScheduleSignTransaction",
+    "token_fee_schedule_update": "hiero_sdk_python.tokens.token_fee_schedule_update_transaction.TokenFeeScheduleUpdateTransaction",
+    "token_update_nfts": "hiero_sdk_python.tokens.token_update_nfts_transaction.TokenUpdateNftsTransaction",
+    "nodeCreate": "hiero_sdk_python.nodes.node_create_transaction.NodeCreateTransaction",
+    "nodeUpdate": "hiero_sdk_python.nodes.node_update_transaction.NodeUpdateTransaction",
+    "nodeDelete": "hiero_sdk_python.nodes.node_delete_transaction.NodeDeleteTransaction",
+    "registeredNodeCreate": "hiero_sdk_python.nodes.registered_node_create_transaction.RegisteredNodeCreateTransaction",
+    "registeredNodeUpdate": "hiero_sdk_python.nodes.registered_node_update_transaction.RegisteredNodeUpdateTransaction",
+    "registeredNodeDelete": "hiero_sdk_python.nodes.registered_node_delete_transaction.RegisteredNodeDeleteTransaction",
+    "util_prng": "hiero_sdk_python.prng_transaction.PrngTransaction",
+    "tokenReject": "hiero_sdk_python.tokens.token_reject_transaction.TokenRejectTransaction",
+    "tokenAirdrop": "hiero_sdk_python.tokens.token_airdrop_transaction.TokenAirdropTransaction",
+    "tokenCancelAirdrop": "hiero_sdk_python.tokens.token_airdrop_transaction_cancel.TokenCancelAirdropTransaction",
+    "tokenClaimAirdrop": "hiero_sdk_python.tokens.token_airdrop_claim.TokenClaimAirdropTransaction",
+    "atomic_batch": "hiero_sdk_python.transaction.batch_transaction.BatchTransaction",
+}
+
+
 class Transaction(_Executable):
     """
     Base class for all Hedera transactions.
@@ -786,65 +845,7 @@ class Transaction(_Executable):
         Returns:
             type: The corresponding transaction class, or None if unknown
         """
-        transaction_type_map = {
-            "cryptoTransfer": "hiero_sdk_python.transaction.transfer_transaction.TransferTransaction",
-            "contractCall": "hiero_sdk_python.contract.contract_execute_transaction.ContractExecuteTransaction",
-            "contractCreateInstance": "hiero_sdk_python.contract.contract_create_transaction.ContractCreateTransaction",
-            "contractUpdateInstance": "hiero_sdk_python.contract.contract_update_transaction.ContractUpdateTransaction",
-            "contractDeleteInstance": "hiero_sdk_python.contract.contract_delete_transaction.ContractDeleteTransaction",
-            "ethereumTransaction": "hiero_sdk_python.contract.ethereum_transaction.EthereumTransaction",
-            "cryptoAddLiveHash": None,  # Not implemented in SDK
-            "cryptoApproveAllowance": "hiero_sdk_python.account.account_allowance_approve_transaction.AccountAllowanceApproveTransaction",
-            "cryptoDeleteAllowance": "hiero_sdk_python.account.account_allowance_delete_transaction.AccountAllowanceDeleteTransaction",
-            "cryptoCreateAccount": "hiero_sdk_python.account.account_create_transaction.AccountCreateTransaction",
-            "cryptoDelete": "hiero_sdk_python.account.account_delete_transaction.AccountDeleteTransaction",
-            "cryptoDeleteLiveHash": None,  # Not implemented in SDK
-            "cryptoUpdateAccount": "hiero_sdk_python.account.account_update_transaction.AccountUpdateTransaction",
-            "fileAppend": "hiero_sdk_python.file.file_append_transaction.FileAppendTransaction",
-            "fileCreate": "hiero_sdk_python.file.file_create_transaction.FileCreateTransaction",
-            "fileDelete": "hiero_sdk_python.file.file_delete_transaction.FileDeleteTransaction",
-            "fileUpdate": "hiero_sdk_python.file.file_update_transaction.FileUpdateTransaction",
-            "systemDelete": None,  # Admin transaction
-            "systemUndelete": None,  # Admin transaction
-            "freeze": "hiero_sdk_python.system.freeze_transaction.FreezeTransaction",
-            "consensusCreateTopic": "hiero_sdk_python.consensus.topic_create_transaction.TopicCreateTransaction",
-            "consensusUpdateTopic": "hiero_sdk_python.consensus.topic_update_transaction.TopicUpdateTransaction",
-            "consensusDeleteTopic": "hiero_sdk_python.consensus.topic_delete_transaction.TopicDeleteTransaction",
-            "consensusSubmitMessage": "hiero_sdk_python.consensus.topic_message_submit_transaction.TopicMessageSubmitTransaction",
-            "tokenCreation": "hiero_sdk_python.tokens.token_create_transaction.TokenCreateTransaction",
-            "tokenFreeze": "hiero_sdk_python.tokens.token_freeze_transaction.TokenFreezeTransaction",
-            "tokenUnfreeze": "hiero_sdk_python.tokens.token_unfreeze_transaction.TokenUnfreezeTransaction",
-            "tokenGrantKyc": "hiero_sdk_python.tokens.token_grant_kyc_transaction.TokenGrantKycTransaction",
-            "tokenRevokeKyc": "hiero_sdk_python.tokens.token_revoke_kyc_transaction.TokenRevokeKycTransaction",
-            "tokenDeletion": "hiero_sdk_python.tokens.token_delete_transaction.TokenDeleteTransaction",
-            "tokenUpdate": "hiero_sdk_python.tokens.token_update_transaction.TokenUpdateTransaction",
-            "tokenMint": "hiero_sdk_python.tokens.token_mint_transaction.TokenMintTransaction",
-            "tokenBurn": "hiero_sdk_python.tokens.token_burn_transaction.TokenBurnTransaction",
-            "tokenWipe": "hiero_sdk_python.tokens.token_wipe_transaction.TokenWipeTransaction",
-            "tokenAssociate": "hiero_sdk_python.tokens.token_associate_transaction.TokenAssociateTransaction",
-            "tokenDissociate": "hiero_sdk_python.tokens.token_dissociate_transaction.TokenDissociateTransaction",
-            "token_pause": "hiero_sdk_python.tokens.token_pause_transaction.TokenPauseTransaction",
-            "token_unpause": "hiero_sdk_python.tokens.token_unpause_transaction.TokenUnpauseTransaction",
-            "scheduleCreate": "hiero_sdk_python.schedule.schedule_create_transaction.ScheduleCreateTransaction",
-            "scheduleDelete": "hiero_sdk_python.schedule.schedule_delete_transaction.ScheduleDeleteTransaction",
-            "scheduleSign": "hiero_sdk_python.schedule.schedule_sign_transaction.ScheduleSignTransaction",
-            "token_fee_schedule_update": "hiero_sdk_python.tokens.token_fee_schedule_update_transaction.TokenFeeScheduleUpdateTransaction",
-            "token_update_nfts": "hiero_sdk_python.tokens.token_update_nfts_transaction.TokenUpdateNftsTransaction",
-            "nodeCreate": "hiero_sdk_python.nodes.node_create_transaction.NodeCreateTransaction",
-            "nodeUpdate": "hiero_sdk_python.nodes.node_update_transaction.NodeUpdateTransaction",
-            "nodeDelete": "hiero_sdk_python.nodes.node_delete_transaction.NodeDeleteTransaction",
-            "registeredNodeCreate": "hiero_sdk_python.nodes.registered_node_create_transaction.RegisteredNodeCreateTransaction",
-            "registeredNodeUpdate": "hiero_sdk_python.nodes.registered_node_update_transaction.RegisteredNodeUpdateTransaction",
-            "registeredNodeDelete": "hiero_sdk_python.nodes.registered_node_delete_transaction.RegisteredNodeDeleteTransaction",
-            "util_prng": "hiero_sdk_python.prng_transaction.PrngTransaction",
-            "tokenReject": "hiero_sdk_python.tokens.token_reject_transaction.TokenRejectTransaction",
-            "tokenAirdrop": "hiero_sdk_python.tokens.token_airdrop_transaction.TokenAirdropTransaction",
-            "tokenCancelAirdrop": "hiero_sdk_python.tokens.token_airdrop_transaction_cancel.TokenCancelAirdropTransaction",
-            "tokenClaimAirdrop": "hiero_sdk_python.tokens.token_airdrop_claim.TokenClaimAirdropTransaction",
-            "atomic_batch": "hiero_sdk_python.transaction.batch_transaction.BatchTransaction",
-        }
-
-        class_path = transaction_type_map.get(transaction_type)
+        class_path = _TRANSACTION_TYPE_MAP.get(transaction_type)
 
         if class_path is None:
             return None

--- a/src/hiero_sdk_python/transaction/transaction.py
+++ b/src/hiero_sdk_python/transaction/transaction.py
@@ -836,7 +836,7 @@ class Transaction(_Executable):
             "registeredNodeCreate": "hiero_sdk_python.nodes.registered_node_create_transaction.RegisteredNodeCreateTransaction",
             "registeredNodeUpdate": "hiero_sdk_python.nodes.registered_node_update_transaction.RegisteredNodeUpdateTransaction",
             "registeredNodeDelete": "hiero_sdk_python.nodes.registered_node_delete_transaction.RegisteredNodeDeleteTransaction",
-            "utilPrng": "hiero_sdk_python.prng_transaction.PrngTransaction",
+            "util_prng": "hiero_sdk_python.prng_transaction.PrngTransaction",
             "tokenReject": "hiero_sdk_python.tokens.token_reject_transaction.TokenRejectTransaction",
             "tokenAirdrop": "hiero_sdk_python.tokens.token_airdrop_transaction.TokenAirdropTransaction",
             "tokenCancelAirdrop": "hiero_sdk_python.tokens.token_airdrop_transaction_cancel.TokenCancelAirdropTransaction",

--- a/src/hiero_sdk_python/transaction/transaction.py
+++ b/src/hiero_sdk_python/transaction/transaction.py
@@ -806,7 +806,7 @@ class Transaction(_Executable):
             "fileUpdate": "hiero_sdk_python.file.file_update_transaction.FileUpdateTransaction",
             "systemDelete": None,  # Admin transaction
             "systemUndelete": None,  # Admin transaction
-            "freeze": None,  # Admin transaction
+            "freeze": "hiero_sdk_python.system.freeze_transaction.FreezeTransaction",
             "consensusCreateTopic": "hiero_sdk_python.consensus.topic_create_transaction.TopicCreateTransaction",
             "consensusUpdateTopic": "hiero_sdk_python.consensus.topic_update_transaction.TopicUpdateTransaction",
             "consensusDeleteTopic": "hiero_sdk_python.consensus.topic_delete_transaction.TopicDeleteTransaction",
@@ -823,13 +823,13 @@ class Transaction(_Executable):
             "tokenWipe": "hiero_sdk_python.tokens.token_wipe_transaction.TokenWipeTransaction",
             "tokenAssociate": "hiero_sdk_python.tokens.token_associate_transaction.TokenAssociateTransaction",
             "tokenDissociate": "hiero_sdk_python.tokens.token_dissociate_transaction.TokenDissociateTransaction",
-            "tokenPause": "hiero_sdk_python.tokens.token_pause_transaction.TokenPauseTransaction",
-            "tokenUnpause": "hiero_sdk_python.tokens.token_pause_transaction.TokenUnpauseTransaction",
+            "token_pause": "hiero_sdk_python.tokens.token_pause_transaction.TokenPauseTransaction",
+            "token_unpause": "hiero_sdk_python.tokens.token_unpause_transaction.TokenUnpauseTransaction",
             "scheduleCreate": "hiero_sdk_python.schedule.schedule_create_transaction.ScheduleCreateTransaction",
             "scheduleDelete": "hiero_sdk_python.schedule.schedule_delete_transaction.ScheduleDeleteTransaction",
             "scheduleSign": "hiero_sdk_python.schedule.schedule_sign_transaction.ScheduleSignTransaction",
-            "tokenFeeScheduleUpdate": None,  # Not commonly used
-            "tokenUpdateNfts": "hiero_sdk_python.tokens.token_update_nfts_transaction.TokenUpdateNftsTransaction",
+            "token_fee_schedule_update": "hiero_sdk_python.tokens.token_fee_schedule_update_transaction.TokenFeeScheduleUpdateTransaction",
+            "token_update_nfts": "hiero_sdk_python.tokens.token_update_nfts_transaction.TokenUpdateNftsTransaction",
             "nodeCreate": "hiero_sdk_python.nodes.node_create_transaction.NodeCreateTransaction",
             "nodeUpdate": "hiero_sdk_python.nodes.node_update_transaction.NodeUpdateTransaction",
             "nodeDelete": "hiero_sdk_python.nodes.node_delete_transaction.NodeDeleteTransaction",
@@ -839,7 +839,8 @@ class Transaction(_Executable):
             "utilPrng": "hiero_sdk_python.prng_transaction.PrngTransaction",
             "tokenReject": "hiero_sdk_python.tokens.token_reject_transaction.TokenRejectTransaction",
             "tokenAirdrop": "hiero_sdk_python.tokens.token_airdrop_transaction.TokenAirdropTransaction",
-            "tokenCancelAirdrop": "hiero_sdk_python.tokens.token_cancel_airdrop_transaction.TokenCancelAirdropTransaction",
+            "tokenCancelAirdrop": "hiero_sdk_python.tokens.token_airdrop_transaction_cancel.TokenCancelAirdropTransaction",
+            "tokenClaimAirdrop": "hiero_sdk_python.tokens.token_airdrop_claim.TokenClaimAirdropTransaction",
             "atomic_batch": "hiero_sdk_python.transaction.batch_transaction.BatchTransaction",
         }
 

--- a/tests/unit/account_allowance_approve_transaction_test.py
+++ b/tests/unit/account_allowance_approve_transaction_test.py
@@ -404,3 +404,22 @@ def test_zero_amount_allowances(account_allowance_transaction, sample_accounts, 
     assert len(account_allowance_transaction.token_allowances) == 1
     assert account_allowance_transaction.hbar_allowances[0].amount == 0
     assert account_allowance_transaction.token_allowances[0].amount == 0
+
+
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for AccountAllowanceApproveTransaction."""
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+    owner = AccountId(0, 0, 200)
+    spender = AccountId(0, 0, 300)
+
+    tx = AccountAllowanceApproveTransaction()
+    tx.approve_hbar_allowance(owner, spender, Hbar(10))
+    tx.operator_account_id = operator_id
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = AccountAllowanceApproveTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert len(reconstructed.hbar_allowances) == 1
+    assert reconstructed.hbar_allowances[0].owner_account_id == owner
+    assert reconstructed.hbar_allowances[0].spender_account_id == spender

--- a/tests/unit/account_allowance_approve_transaction_test.py
+++ b/tests/unit/account_allowance_approve_transaction_test.py
@@ -16,6 +16,8 @@ from hiero_sdk_python.hapi.services.crypto_approve_allowance_pb2 import (
 from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.tokens.nft_id import NftId
 from hiero_sdk_python.tokens.token_id import TokenId
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 
 pytestmark = pytest.mark.unit
@@ -406,20 +408,34 @@ def test_zero_amount_allowances(account_allowance_transaction, sample_accounts, 
     assert account_allowance_transaction.token_allowances[0].amount == 0
 
 
-def test_from_protobuf(mock_account_ids):
+def test_from_bytes(mock_account_ids):
     """Test round-trip via _from_protobuf for AccountAllowanceApproveTransaction."""
     operator_id, _, node_account_id, _, _ = mock_account_ids
     owner = AccountId(0, 0, 200)
     spender = AccountId(0, 0, 300)
+    token_id = TokenId(0, 0, 500)
+    nft_id = NftId(token_id, 1)
 
     tx = AccountAllowanceApproveTransaction()
     tx.approve_hbar_allowance(owner, spender, Hbar(10))
-    tx.operator_account_id = operator_id
+    tx.approve_token_allowance(token_id, owner, spender, 100)
+    tx.approve_token_nft_allowance(nft_id, owner, spender)
+    tx.transaction_id = TransactionId.generate(operator_id)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = AccountAllowanceApproveTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, AccountAllowanceApproveTransaction)
     assert len(reconstructed.hbar_allowances) == 1
     assert reconstructed.hbar_allowances[0].owner_account_id == owner
     assert reconstructed.hbar_allowances[0].spender_account_id == spender
+    assert len(reconstructed.token_allowances) == 1
+    assert reconstructed.token_allowances[0].token_id == token_id
+    assert reconstructed.token_allowances[0].owner_account_id == owner
+    assert reconstructed.token_allowances[0].spender_account_id == spender
+    assert reconstructed.token_allowances[0].amount == 100
+    assert len(reconstructed.nft_allowances) == 1
+    assert reconstructed.nft_allowances[0].token_id == token_id
+    assert reconstructed.nft_allowances[0].owner_account_id == owner
+    assert reconstructed.nft_allowances[0].spender_account_id == spender

--- a/tests/unit/account_allowance_approve_transaction_test.py
+++ b/tests/unit/account_allowance_approve_transaction_test.py
@@ -430,6 +430,7 @@ def test_from_bytes(mock_account_ids):
     assert len(reconstructed.hbar_allowances) == 1
     assert reconstructed.hbar_allowances[0].owner_account_id == owner
     assert reconstructed.hbar_allowances[0].spender_account_id == spender
+    assert reconstructed.hbar_allowances[0].amount == Hbar(10).to_tinybars()
     assert len(reconstructed.token_allowances) == 1
     assert reconstructed.token_allowances[0].token_id == token_id
     assert reconstructed.token_allowances[0].owner_account_id == owner
@@ -439,3 +440,4 @@ def test_from_bytes(mock_account_ids):
     assert reconstructed.nft_allowances[0].token_id == token_id
     assert reconstructed.nft_allowances[0].owner_account_id == owner
     assert reconstructed.nft_allowances[0].spender_account_id == spender
+    assert nft_id.serial_number in reconstructed.nft_allowances[0].serial_numbers

--- a/tests/unit/account_allowance_delete_transaction_test.py
+++ b/tests/unit/account_allowance_delete_transaction_test.py
@@ -17,6 +17,8 @@ from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.tokens.nft_id import NftId
 from hiero_sdk_python.tokens.token_id import TokenId
 from hiero_sdk_python.tokens.token_nft_allowance import TokenNftAllowance
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 
 pytestmark = pytest.mark.unit
@@ -261,7 +263,7 @@ def test_empty_nft_wipe_list(account_allowance_delete_transaction):
     assert len(proto_body.nftAllowances) == 0
 
 
-def test_from_protobuf(mock_account_ids):
+def test_from_bytes(mock_account_ids):
     """Test round-trip via _from_protobuf for AccountAllowanceDeleteTransaction."""
     operator_id, _, node_account_id, _, _ = mock_account_ids
     owner = AccountId(0, 0, 200)
@@ -270,12 +272,14 @@ def test_from_protobuf(mock_account_ids):
 
     tx = AccountAllowanceDeleteTransaction()
     tx.delete_all_token_nft_allowances(nft_id, owner)
-    tx.operator_account_id = operator_id
+    tx.transaction_id = TransactionId.generate(operator_id)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = AccountAllowanceDeleteTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, AccountAllowanceDeleteTransaction)
     assert len(reconstructed.nft_wipe) == 1
     assert reconstructed.nft_wipe[0].token_id == token_id
     assert reconstructed.nft_wipe[0].owner_account_id == owner
+    assert reconstructed.nft_wipe[0].serial_numbers == [1]

--- a/tests/unit/account_allowance_delete_transaction_test.py
+++ b/tests/unit/account_allowance_delete_transaction_test.py
@@ -259,3 +259,23 @@ def test_empty_nft_wipe_list(account_allowance_delete_transaction):
 
     proto_body = account_allowance_delete_transaction._build_proto_body()
     assert len(proto_body.nftAllowances) == 0
+
+
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for AccountAllowanceDeleteTransaction."""
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+    owner = AccountId(0, 0, 200)
+    token_id = TokenId(0, 0, 100)
+    nft_id = NftId(token_id, 1)
+
+    tx = AccountAllowanceDeleteTransaction()
+    tx.delete_all_token_nft_allowances(nft_id, owner)
+    tx.operator_account_id = operator_id
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = AccountAllowanceDeleteTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert len(reconstructed.nft_wipe) == 1
+    assert reconstructed.nft_wipe[0].token_id == token_id
+    assert reconstructed.nft_wipe[0].owner_account_id == owner

--- a/tests/unit/account_create_transaction_test.py
+++ b/tests/unit/account_create_transaction_test.py
@@ -25,6 +25,7 @@ from hiero_sdk_python.hapi.services.transaction_response_pb2 import (
     TransactionResponse as TransactionResponseProto,
 )
 from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 from tests.unit.mock_server import mock_hedera_servers
 
@@ -541,7 +542,7 @@ def test_set_stake_account_id_reset_stake_node_id():
     assert tx.staked_node_id is None
 
 
-def test_from_protobuf(mock_account_ids):
+def test_from_bytes(mock_account_ids):
     """Test round-trip via _from_protobuf for AccountCreateTransaction."""
     operator_id, node_account_id = mock_account_ids
 
@@ -552,9 +553,10 @@ def test_from_protobuf(mock_account_ids):
     tx.set_receiver_signature_required(True)
     tx.transaction_id = generate_transaction_id(operator_id)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = AccountCreateTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, AccountCreateTransaction)
     assert reconstructed.initial_balance == Hbar(5).to_tinybars()
     assert reconstructed.receiver_signature_required is True

--- a/tests/unit/account_create_transaction_test.py
+++ b/tests/unit/account_create_transaction_test.py
@@ -539,3 +539,22 @@ def test_set_stake_account_id_reset_stake_node_id():
     tx.set_staked_account_id(AccountId(0, 0, 1))
     assert tx.staked_account_id == AccountId(0, 0, 1)
     assert tx.staked_node_id is None
+
+
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for AccountCreateTransaction."""
+    operator_id, node_account_id = mock_account_ids
+
+    from hiero_sdk_python.hbar import Hbar
+
+    tx = AccountCreateTransaction()
+    tx.set_initial_balance(Hbar(5).to_tinybars())
+    tx.set_receiver_signature_required(True)
+    tx.transaction_id = generate_transaction_id(operator_id)
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = AccountCreateTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.initial_balance == Hbar(5).to_tinybars()
+    assert reconstructed.receiver_signature_required is True

--- a/tests/unit/account_create_transaction_test.py
+++ b/tests/unit/account_create_transaction_test.py
@@ -560,3 +560,20 @@ def test_from_bytes(mock_account_ids):
     assert isinstance(reconstructed, AccountCreateTransaction)
     assert reconstructed.initial_balance == Hbar(5).to_tinybars()
     assert reconstructed.receiver_signature_required is True
+
+
+def test_from_bytes_without_auto_renew_period(mock_account_ids):
+    """When auto_renew_period is None, round-trip must preserve None (not restore the default)."""
+    operator_id, node_account_id = mock_account_ids
+
+    tx = AccountCreateTransaction(auto_renew_period=None)
+    tx.set_initial_balance(1000)
+    tx.transaction_id = generate_transaction_id(operator_id)
+    tx.node_account_id = node_account_id
+    tx.freeze()
+
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
+
+    assert isinstance(reconstructed, AccountCreateTransaction)
+    assert reconstructed.initial_balance == 1000
+    assert reconstructed.auto_renew_period is None

--- a/tests/unit/account_delete_transaction_test.py
+++ b/tests/unit/account_delete_transaction_test.py
@@ -13,6 +13,8 @@ from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
     SchedulableTransactionBody,
 )
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 
 pytestmark = pytest.mark.unit
@@ -261,8 +263,8 @@ def test_build_scheduled_body(delete_params):
     assert schedulable_body.cryptoDelete.transferAccountID == delete_params["transfer_account_id"]._to_proto()
 
 
-def test_from_protobuf(mock_account_ids):
-    """Test round-trip via _from_protobuf for AccountDeleteTransaction."""
+def test_from_bytes(mock_account_ids):
+    """Test round-trip via Transaction.from_bytes() for AccountDeleteTransaction."""
     operator_id, _, node_account_id, _, _ = mock_account_ids
     account_id_sender = AccountId(0, 0, 1)
     account_id_recipient = AccountId(0, 0, 2)
@@ -271,12 +273,13 @@ def test_from_protobuf(mock_account_ids):
         account_id=account_id_sender,
         transfer_account_id=account_id_recipient,
     )
-    tx.operator_account_id = operator_id
+    tx.transaction_id = TransactionId.generate(operator_id)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = AccountDeleteTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, AccountDeleteTransaction)
     assert reconstructed.account_id == account_id_sender
     assert reconstructed.transfer_account_id == account_id_recipient
 

--- a/tests/unit/account_delete_transaction_test.py
+++ b/tests/unit/account_delete_transaction_test.py
@@ -261,6 +261,26 @@ def test_build_scheduled_body(delete_params):
     assert schedulable_body.cryptoDelete.transferAccountID == delete_params["transfer_account_id"]._to_proto()
 
 
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for AccountDeleteTransaction."""
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+    account_id_sender = AccountId(0, 0, 1)
+    account_id_recipient = AccountId(0, 0, 2)
+
+    tx = AccountDeleteTransaction(
+        account_id=account_id_sender,
+        transfer_account_id=account_id_recipient,
+    )
+    tx.operator_account_id = operator_id
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = AccountDeleteTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.account_id == account_id_sender
+    assert reconstructed.transfer_account_id == account_id_recipient
+
+
 def test_parameter_validation_none_values():
     """Test that parameters can be set to None."""
     delete_tx = AccountDeleteTransaction(

--- a/tests/unit/account_update_transaction_test.py
+++ b/tests/unit/account_update_transaction_test.py
@@ -35,6 +35,8 @@ from hiero_sdk_python.hapi.services.transaction_response_pb2 import (
     TransactionResponse as TransactionResponseProto,
 )
 from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 from tests.unit.mock_server import mock_hedera_servers
 
 
@@ -815,7 +817,7 @@ def test_set_keylist_threshold_key():
     assert len(update_body.key.thresholdKey.keys.keys) == 3
 
 
-def test_from_protobuf(mock_account_ids):
+def test_from_bytes(mock_account_ids):
     """Test round-trip via _from_protobuf for AccountUpdateTransaction."""
     operator_id, _, node_account_id, _, _ = mock_account_ids
     account_id_sender = AccountId(0, 0, 1)
@@ -823,11 +825,20 @@ def test_from_protobuf(mock_account_ids):
     tx = AccountUpdateTransaction()
     tx.set_account_id(account_id_sender)
     tx.set_account_memo("updated")
-    tx.operator_account_id = operator_id
+    tx.set_staked_node_id(5)
+    tx.set_decline_staking_reward(False)
+    tx.set_receiver_signature_required(False)
+    tx.set_max_automatic_token_associations(10)
+    tx.transaction_id = TransactionId.generate(operator_id)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = AccountUpdateTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, AccountUpdateTransaction)
     assert reconstructed.account_id == account_id_sender
     assert reconstructed.account_memo == "updated"
+    assert reconstructed.staked_node_id == 5
+    assert reconstructed.decline_staking_reward == False
+    assert reconstructed.receiver_signature_required == False
+    assert reconstructed.max_automatic_token_associations == 10

--- a/tests/unit/account_update_transaction_test.py
+++ b/tests/unit/account_update_transaction_test.py
@@ -813,3 +813,21 @@ def test_set_keylist_threshold_key():
     assert update_body.key.HasField("thresholdKey")
     assert update_body.key.thresholdKey.threshold == 2
     assert len(update_body.key.thresholdKey.keys.keys) == 3
+
+
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for AccountUpdateTransaction."""
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+    account_id_sender = AccountId(0, 0, 1)
+
+    tx = AccountUpdateTransaction()
+    tx.set_account_id(account_id_sender)
+    tx.set_account_memo("updated")
+    tx.operator_account_id = operator_id
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = AccountUpdateTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.account_id == account_id_sender
+    assert reconstructed.account_memo == "updated"

--- a/tests/unit/contract_create_transaction_test.py
+++ b/tests/unit/contract_create_transaction_test.py
@@ -427,3 +427,25 @@ def test_contract_create_params_dataclass():
     assert params_default.staked_account_id is None
     assert params_default.staked_node_id is None
     assert params_default.decline_reward is None
+
+
+def test_from_bytes(mock_account_ids):
+    from hiero_sdk_python.transaction.transaction import Transaction
+    from hiero_sdk_python.transaction.transaction_id import TransactionId
+
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    tx = ContractCreateTransaction()
+    tx.set_gas(100_000)
+    tx.set_bytecode(b"\x60\x80\x60\x40")
+    tx.set_contract_memo("hello")
+    tx.transaction_id = TransactionId.generate(operator_id)
+    tx.node_account_id = node_account_id
+    tx.freeze()
+
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
+
+    assert isinstance(reconstructed, ContractCreateTransaction)
+    assert reconstructed.gas == 100_000
+    assert reconstructed.bytecode == b"\x60\x80\x60\x40"
+    assert reconstructed.contract_memo == "hello"

--- a/tests/unit/contract_delete_transaction_test.py
+++ b/tests/unit/contract_delete_transaction_test.py
@@ -410,3 +410,46 @@ def test_constructor_parameter_combinations():
     assert delete_tx.transfer_contract_id is None
     assert delete_tx.transfer_account_id is None
     assert delete_tx.permanent_removal is True
+
+
+def test_from_bytes(mock_account_ids):
+    from hiero_sdk_python.transaction.transaction import Transaction
+    from hiero_sdk_python.transaction.transaction_id import TransactionId
+
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    tx = ContractDeleteTransaction()
+    tx.set_contract_id(ContractId(0, 0, 999))
+    tx.set_transfer_account_id(AccountId(0, 0, 1))
+    tx.transaction_id = TransactionId.generate(operator_id)
+    tx.node_account_id = node_account_id
+    tx.freeze()
+
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
+
+    assert isinstance(reconstructed, ContractDeleteTransaction)
+    assert reconstructed.contract_id == ContractId(0, 0, 999)
+    assert reconstructed.transfer_account_id == AccountId(0, 0, 1)
+    assert reconstructed.transfer_contract_id is None
+
+
+def test_from_bytes_with_permanent_removal(mock_account_ids):
+    from hiero_sdk_python.transaction.transaction import Transaction
+    from hiero_sdk_python.transaction.transaction_id import TransactionId
+
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    tx = ContractDeleteTransaction()
+    tx.set_contract_id(ContractId(0, 0, 123))
+    tx.set_permanent_removal(True)
+    tx.transaction_id = TransactionId.generate(operator_id)
+    tx.node_account_id = node_account_id
+    tx.freeze()
+
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
+
+    assert isinstance(reconstructed, ContractDeleteTransaction)
+    assert reconstructed.contract_id == ContractId(0, 0, 123)
+    assert reconstructed.permanent_removal is True
+    assert reconstructed.transfer_account_id is None
+    assert reconstructed.transfer_contract_id is None

--- a/tests/unit/contract_execute_transaction_test.py
+++ b/tests/unit/contract_execute_transaction_test.py
@@ -384,3 +384,25 @@ def test_contract_execute_transaction_can_execute():
 
         assert receipt.status == ResponseCode.SUCCESS, "Transaction should have succeeded"
         assert str(receipt.contract_id) == str(contract_id)
+
+
+def test_from_bytes(mock_account_ids):
+    from hiero_sdk_python.transaction.transaction import Transaction
+    from hiero_sdk_python.transaction.transaction_id import TransactionId
+
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    tx = ContractExecuteTransaction()
+    tx.set_contract_id(ContractId(0, 0, 777))
+    tx.set_gas(200_000)
+    tx.set_function_parameters(b"\x01\x02\x03")
+    tx.transaction_id = TransactionId.generate(operator_id)
+    tx.node_account_id = node_account_id
+    tx.freeze()
+
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
+
+    assert isinstance(reconstructed, ContractExecuteTransaction)
+    assert reconstructed.contract_id == ContractId(0, 0, 777)
+    assert reconstructed.gas == 200_000
+    assert reconstructed.function_parameters == b"\x01\x02\x03"

--- a/tests/unit/contract_update_transaction_test.py
+++ b/tests/unit/contract_update_transaction_test.py
@@ -383,3 +383,25 @@ def test_decline_reward_false(contract_id):
     tx = ContractUpdateTransaction().set_contract_id(contract_id).set_decline_reward(False)
 
     assert tx.decline_reward is False
+
+
+def test_from_bytes(mock_account_ids, contract_id):
+    from hiero_sdk_python.transaction.transaction import Transaction
+    from hiero_sdk_python.transaction.transaction_id import TransactionId
+
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    tx = ContractUpdateTransaction()
+    tx.set_contract_id(contract_id)
+    tx.set_contract_memo("updated memo")
+    tx.set_auto_renew_period(Duration(7_776_000))
+    tx.transaction_id = TransactionId.generate(operator_id)
+    tx.node_account_id = node_account_id
+    tx.freeze()
+
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
+
+    assert isinstance(reconstructed, ContractUpdateTransaction)
+    assert reconstructed.contract_id == contract_id
+    assert reconstructed.contract_memo == "updated memo"
+    assert reconstructed.auto_renew_period.seconds == 7_776_000

--- a/tests/unit/ethereum_transaction_test.py
+++ b/tests/unit/ethereum_transaction_test.py
@@ -233,3 +233,43 @@ def test_ethereum_transaction_can_execute():
         receipt = transaction.execute(client)
 
         assert receipt.status == ResponseCode.SUCCESS, "Transaction should have succeeded"
+
+
+def test_from_bytes(mock_account_ids):
+    from hiero_sdk_python.transaction.transaction import Transaction
+    from hiero_sdk_python.transaction.transaction_id import TransactionId
+
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    tx = EthereumTransaction()
+    tx.set_ethereum_data(b"eth_tx_data")
+    tx.set_max_gas_allowed(500_000)
+    tx.transaction_id = TransactionId.generate(operator_id)
+    tx.node_account_id = node_account_id
+    tx.freeze()
+
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
+
+    assert isinstance(reconstructed, EthereumTransaction)
+    assert reconstructed.ethereum_data == b"eth_tx_data"
+    assert reconstructed.max_gas_allowed == 500_000
+    assert reconstructed.call_data is None
+
+
+def test_from_bytes_with_call_data(mock_account_ids):
+    from hiero_sdk_python.transaction.transaction import Transaction
+    from hiero_sdk_python.transaction.transaction_id import TransactionId
+
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    tx = EthereumTransaction()
+    tx.set_ethereum_data(b"eth_tx")
+    tx.set_call_data_file_id(FileId(0, 0, 88))
+    tx.transaction_id = TransactionId.generate(operator_id)
+    tx.node_account_id = node_account_id
+    tx.freeze()
+
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
+
+    assert isinstance(reconstructed, EthereumTransaction)
+    assert reconstructed.call_data == FileId(0, 0, 88)

--- a/tests/unit/file_append_transaction_test.py
+++ b/tests/unit/file_append_transaction_test.py
@@ -404,7 +404,7 @@ def test_chunk_transaction_id_nanosecond_overflow(file_id):
 
 
 @pytest.mark.unit
-def test_from_protobuf(mock_account_ids):
+def test_from_bytes(mock_account_ids):
     """Test round-trip via _from_protobuf for FileAppendTransaction."""
     operator_id, _, node_account_id, _, _ = mock_account_ids
     test_file_id = FileId(0, 0, 5)
@@ -412,11 +412,12 @@ def test_from_protobuf(mock_account_ids):
     tx = FileAppendTransaction()
     tx.set_file_id(test_file_id)
     tx.set_contents(b"appended")
-    tx.operator_account_id = operator_id
+    tx.transaction_id = TransactionId.generate(operator_id)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = FileAppendTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, FileAppendTransaction)
     assert reconstructed.file_id == test_file_id
     assert reconstructed.contents == b"appended"

--- a/tests/unit/file_append_transaction_test.py
+++ b/tests/unit/file_append_transaction_test.py
@@ -401,3 +401,22 @@ def test_chunk_transaction_id_nanosecond_overflow(file_id):
     # Second chunk seconds=base_seconds + 1, nanos=0
     assert tx._transaction_ids[1].valid_start.seconds == base_seconds + 1
     assert tx._transaction_ids[1].valid_start.nanos == 0
+
+
+@pytest.mark.unit
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for FileAppendTransaction."""
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+    test_file_id = FileId(0, 0, 5)
+
+    tx = FileAppendTransaction()
+    tx.set_file_id(test_file_id)
+    tx.set_contents(b"appended")
+    tx.operator_account_id = operator_id
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = FileAppendTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.file_id == test_file_id
+    assert reconstructed.contents == b"appended"

--- a/tests/unit/file_create_transaction_test.py
+++ b/tests/unit/file_create_transaction_test.py
@@ -268,9 +268,14 @@ def test_from_bytes(mock_account_ids):
     """Test round-trip via Transaction.from_bytes() for FileCreateTransaction."""
     operator_id, _, node_account_id, _, _ = mock_account_ids
 
+    key = PrivateKey.generate().public_key()
+    expiration = Timestamp(seconds=9999999999, nanos=0)
+
     tx = FileCreateTransaction()
     tx.set_contents(b"file contents")
     tx.set_file_memo("my file")
+    tx.set_expiration_time(expiration)
+    tx.set_keys([key])
     tx.transaction_id = TransactionId.generate(operator_id)
     tx.node_account_id = node_account_id
     tx.freeze()
@@ -280,3 +285,6 @@ def test_from_bytes(mock_account_ids):
     assert isinstance(reconstructed, FileCreateTransaction)
     assert reconstructed.contents == b"file contents"
     assert reconstructed.file_memo == "my file"
+    assert reconstructed.expiration_time.seconds == expiration.seconds
+    assert len(reconstructed.keys) == 1
+    assert reconstructed.keys[0].to_bytes_raw() == key.to_bytes_raw()

--- a/tests/unit/file_create_transaction_test.py
+++ b/tests/unit/file_create_transaction_test.py
@@ -26,6 +26,8 @@ from hiero_sdk_python.hapi.services.transaction_response_pb2 import (
 from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.timestamp import Timestamp
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 from tests.unit.mock_server import mock_hedera_servers
 
 
@@ -262,18 +264,19 @@ def test_file_create_transaction_from_proto():
     assert from_proto.keys == []
 
 
-def test_from_protobuf(mock_account_ids):
-    """Test round-trip via _from_protobuf for FileCreateTransaction."""
+def test_from_bytes(mock_account_ids):
+    """Test round-trip via Transaction.from_bytes() for FileCreateTransaction."""
     operator_id, _, node_account_id, _, _ = mock_account_ids
 
     tx = FileCreateTransaction()
     tx.set_contents(b"file contents")
     tx.set_file_memo("my file")
-    tx.operator_account_id = operator_id
+    tx.transaction_id = TransactionId.generate(operator_id)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = FileCreateTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, FileCreateTransaction)
     assert reconstructed.contents == b"file contents"
     assert reconstructed.file_memo == "my file"

--- a/tests/unit/file_create_transaction_test.py
+++ b/tests/unit/file_create_transaction_test.py
@@ -260,3 +260,20 @@ def test_file_create_transaction_from_proto():
     assert from_proto.contents == b""
     assert from_proto.file_memo == ""
     assert from_proto.keys == []
+
+
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for FileCreateTransaction."""
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    tx = FileCreateTransaction()
+    tx.set_contents(b"file contents")
+    tx.set_file_memo("my file")
+    tx.operator_account_id = operator_id
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = FileCreateTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.contents == b"file contents"
+    assert reconstructed.file_memo == "my file"

--- a/tests/unit/file_delete_transaction_test.py
+++ b/tests/unit/file_delete_transaction_test.py
@@ -131,3 +131,17 @@ def test_get_method():
 
     assert method.query is None
     assert method.transaction == mock_file_stub.deleteFile
+
+
+def test_from_protobuf(mock_account_ids, file_id):
+    """Test round-trip via _from_protobuf for FileDeleteTransaction."""
+    account_id, _, node_account_id, _, _ = mock_account_ids
+
+    tx = FileDeleteTransaction(file_id=file_id)
+    tx.node_account_id = node_account_id
+    tx.operator_account_id = account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = FileDeleteTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.file_id == file_id

--- a/tests/unit/file_delete_transaction_test.py
+++ b/tests/unit/file_delete_transaction_test.py
@@ -12,6 +12,8 @@ from hiero_sdk_python.file.file_delete_transaction import FileDeleteTransaction
 from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
     SchedulableTransactionBody,
 )
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 
 pytestmark = pytest.mark.unit
@@ -133,15 +135,16 @@ def test_get_method():
     assert method.transaction == mock_file_stub.deleteFile
 
 
-def test_from_protobuf(mock_account_ids, file_id):
-    """Test round-trip via _from_protobuf for FileDeleteTransaction."""
+def test_from_bytes(mock_account_ids, file_id):
+    """Test round-trip via Transaction.from_bytes() for FileDeleteTransaction."""
     account_id, _, node_account_id, _, _ = mock_account_ids
 
     tx = FileDeleteTransaction(file_id=file_id)
+    tx.transaction_id = TransactionId.generate(account_id)
     tx.node_account_id = node_account_id
-    tx.operator_account_id = account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = FileDeleteTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, FileDeleteTransaction)
     assert reconstructed.file_id == file_id

--- a/tests/unit/file_update_transaction_test.py
+++ b/tests/unit/file_update_transaction_test.py
@@ -358,3 +358,21 @@ def test_encode_contents_string():
     # Test None handling
     encoded = file_tx._encode_contents(None)
     assert encoded is None
+
+
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for FileUpdateTransaction."""
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+    test_file_id = FileId(0, 0, 5)
+
+    tx = FileUpdateTransaction()
+    tx.set_file_id(test_file_id)
+    tx.set_contents(b"updated")
+    tx.operator_account_id = operator_id
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = FileUpdateTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.file_id == test_file_id
+    assert reconstructed.contents == b"updated"

--- a/tests/unit/file_update_transaction_test.py
+++ b/tests/unit/file_update_transaction_test.py
@@ -366,10 +366,15 @@ def test_from_bytes(mock_account_ids):
     """Test round-trip via _from_protobuf for FileUpdateTransaction."""
     operator_id, _, node_account_id, _, _ = mock_account_ids
     test_file_id = FileId(0, 0, 5)
+    key = PrivateKey.generate().public_key()
+    expiration = Timestamp(seconds=9999999999, nanos=0)
 
     tx = FileUpdateTransaction()
     tx.set_file_id(test_file_id)
     tx.set_contents(b"updated")
+    tx.set_file_memo("updated memo")
+    tx.set_expiration_time(expiration)
+    tx.set_keys([key])
     tx.transaction_id = TransactionId.generate(operator_id)
     tx.node_account_id = node_account_id
     tx.freeze()
@@ -379,3 +384,7 @@ def test_from_bytes(mock_account_ids):
     assert isinstance(reconstructed, FileUpdateTransaction)
     assert reconstructed.file_id == test_file_id
     assert reconstructed.contents == b"updated"
+    assert reconstructed.file_memo == "updated memo"
+    assert reconstructed.expiration_time.seconds == expiration.seconds
+    assert len(reconstructed.keys) == 1
+    assert reconstructed.keys[0].to_bytes_raw() == key.to_bytes_raw()

--- a/tests/unit/file_update_transaction_test.py
+++ b/tests/unit/file_update_transaction_test.py
@@ -32,6 +32,8 @@ from hiero_sdk_python.hapi.services.transaction_response_pb2 import (
 from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.timestamp import Timestamp
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 from tests.unit.mock_server import mock_hedera_servers
 
 
@@ -360,7 +362,7 @@ def test_encode_contents_string():
     assert encoded is None
 
 
-def test_from_protobuf(mock_account_ids):
+def test_from_bytes(mock_account_ids):
     """Test round-trip via _from_protobuf for FileUpdateTransaction."""
     operator_id, _, node_account_id, _, _ = mock_account_ids
     test_file_id = FileId(0, 0, 5)
@@ -368,11 +370,12 @@ def test_from_protobuf(mock_account_ids):
     tx = FileUpdateTransaction()
     tx.set_file_id(test_file_id)
     tx.set_contents(b"updated")
-    tx.operator_account_id = operator_id
+    tx.transaction_id = TransactionId.generate(operator_id)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = FileUpdateTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, FileUpdateTransaction)
     assert reconstructed.file_id == test_file_id
     assert reconstructed.contents == b"updated"

--- a/tests/unit/freeze_transaction_test.py
+++ b/tests/unit/freeze_transaction_test.py
@@ -289,3 +289,18 @@ def test_build_proto_body_with_none_fields():
     assert not proto_body.HasField("update_file")
     assert proto_body.file_hash == b""
     assert proto_body.freeze_type == proto_FreezeType.UNKNOWN_FREEZE_TYPE
+
+
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for FreezeTransaction."""
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    tx = FreezeTransaction()
+    tx.set_freeze_type(FreezeType.FREEZE_ONLY)
+    tx.operator_account_id = operator_id
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = FreezeTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.freeze_type == FreezeType.FREEZE_ONLY

--- a/tests/unit/freeze_transaction_test.py
+++ b/tests/unit/freeze_transaction_test.py
@@ -18,6 +18,8 @@ from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
 from hiero_sdk_python.system.freeze_transaction import FreezeTransaction
 from hiero_sdk_python.system.freeze_type import FreezeType
 from hiero_sdk_python.timestamp import Timestamp
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 
 pytestmark = pytest.mark.unit
@@ -291,16 +293,24 @@ def test_build_proto_body_with_none_fields():
     assert proto_body.freeze_type == proto_FreezeType.UNKNOWN_FREEZE_TYPE
 
 
-def test_from_protobuf(mock_account_ids):
+def test_from_bytes(mock_account_ids, freeze_params):
     """Test round-trip via _from_protobuf for FreezeTransaction."""
     operator_id, _, node_account_id, _, _ = mock_account_ids
 
-    tx = FreezeTransaction()
-    tx.set_freeze_type(FreezeType.FREEZE_ONLY)
-    tx.operator_account_id = operator_id
+    tx = FreezeTransaction(
+        start_time=freeze_params["start_time"],
+        file_id=freeze_params["file_id"],
+        file_hash=freeze_params["file_hash"],
+        freeze_type=freeze_params["freeze_type"],
+    )
+    tx.transaction_id = TransactionId.generate(operator_id)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = FreezeTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
-    assert reconstructed.freeze_type == FreezeType.FREEZE_ONLY
+    assert isinstance(reconstructed, FreezeTransaction)
+    assert reconstructed.freeze_type == freeze_params["freeze_type"]
+    assert reconstructed.start_time == freeze_params["start_time"]
+    assert reconstructed.file_id == freeze_params["file_id"]
+    assert reconstructed.file_hash == freeze_params["file_hash"]

--- a/tests/unit/node_create_transaction_test.py
+++ b/tests/unit/node_create_transaction_test.py
@@ -330,3 +330,35 @@ def test_to_proto(mock_client):
 
     assert proto.signedTransactionBytes
     assert len(proto.signedTransactionBytes) > 0
+
+
+def test_from_bytes(mock_account_ids):
+    """Test round-trip via _from_protobuf for NodeCreateTransaction."""
+    from hiero_sdk_python.transaction.transaction import Transaction
+    from hiero_sdk_python.transaction.transaction_id import TransactionId
+
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    tx = NodeCreateTransaction()
+    tx.set_account_id(AccountId(0, 0, 123))
+    tx.set_description("test node")
+    tx.set_gossip_endpoints([Endpoint(domain_name="gossip.example.com", port=50211)])
+    tx.set_service_endpoints([Endpoint(domain_name="service.example.com", port=50212)])
+    tx.set_gossip_ca_certificate(b"test-ca-cert")
+    tx.set_grpc_certificate_hash(b"test-cert-hash")
+    tx.transaction_id = TransactionId.generate(operator_id)
+    tx.node_account_id = node_account_id
+    tx.freeze()
+
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
+
+    assert isinstance(reconstructed, NodeCreateTransaction)
+    assert reconstructed.account_id == AccountId(0, 0, 123)
+    assert reconstructed.description == "test node"
+    assert len(reconstructed.gossip_endpoints) == 1
+    assert reconstructed.gossip_endpoints[0].get_domain_name() == "gossip.example.com"
+    assert reconstructed.gossip_endpoints[0].get_port() == 50211
+    assert len(reconstructed.service_endpoints) == 1
+    assert reconstructed.service_endpoints[0].get_domain_name() == "service.example.com"
+    assert reconstructed.gossip_ca_certificate == b"test-ca-cert"
+    assert reconstructed.grpc_certificate_hash == b"test-cert-hash"

--- a/tests/unit/node_delete_transaction_test.py
+++ b/tests/unit/node_delete_transaction_test.py
@@ -190,3 +190,21 @@ def test_build_proto_body_missing_node_id():
 
     with pytest.raises(ValueError, match="Missing required NodeID"):
         node_tx._build_proto_body()
+
+
+def test_from_bytes(mock_account_ids):
+    from hiero_sdk_python.transaction.transaction import Transaction
+    from hiero_sdk_python.transaction.transaction_id import TransactionId
+
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    tx = NodeDeleteTransaction()
+    tx.set_node_id(42)
+    tx.transaction_id = TransactionId.generate(operator_id)
+    tx.node_account_id = node_account_id
+    tx.freeze()
+
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
+
+    assert isinstance(reconstructed, NodeDeleteTransaction)
+    assert reconstructed.node_id == 42

--- a/tests/unit/node_update_transaction_test.py
+++ b/tests/unit/node_update_transaction_test.py
@@ -351,3 +351,37 @@ def test_to_proto(mock_client):
 
     assert proto.signedTransactionBytes
     assert len(proto.signedTransactionBytes) > 0
+
+
+def test_from_bytes(mock_account_ids):
+    """Test round-trip via _from_protobuf for NodeUpdateTransaction."""
+    from hiero_sdk_python.transaction.transaction import Transaction
+    from hiero_sdk_python.transaction.transaction_id import TransactionId
+
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    tx = NodeUpdateTransaction()
+    tx.set_node_id(5)
+    tx.set_account_id(AccountId(0, 0, 123))
+    tx.set_description("updated node")
+    tx.set_gossip_endpoints([Endpoint(domain_name="gossip.example.com", port=50211)])
+    tx.set_service_endpoints([Endpoint(domain_name="service.example.com", port=50212)])
+    tx.set_gossip_ca_certificate(b"test-ca-cert")
+    tx.set_grpc_certificate_hash(b"test-cert-hash")
+    tx.transaction_id = TransactionId.generate(operator_id)
+    tx.node_account_id = node_account_id
+    tx.freeze()
+
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
+
+    assert isinstance(reconstructed, NodeUpdateTransaction)
+    assert reconstructed.node_id == 5
+    assert reconstructed.account_id == AccountId(0, 0, 123)
+    assert reconstructed.description == "updated node"
+    assert len(reconstructed.gossip_endpoints) == 1
+    assert reconstructed.gossip_endpoints[0].get_domain_name() == "gossip.example.com"
+    assert reconstructed.gossip_endpoints[0].get_port() == 50211
+    assert len(reconstructed.service_endpoints) == 1
+    assert reconstructed.service_endpoints[0].get_domain_name() == "service.example.com"
+    assert reconstructed.gossip_ca_certificate == b"test-ca-cert"
+    assert reconstructed.grpc_certificate_hash == b"test-cert-hash"

--- a/tests/unit/prng_transaction_test.py
+++ b/tests/unit/prng_transaction_test.py
@@ -162,3 +162,21 @@ def test_prng_transaction_can_execute():
         receipt = transaction.execute(client)
 
         assert receipt.status == ResponseCode.SUCCESS, "Transaction should have succeeded"
+
+
+def test_from_bytes(mock_account_ids):
+    from hiero_sdk_python.transaction.transaction import Transaction
+    from hiero_sdk_python.transaction.transaction_id import TransactionId
+
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
+    tx = PrngTransaction()
+    tx.set_range(500)
+    tx.transaction_id = TransactionId.generate(operator_id)
+    tx.node_account_id = node_account_id
+    tx.freeze()
+
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
+
+    assert isinstance(reconstructed, PrngTransaction)
+    assert reconstructed.range == 500

--- a/tests/unit/schedule_create_transaction_test.py
+++ b/tests/unit/schedule_create_transaction_test.py
@@ -15,6 +15,7 @@ from hiero_sdk_python.schedule.schedule_create_transaction import (
     ScheduleCreateTransaction,
 )
 from hiero_sdk_python.timestamp import Timestamp
+from hiero_sdk_python.tokens.token_grant_kyc_transaction import TokenGrantKycTransaction
 from hiero_sdk_python.transaction.transfer_transaction import TransferTransaction
 
 
@@ -265,3 +266,26 @@ def test_to_proto(mock_client):
 
     assert proto.signedTransactionBytes
     assert len(proto.signedTransactionBytes) > 0
+
+
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for ScheduleCreateTransaction."""
+    account_id_sender, _, node_account_id, token_id_1, _ = mock_account_ids
+
+    inner_tx = TokenGrantKycTransaction()
+    inner_tx.set_token_id(token_id_1)
+    inner_tx.set_account_id(account_id_sender)
+    schedulable_body = inner_tx.build_scheduled_body()
+
+    tx = ScheduleCreateTransaction()
+    tx.set_schedule_memo("test memo")
+    tx.set_payer_account_id(account_id_sender)
+    tx._set_schedulable_body(schedulable_body)
+    tx.operator_account_id = account_id_sender
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = ScheduleCreateTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.schedule_memo == "test memo"
+    assert reconstructed.payer_account_id == account_id_sender

--- a/tests/unit/schedule_create_transaction_test.py
+++ b/tests/unit/schedule_create_transaction_test.py
@@ -16,6 +16,8 @@ from hiero_sdk_python.schedule.schedule_create_transaction import (
 )
 from hiero_sdk_python.timestamp import Timestamp
 from hiero_sdk_python.tokens.token_grant_kyc_transaction import TokenGrantKycTransaction
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 from hiero_sdk_python.transaction.transfer_transaction import TransferTransaction
 
 
@@ -268,7 +270,7 @@ def test_to_proto(mock_client):
     assert len(proto.signedTransactionBytes) > 0
 
 
-def test_from_protobuf(mock_account_ids):
+def test_from_bytes(mock_account_ids):
     """Test round-trip via _from_protobuf for ScheduleCreateTransaction."""
     account_id_sender, _, node_account_id, token_id_1, _ = mock_account_ids
 
@@ -281,11 +283,14 @@ def test_from_protobuf(mock_account_ids):
     tx.set_schedule_memo("test memo")
     tx.set_payer_account_id(account_id_sender)
     tx._set_schedulable_body(schedulable_body)
-    tx.operator_account_id = account_id_sender
+    tx.transaction_id = TransactionId.generate(account_id_sender)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = ScheduleCreateTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, ScheduleCreateTransaction)
     assert reconstructed.schedule_memo == "test memo"
     assert reconstructed.payer_account_id == account_id_sender
+    assert reconstructed.schedulable_body == schedulable_body
+    assert reconstructed.schedulable_body.HasField("tokenGrantKyc")

--- a/tests/unit/schedule_delete_transaction_test.py
+++ b/tests/unit/schedule_delete_transaction_test.py
@@ -24,6 +24,8 @@ from hiero_sdk_python.schedule.schedule_delete_transaction import (
     ScheduleDeleteTransaction,
 )
 from hiero_sdk_python.schedule.schedule_id import ScheduleId
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 from tests.unit.mock_server import mock_hedera_servers
 
 
@@ -251,16 +253,17 @@ def test_schedule_delete_transaction_can_execute():
         assert receipt.status == ResponseCode.SUCCESS, "Transaction should have succeeded"
 
 
-def test_from_protobuf(mock_account_ids):
-    """Test round-trip via _from_protobuf for ScheduleDeleteTransaction."""
+def test_from_bytes(mock_account_ids):
+    """Test round-trip via Transaction.from_bytes() for ScheduleDeleteTransaction."""
     operator_id, _, node_account_id, _, _ = mock_account_ids
     schedule_id = ScheduleId(0, 0, 99)
 
     tx = ScheduleDeleteTransaction(schedule_id=schedule_id)
-    tx.operator_account_id = operator_id
+    tx.transaction_id = TransactionId.generate(operator_id)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = ScheduleDeleteTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, ScheduleDeleteTransaction)
     assert reconstructed.schedule_id == schedule_id

--- a/tests/unit/schedule_delete_transaction_test.py
+++ b/tests/unit/schedule_delete_transaction_test.py
@@ -249,3 +249,18 @@ def test_schedule_delete_transaction_can_execute():
         receipt = transaction.execute(client)
 
         assert receipt.status == ResponseCode.SUCCESS, "Transaction should have succeeded"
+
+
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for ScheduleDeleteTransaction."""
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+    schedule_id = ScheduleId(0, 0, 99)
+
+    tx = ScheduleDeleteTransaction(schedule_id=schedule_id)
+    tx.operator_account_id = operator_id
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = ScheduleDeleteTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.schedule_id == schedule_id

--- a/tests/unit/schedule_sign_transaction_test.py
+++ b/tests/unit/schedule_sign_transaction_test.py
@@ -192,3 +192,18 @@ def test_schedule_id_property_access():
     # Test getting via property
     retrieved_schedule_id = schedule_sign_tx.schedule_id
     assert retrieved_schedule_id == schedule_id
+
+
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for ScheduleSignTransaction."""
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+    schedule_id = ScheduleId(0, 0, 42)
+
+    tx = ScheduleSignTransaction(schedule_id=schedule_id)
+    tx.operator_account_id = operator_id
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = ScheduleSignTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.schedule_id == schedule_id

--- a/tests/unit/schedule_sign_transaction_test.py
+++ b/tests/unit/schedule_sign_transaction_test.py
@@ -10,6 +10,8 @@ import pytest
 
 from hiero_sdk_python.schedule.schedule_id import ScheduleId
 from hiero_sdk_python.schedule.schedule_sign_transaction import ScheduleSignTransaction
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 
 pytestmark = pytest.mark.unit
@@ -194,16 +196,17 @@ def test_schedule_id_property_access():
     assert retrieved_schedule_id == schedule_id
 
 
-def test_from_protobuf(mock_account_ids):
-    """Test round-trip via _from_protobuf for ScheduleSignTransaction."""
+def test_from_bytes(mock_account_ids):
+    """Test round-trip via Transaction.from_bytes() for ScheduleSignTransaction."""
     operator_id, _, node_account_id, _, _ = mock_account_ids
     schedule_id = ScheduleId(0, 0, 42)
 
     tx = ScheduleSignTransaction(schedule_id=schedule_id)
-    tx.operator_account_id = operator_id
+    tx.transaction_id = TransactionId.generate(operator_id)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = ScheduleSignTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, ScheduleSignTransaction)
     assert reconstructed.schedule_id == schedule_id

--- a/tests/unit/token_airdrop_claim_test.py
+++ b/tests/unit/token_airdrop_claim_test.py
@@ -313,3 +313,26 @@ def test_str_and_repr():
     tx.add_pending_airdrop_id(PendingAirdropId(sender, receiver, TokenId(0, 0, 10), None))
     assert "Pending Airdrops to claim:" in str(tx)
     assert repr(tx).startswith("TokenClaimAirdropTransaction(")
+
+
+def test_from_bytes(mock_account_ids):
+    from hiero_sdk_python.transaction.transaction import Transaction
+    from hiero_sdk_python.transaction.transaction_id import TransactionId
+
+    sender, receiver, node_account_id, token_id_1, _ = mock_account_ids
+
+    pending = PendingAirdropId(sender, receiver, token_id_1, None)
+    tx = TokenClaimAirdropTransaction(pending_airdrop_ids=[pending])
+    tx.transaction_id = TransactionId.generate(sender)
+    tx.node_account_id = node_account_id
+    tx.freeze()
+
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
+
+    assert isinstance(reconstructed, TokenClaimAirdropTransaction)
+    assert len(reconstructed._pending_airdrop_ids) == 1
+    airdrop = reconstructed._pending_airdrop_ids[0]
+    assert airdrop.sender_id == sender
+    assert airdrop.receiver_id == receiver
+    assert airdrop.token_id == token_id_1
+    assert airdrop.nft_id is None

--- a/tests/unit/token_airdrop_transaction_cancel_test.py
+++ b/tests/unit/token_airdrop_transaction_cancel_test.py
@@ -278,3 +278,25 @@ def test_build_scheduled_body(mock_account_ids):
     assert proto_pending_airdrop.non_fungible_token.token_ID == token_id_2._to_proto()
     assert proto_pending_airdrop.non_fungible_token.serial_number == 10
     assert proto_pending_airdrop.HasField("fungible_token_type") == False
+
+
+def test_from_bytes(mock_account_ids):
+    from hiero_sdk_python.transaction.transaction import Transaction
+    from hiero_sdk_python.transaction.transaction_id import TransactionId
+
+    sender, receiver, node_account_id, token_id_1, _ = mock_account_ids
+
+    pending = PendingAirdropId(sender, receiver, token_id_1, None)
+    tx = TokenCancelAirdropTransaction(pending_airdrops=[pending])
+    tx.transaction_id = TransactionId.generate(sender)
+    tx.node_account_id = node_account_id
+    tx.freeze()
+
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
+
+    assert isinstance(reconstructed, TokenCancelAirdropTransaction)
+    assert len(reconstructed.pending_airdrops) == 1
+    airdrop = reconstructed.pending_airdrops[0]
+    assert airdrop.sender_id == sender
+    assert airdrop.receiver_id == receiver
+    assert airdrop.token_id == token_id_1

--- a/tests/unit/token_airdrop_transaction_test.py
+++ b/tests/unit/token_airdrop_transaction_test.py
@@ -11,6 +11,8 @@ from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
 from hiero_sdk_python.hapi.services.token_airdrop_pb2 import TokenAirdropTransactionBody
 from hiero_sdk_python.tokens.nft_id import NftId
 from hiero_sdk_python.tokens.token_airdrop_transaction import TokenAirdropTransaction
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 
 pytestmark = pytest.mark.unit
@@ -404,17 +406,22 @@ def test_from_proto_without_token_transfer(mock_account_ids):
     assert not airdrop_tx.token_transfers
 
 
-def test_from_protobuf(mock_account_ids):
+def test_from_bytes(mock_account_ids):
     """Test round-trip via _from_protobuf for TokenAirdropTransaction."""
     sender, receiver, node_account_id, token_id_1, _ = mock_account_ids
 
     tx = TokenAirdropTransaction()
     tx.add_token_transfer(token_id=token_id_1, account_id=sender, amount=-1)
     tx.add_token_transfer(token_id=token_id_1, account_id=receiver, amount=1)
-    tx.operator_account_id = sender
+    tx.transaction_id = TransactionId.generate(sender)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = TokenAirdropTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, TokenAirdropTransaction)
     assert len(reconstructed.token_transfers[token_id_1]) == 2
+    assert reconstructed.token_transfers[token_id_1][0].account_id == sender
+    assert reconstructed.token_transfers[token_id_1][0].amount == -1
+    assert reconstructed.token_transfers[token_id_1][1].account_id == receiver
+    assert reconstructed.token_transfers[token_id_1][1].amount == 1

--- a/tests/unit/token_airdrop_transaction_test.py
+++ b/tests/unit/token_airdrop_transaction_test.py
@@ -402,3 +402,19 @@ def test_from_proto_without_token_transfer(mock_account_ids):
     assert nft_transfer[0].is_approved == True
 
     assert not airdrop_tx.token_transfers
+
+
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for TokenAirdropTransaction."""
+    sender, receiver, node_account_id, token_id_1, _ = mock_account_ids
+
+    tx = TokenAirdropTransaction()
+    tx.add_token_transfer(token_id=token_id_1, account_id=sender, amount=-1)
+    tx.add_token_transfer(token_id=token_id_1, account_id=receiver, amount=1)
+    tx.operator_account_id = sender
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = TokenAirdropTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert len(reconstructed.token_transfers[token_id_1]) == 2

--- a/tests/unit/token_airdrop_transaction_test.py
+++ b/tests/unit/token_airdrop_transaction_test.py
@@ -425,3 +425,25 @@ def test_from_bytes(mock_account_ids):
     assert reconstructed.token_transfers[token_id_1][0].amount == -1
     assert reconstructed.token_transfers[token_id_1][1].account_id == receiver
     assert reconstructed.token_transfers[token_id_1][1].amount == 1
+
+
+def test_from_bytes_nft(mock_account_ids):
+    """Test round-trip via _from_protobuf for TokenAirdropTransaction with NFT transfers."""
+    sender, receiver, node_account_id, token_id_1, _ = mock_account_ids
+    nft_id = NftId(token_id=token_id_1, serial_number=7)
+
+    tx = TokenAirdropTransaction()
+    tx.add_nft_transfer(nft_id=nft_id, sender_id=sender, receiver_id=receiver, is_approved=False)
+    tx.transaction_id = TransactionId.generate(sender)
+    tx.node_account_id = node_account_id
+    tx.freeze()
+
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
+
+    assert isinstance(reconstructed, TokenAirdropTransaction)
+    nft_transfers = reconstructed.nft_transfers[token_id_1]
+    assert len(nft_transfers) == 1
+    assert nft_transfers[0].sender_id == sender
+    assert nft_transfers[0].receiver_id == receiver
+    assert nft_transfers[0].serial_number == 7
+    assert not nft_transfers[0].is_approved

--- a/tests/unit/token_associate_transaction_test.py
+++ b/tests/unit/token_associate_transaction_test.py
@@ -218,3 +218,23 @@ def test_from_proto_builds_transaction(mock_account_ids):
     assert len(tx.token_ids) == 2
     assert tx.token_ids[0] == token_id_1
     assert tx.token_ids[1] == token_id_2
+
+
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for TokenAssociateTransaction."""
+    account_id_sender, _, node_account_id, token_id_1, token_id_2 = mock_account_ids
+
+    tx = TokenAssociateTransaction()
+    tx.set_account_id(account_id_sender)
+    tx.add_token_id(token_id_1)
+    tx.add_token_id(token_id_2)
+    tx.transaction_id = generate_transaction_id(account_id_sender)
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = TokenAssociateTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.account_id == account_id_sender
+    assert len(reconstructed.token_ids) == 2
+    assert reconstructed.token_ids[0] == token_id_1
+    assert reconstructed.token_ids[1] == token_id_2

--- a/tests/unit/token_associate_transaction_test.py
+++ b/tests/unit/token_associate_transaction_test.py
@@ -10,6 +10,7 @@ from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
 )
 from hiero_sdk_python.tokens.token_associate_transaction import TokenAssociateTransaction
 from hiero_sdk_python.tokens.token_id import TokenId
+from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 
@@ -220,7 +221,7 @@ def test_from_proto_builds_transaction(mock_account_ids):
     assert tx.token_ids[1] == token_id_2
 
 
-def test_from_protobuf(mock_account_ids):
+def test_from_bytes(mock_account_ids):
     """Test round-trip via _from_protobuf for TokenAssociateTransaction."""
     account_id_sender, _, node_account_id, token_id_1, token_id_2 = mock_account_ids
 
@@ -230,10 +231,11 @@ def test_from_protobuf(mock_account_ids):
     tx.add_token_id(token_id_2)
     tx.transaction_id = generate_transaction_id(account_id_sender)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = TokenAssociateTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, TokenAssociateTransaction)
     assert reconstructed.account_id == account_id_sender
     assert len(reconstructed.token_ids) == 2
     assert reconstructed.token_ids[0] == token_id_1

--- a/tests/unit/token_burn_transaction_test.py
+++ b/tests/unit/token_burn_transaction_test.py
@@ -12,6 +12,8 @@ from hiero_sdk_python.hapi.services.transaction_response_pb2 import TransactionR
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.token_burn_transaction import TokenBurnTransaction
 from hiero_sdk_python.tokens.token_id import TokenId
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 from tests.unit.mock_server import mock_hedera_servers
 
 
@@ -184,32 +186,36 @@ def test_build_scheduled_body_nft(mock_account_ids):
     assert schedulable_body.tokenBurn.serialNumbers == serials
 
 
-def test_from_protobuf_fungible(mock_account_ids):
+def test_from_bytes_fungible(mock_account_ids):
     """Test round-trip via _from_protobuf for fungible TokenBurnTransaction."""
     operator_id, _, node_account_id, token_id_1, _ = mock_account_ids
 
     tx = TokenBurnTransaction(token_id=token_id_1, amount=100)
-    tx.operator_account_id = operator_id
+    tx.transaction_id = TransactionId.generate(operator_id)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = TokenBurnTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, TokenBurnTransaction)
     assert reconstructed.token_id == token_id_1
     assert reconstructed.amount == 100
+    assert reconstructed.serials == []
 
 
-def test_from_protobuf_nft(mock_account_ids):
+def test_from_bytes_nft(mock_account_ids):
     """Test round-trip via _from_protobuf for NFT TokenBurnTransaction."""
     operator_id, _, node_account_id, token_id_1, _ = mock_account_ids
     serials = [1, 2, 3]
 
     tx = TokenBurnTransaction(token_id=token_id_1, serials=serials)
-    tx.operator_account_id = operator_id
+    tx.transaction_id = TransactionId.generate(operator_id)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = TokenBurnTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, TokenBurnTransaction)
     assert reconstructed.token_id == token_id_1
     assert list(reconstructed.serials) == serials
+    assert reconstructed.amount is None

--- a/tests/unit/token_burn_transaction_test.py
+++ b/tests/unit/token_burn_transaction_test.py
@@ -182,3 +182,34 @@ def test_build_scheduled_body_nft(mock_account_ids):
     assert schedulable_body.tokenBurn.token == token_id._to_proto()
     assert schedulable_body.tokenBurn.amount == 0
     assert schedulable_body.tokenBurn.serialNumbers == serials
+
+
+def test_from_protobuf_fungible(mock_account_ids):
+    """Test round-trip via _from_protobuf for fungible TokenBurnTransaction."""
+    operator_id, _, node_account_id, token_id_1, _ = mock_account_ids
+
+    tx = TokenBurnTransaction(token_id=token_id_1, amount=100)
+    tx.operator_account_id = operator_id
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = TokenBurnTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.token_id == token_id_1
+    assert reconstructed.amount == 100
+
+
+def test_from_protobuf_nft(mock_account_ids):
+    """Test round-trip via _from_protobuf for NFT TokenBurnTransaction."""
+    operator_id, _, node_account_id, token_id_1, _ = mock_account_ids
+    serials = [1, 2, 3]
+
+    tx = TokenBurnTransaction(token_id=token_id_1, serials=serials)
+    tx.operator_account_id = operator_id
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = TokenBurnTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.token_id == token_id_1
+    assert list(reconstructed.serials) == serials

--- a/tests/unit/token_create_transaction_test.py
+++ b/tests/unit/token_create_transaction_test.py
@@ -963,3 +963,38 @@ def test_to_proto_key_wrapper_still_works():
     with pytest.raises(TypeError) as e:
         tx._to_proto_key("this is not a key")
     assert "Key must be of type PrivateKey or PublicKey" in str(e.value)
+
+
+def test_from_bytes(mock_account_ids):
+    from hiero_sdk_python.crypto.private_key import PrivateKey
+    from hiero_sdk_python.transaction.transaction import Transaction
+
+    treasury_account, _, node_account_id, _, _ = mock_account_ids
+
+    admin_key = PrivateKey.generate_ed25519().public_key()
+    supply_key = PrivateKey.generate_ed25519().public_key()
+
+    tx = (
+        TokenCreateTransaction()
+        .set_token_name("TestToken")
+        .set_token_symbol("TT")
+        .set_decimals(2)
+        .set_initial_supply(1000)
+        .set_treasury_account_id(treasury_account)
+        .set_admin_key(admin_key)
+        .set_supply_key(supply_key)
+    )
+    tx.transaction_id = TransactionId.generate(treasury_account)
+    tx.node_account_id = node_account_id
+    tx.freeze()
+
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
+
+    assert isinstance(reconstructed, TokenCreateTransaction)
+    assert reconstructed._token_params.token_name == "TestToken"
+    assert reconstructed._token_params.token_symbol == "TT"
+    assert reconstructed._token_params.decimals == 2
+    assert reconstructed._token_params.initial_supply == 1000
+    assert reconstructed._token_params.treasury_account_id == treasury_account
+    assert reconstructed._keys.admin_key is not None
+    assert reconstructed._keys.supply_key is not None

--- a/tests/unit/token_delete_transaction_test.py
+++ b/tests/unit/token_delete_transaction_test.py
@@ -9,6 +9,7 @@ from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
     SchedulableTransactionBody,
 )
 from hiero_sdk_python.tokens.token_delete_transaction import TokenDeleteTransaction
+from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 
@@ -115,7 +116,7 @@ def test_build_scheduled_body(mock_account_ids):
     assert schedulable_body.tokenDeletion.token == token_id._to_proto()
 
 
-def test_from_protobuf(mock_account_ids):
+def test_from_bytes(mock_account_ids):
     """Test round-trip via _from_protobuf for TokenDeleteTransaction."""
     account_id, _, node_account_id, token_id_1, _ = mock_account_ids
 
@@ -123,8 +124,9 @@ def test_from_protobuf(mock_account_ids):
     tx.set_token_id(token_id_1)
     tx.transaction_id = generate_transaction_id(account_id)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = TokenDeleteTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, TokenDeleteTransaction)
     assert reconstructed.token_id == token_id_1

--- a/tests/unit/token_delete_transaction_test.py
+++ b/tests/unit/token_delete_transaction_test.py
@@ -113,3 +113,18 @@ def test_build_scheduled_body(mock_account_ids):
     assert isinstance(schedulable_body, SchedulableTransactionBody)
     assert schedulable_body.HasField("tokenDeletion")
     assert schedulable_body.tokenDeletion.token == token_id._to_proto()
+
+
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for TokenDeleteTransaction."""
+    account_id, _, node_account_id, token_id_1, _ = mock_account_ids
+
+    tx = TokenDeleteTransaction()
+    tx.set_token_id(token_id_1)
+    tx.transaction_id = generate_transaction_id(account_id)
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = TokenDeleteTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.token_id == token_id_1

--- a/tests/unit/token_dissociate_transaction_test.py
+++ b/tests/unit/token_dissociate_transaction_test.py
@@ -9,6 +9,7 @@ from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
     SchedulableTransactionBody,
 )
 from hiero_sdk_python.tokens.token_dissociate_transaction import TokenDissociateTransaction
+from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 
@@ -172,8 +173,8 @@ def test_from_proto(mock_account_ids):
     assert reconstructed_tx.token_ids[1] == token_id_2
 
 
-def test_from_protobuf(mock_account_ids):
-    """Test round-trip via _from_protobuf for TokenDissociateTransaction."""
+def test_from_bytes(mock_account_ids):
+    """Test round-trip via Transaction.from_bytes() for TokenDissociateTransaction."""
     account_id_sender, _, node_account_id, token_id_1, token_id_2 = mock_account_ids
 
     tx = TokenDissociateTransaction()
@@ -182,10 +183,11 @@ def test_from_protobuf(mock_account_ids):
     tx.add_token_id(token_id_2)
     tx.transaction_id = generate_transaction_id(account_id_sender)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = TokenDissociateTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, TokenDissociateTransaction)
     assert reconstructed.account_id == account_id_sender
     assert len(reconstructed.token_ids) == 2
     assert reconstructed.token_ids[0] == token_id_1

--- a/tests/unit/token_dissociate_transaction_test.py
+++ b/tests/unit/token_dissociate_transaction_test.py
@@ -172,6 +172,26 @@ def test_from_proto(mock_account_ids):
     assert reconstructed_tx.token_ids[1] == token_id_2
 
 
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for TokenDissociateTransaction."""
+    account_id_sender, _, node_account_id, token_id_1, token_id_2 = mock_account_ids
+
+    tx = TokenDissociateTransaction()
+    tx.set_account_id(account_id_sender)
+    tx.add_token_id(token_id_1)
+    tx.add_token_id(token_id_2)
+    tx.transaction_id = generate_transaction_id(account_id_sender)
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = TokenDissociateTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.account_id == account_id_sender
+    assert len(reconstructed.token_ids) == 2
+    assert reconstructed.token_ids[0] == token_id_1
+    assert reconstructed.token_ids[1] == token_id_2
+
+
 def test_build_scheduled_body(mock_account_ids):
     """Test building a scheduled transaction body for token dissociate transaction."""
     account_id, _, _, token_id_1, token_id_2 = mock_account_ids

--- a/tests/unit/token_fee_schedule_update_transaction_test.py
+++ b/tests/unit/token_fee_schedule_update_transaction_test.py
@@ -123,4 +123,8 @@ def test_from_protobuf(mock_account_ids):
 
     assert reconstructed.token_id == token_id_1
     assert len(reconstructed.custom_fees) == 1
-    assert reconstructed.custom_fees[0].amount == 100
+    restored_fee = reconstructed.custom_fees[0]
+    assert isinstance(restored_fee, CustomFixedFee)
+    assert restored_fee.amount == 100
+    assert restored_fee.denominating_token_id == token_id_2
+    assert restored_fee.fee_collector_account_id == account_id_sender

--- a/tests/unit/token_fee_schedule_update_transaction_test.py
+++ b/tests/unit/token_fee_schedule_update_transaction_test.py
@@ -102,3 +102,25 @@ def test_build_transaction_body_with_empty_custom_fees(mock_account_ids):
     assert transaction_body.HasField("token_fee_schedule_update")
     assert transaction_body.token_fee_schedule_update.token_id == token_id._to_proto()
     assert len(transaction_body.token_fee_schedule_update.custom_fees) == 0
+
+
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for TokenFeeScheduleUpdateTransaction."""
+    account_id_sender, _, node_account_id, token_id_1, token_id_2 = mock_account_ids
+
+    fee = CustomFixedFee(
+        amount=100,
+        denominating_token_id=token_id_2,
+        fee_collector_account_id=account_id_sender,
+    )
+
+    tx = TokenFeeScheduleUpdateTransaction(token_id=token_id_1, custom_fees=[fee])
+    tx.operator_account_id = account_id_sender
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = TokenFeeScheduleUpdateTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.token_id == token_id_1
+    assert len(reconstructed.custom_fees) == 1
+    assert reconstructed.custom_fees[0].amount == 100

--- a/tests/unit/token_fee_schedule_update_transaction_test.py
+++ b/tests/unit/token_fee_schedule_update_transaction_test.py
@@ -7,6 +7,8 @@ from hiero_sdk_python.tokens.custom_fixed_fee import CustomFixedFee
 from hiero_sdk_python.tokens.token_fee_schedule_update_transaction import (
     TokenFeeScheduleUpdateTransaction,
 )
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 
 pytestmark = pytest.mark.unit
@@ -104,8 +106,8 @@ def test_build_transaction_body_with_empty_custom_fees(mock_account_ids):
     assert len(transaction_body.token_fee_schedule_update.custom_fees) == 0
 
 
-def test_from_protobuf(mock_account_ids):
-    """Test round-trip via _from_protobuf for TokenFeeScheduleUpdateTransaction."""
+def test_from_bytes(mock_account_ids):
+    """Test round-trip via Transaction.from_bytes() for TokenFeeScheduleUpdateTransaction."""
     account_id_sender, _, node_account_id, token_id_1, token_id_2 = mock_account_ids
 
     fee = CustomFixedFee(
@@ -115,12 +117,13 @@ def test_from_protobuf(mock_account_ids):
     )
 
     tx = TokenFeeScheduleUpdateTransaction(token_id=token_id_1, custom_fees=[fee])
-    tx.operator_account_id = account_id_sender
+    tx.transaction_id = TransactionId.generate(account_id_sender)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = TokenFeeScheduleUpdateTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, TokenFeeScheduleUpdateTransaction)
     assert reconstructed.token_id == token_id_1
     assert len(reconstructed.custom_fees) == 1
     restored_fee = reconstructed.custom_fees[0]

--- a/tests/unit/token_freeze_transaction_test.py
+++ b/tests/unit/token_freeze_transaction_test.py
@@ -136,3 +136,20 @@ def test_build_scheduled_body(mock_account_ids):
     assert schedulable_body.HasField("tokenFreeze")
     assert schedulable_body.tokenFreeze.token == token_id._to_proto()
     assert schedulable_body.tokenFreeze.account == freeze_id._to_proto()
+
+
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for TokenFreezeTransaction."""
+    account_id_sender, _, node_account_id, token_id_1, _ = mock_account_ids
+
+    tx = TokenFreezeTransaction()
+    tx.set_token_id(token_id_1)
+    tx.set_account_id(account_id_sender)
+    tx.transaction_id = generate_transaction_id(account_id_sender)
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = TokenFreezeTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.token_id == token_id_1
+    assert reconstructed.account_id == account_id_sender

--- a/tests/unit/token_freeze_transaction_test.py
+++ b/tests/unit/token_freeze_transaction_test.py
@@ -151,5 +151,6 @@ def test_from_protobuf(mock_account_ids):
     body = tx.build_transaction_body()
     reconstructed = TokenFreezeTransaction._from_protobuf(body, body.SerializeToString(), None)
 
+    assert isinstance(reconstructed, TokenFreezeTransaction)
     assert reconstructed.token_id == token_id_1
     assert reconstructed.account_id == account_id_sender

--- a/tests/unit/token_freeze_transaction_test.py
+++ b/tests/unit/token_freeze_transaction_test.py
@@ -9,6 +9,7 @@ from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
     SchedulableTransactionBody,
 )
 from hiero_sdk_python.tokens.token_freeze_transaction import TokenFreezeTransaction
+from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 
@@ -138,8 +139,8 @@ def test_build_scheduled_body(mock_account_ids):
     assert schedulable_body.tokenFreeze.account == freeze_id._to_proto()
 
 
-def test_from_protobuf(mock_account_ids):
-    """Test round-trip via _from_protobuf for TokenFreezeTransaction."""
+def test_from_bytes(mock_account_ids):
+    """Test round-trip via Transaction.from_bytes() for TokenFreezeTransaction."""
     account_id_sender, _, node_account_id, token_id_1, _ = mock_account_ids
 
     tx = TokenFreezeTransaction()
@@ -147,9 +148,9 @@ def test_from_protobuf(mock_account_ids):
     tx.set_account_id(account_id_sender)
     tx.transaction_id = generate_transaction_id(account_id_sender)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = TokenFreezeTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
     assert isinstance(reconstructed, TokenFreezeTransaction)
     assert reconstructed.token_id == token_id_1

--- a/tests/unit/token_grant_kyc_transaction_test.py
+++ b/tests/unit/token_grant_kyc_transaction_test.py
@@ -145,6 +145,23 @@ def test_grant_kyc_transaction_from_proto(mock_account_ids):
     assert from_proto.account_id == AccountId()
 
 
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for TokenGrantKycTransaction."""
+    account_id, _, node_account_id, token_id, _ = mock_account_ids
+
+    tx = TokenGrantKycTransaction()
+    tx.set_token_id(token_id)
+    tx.set_account_id(account_id)
+    tx.operator_account_id = account_id
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = TokenGrantKycTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.token_id == token_id
+    assert reconstructed.account_id == account_id
+
+
 def test_build_scheduled_body(mock_account_ids):
     """Test building a scheduled transaction body for token grant KYC transaction."""
     account_id, _, _, token_id, _ = mock_account_ids

--- a/tests/unit/token_grant_kyc_transaction_test.py
+++ b/tests/unit/token_grant_kyc_transaction_test.py
@@ -13,6 +13,8 @@ from hiero_sdk_python.hapi.services.transaction_response_pb2 import TransactionR
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.token_grant_kyc_transaction import TokenGrantKycTransaction
 from hiero_sdk_python.tokens.token_id import TokenId
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 from tests.unit.mock_server import mock_hedera_servers
 
 
@@ -145,19 +147,20 @@ def test_grant_kyc_transaction_from_proto(mock_account_ids):
     assert from_proto.account_id == AccountId()
 
 
-def test_from_protobuf(mock_account_ids):
-    """Test round-trip via _from_protobuf for TokenGrantKycTransaction."""
+def test_from_bytes(mock_account_ids):
+    """Test round-trip via Transaction.from_bytes() for TokenGrantKycTransaction."""
     account_id, _, node_account_id, token_id, _ = mock_account_ids
 
     tx = TokenGrantKycTransaction()
     tx.set_token_id(token_id)
     tx.set_account_id(account_id)
-    tx.operator_account_id = account_id
+    tx.transaction_id = TransactionId.generate(account_id)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = TokenGrantKycTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, TokenGrantKycTransaction)
     assert reconstructed.token_id == token_id
     assert reconstructed.account_id == account_id
 

--- a/tests/unit/token_mint_transaction_test.py
+++ b/tests/unit/token_mint_transaction_test.py
@@ -267,3 +267,38 @@ def test_build_scheduled_body_nft(mock_account_ids, metadata):
     assert schedulable_body.tokenMint.token == token_id._to_proto()
     assert schedulable_body.tokenMint.amount == 0
     assert schedulable_body.tokenMint.metadata == metadata
+
+
+def test_from_protobuf_fungible(mock_account_ids):
+    """Test round-trip via _from_protobuf for fungible TokenMintTransaction."""
+    payer_account, _, node_account_id, token_id_1, _ = mock_account_ids
+
+    tx = TokenMintTransaction()
+    tx.set_token_id(token_id_1)
+    tx.set_amount(500)
+    tx.transaction_id = generate_transaction_id(payer_account)
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = TokenMintTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.token_id == token_id_1
+    assert reconstructed.amount == 500
+
+
+def test_from_protobuf_nft(mock_account_ids):
+    """Test round-trip via _from_protobuf for NFT TokenMintTransaction."""
+    payer_account, _, node_account_id, token_id_1, _ = mock_account_ids
+    nft_metadata = [b"meta1", b"meta2"]
+
+    tx = TokenMintTransaction()
+    tx.set_token_id(token_id_1)
+    tx.set_metadata(nft_metadata)
+    tx.transaction_id = generate_transaction_id(payer_account)
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = TokenMintTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.token_id == token_id_1
+    assert list(reconstructed.metadata) == nft_metadata

--- a/tests/unit/token_mint_transaction_test.py
+++ b/tests/unit/token_mint_transaction_test.py
@@ -11,6 +11,7 @@ from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
     SchedulableTransactionBody,
 )
 from hiero_sdk_python.tokens.token_mint_transaction import TokenMintTransaction
+from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 
@@ -269,8 +270,8 @@ def test_build_scheduled_body_nft(mock_account_ids, metadata):
     assert schedulable_body.tokenMint.metadata == metadata
 
 
-def test_from_protobuf_fungible(mock_account_ids):
-    """Test round-trip via _from_protobuf for fungible TokenMintTransaction."""
+def test_from_bytes_fungible(mock_account_ids):
+    """Test round-trip via Transaction.from_bytes() for fungible TokenMintTransaction."""
     payer_account, _, node_account_id, token_id_1, _ = mock_account_ids
 
     tx = TokenMintTransaction()
@@ -278,16 +279,17 @@ def test_from_protobuf_fungible(mock_account_ids):
     tx.set_amount(500)
     tx.transaction_id = generate_transaction_id(payer_account)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = TokenMintTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, TokenMintTransaction)
     assert reconstructed.token_id == token_id_1
     assert reconstructed.amount == 500
 
 
-def test_from_protobuf_nft(mock_account_ids):
-    """Test round-trip via _from_protobuf for NFT TokenMintTransaction."""
+def test_from_bytes_nft(mock_account_ids):
+    """Test round-trip via Transaction.from_bytes() for NFT TokenMintTransaction."""
     payer_account, _, node_account_id, token_id_1, _ = mock_account_ids
     nft_metadata = [b"meta1", b"meta2"]
 
@@ -296,9 +298,10 @@ def test_from_protobuf_nft(mock_account_ids):
     tx.set_metadata(nft_metadata)
     tx.transaction_id = generate_transaction_id(payer_account)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = TokenMintTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, TokenMintTransaction)
     assert reconstructed.token_id == token_id_1
     assert list(reconstructed.metadata) == nft_metadata

--- a/tests/unit/token_pause_transaction_test.py
+++ b/tests/unit/token_pause_transaction_test.py
@@ -148,3 +148,18 @@ def test_build_scheduled_body(token_id):
     assert isinstance(schedulable_body, SchedulableTransactionBody)
     assert schedulable_body.HasField("token_pause")
     assert schedulable_body.token_pause.token == token_id._to_proto()
+
+
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for TokenPauseTransaction."""
+    account_id_sender, _, node_account_id, token_id_1, _ = mock_account_ids
+
+    tx = TokenPauseTransaction()
+    tx.set_token_id(token_id_1)
+    tx.operator_account_id = account_id_sender
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = TokenPauseTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.token_id == token_id_1

--- a/tests/unit/token_pause_transaction_test.py
+++ b/tests/unit/token_pause_transaction_test.py
@@ -18,6 +18,8 @@ from hiero_sdk_python.hapi.services.transaction_response_pb2 import TransactionR
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.token_id import TokenId
 from hiero_sdk_python.tokens.token_pause_transaction import TokenPauseTransaction
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 from tests.unit.mock_server import mock_hedera_servers
 
 
@@ -150,16 +152,17 @@ def test_build_scheduled_body(token_id):
     assert schedulable_body.token_pause.token == token_id._to_proto()
 
 
-def test_from_protobuf(mock_account_ids):
-    """Test round-trip via _from_protobuf for TokenPauseTransaction."""
+def test_from_bytes(mock_account_ids):
+    """Test round-trip via Transaction.from_bytes() for TokenPauseTransaction."""
     account_id_sender, _, node_account_id, token_id_1, _ = mock_account_ids
 
     tx = TokenPauseTransaction()
     tx.set_token_id(token_id_1)
-    tx.operator_account_id = account_id_sender
+    tx.transaction_id = TransactionId.generate(account_id_sender)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = TokenPauseTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, TokenPauseTransaction)
     assert reconstructed.token_id == token_id_1

--- a/tests/unit/token_reject_transaction_test.py
+++ b/tests/unit/token_reject_transaction_test.py
@@ -245,3 +245,48 @@ def test_build_scheduled_body_with_nft_ids(mock_account_ids):
     assert schedulable_body.tokenReject.rejections[0].HasField("nft")
     assert schedulable_body.tokenReject.rejections[0].nft.token_ID == token_id._to_proto()
     assert schedulable_body.tokenReject.rejections[0].nft.serial_number == 1
+
+
+def test_from_bytes(mock_account_ids):
+    from hiero_sdk_python.transaction.transaction import Transaction
+    from hiero_sdk_python.transaction.transaction_id import TransactionId
+
+    operator_id, owner_id, node_account_id, token_id, _ = mock_account_ids
+
+    tx = TokenRejectTransaction()
+    tx.set_owner_id(owner_id)
+    tx.set_token_ids([token_id])
+    tx.transaction_id = TransactionId.generate(operator_id)
+    tx.node_account_id = node_account_id
+    tx.freeze()
+
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
+
+    assert isinstance(reconstructed, TokenRejectTransaction)
+    assert reconstructed.owner_id == owner_id
+    assert len(reconstructed.token_ids) == 1
+    assert reconstructed.token_ids[0] == token_id
+    assert reconstructed.nft_ids == []
+
+
+def test_from_bytes_with_nft(mock_account_ids):
+    from hiero_sdk_python.transaction.transaction import Transaction
+    from hiero_sdk_python.transaction.transaction_id import TransactionId
+
+    operator_id, owner_id, node_account_id, token_id, _ = mock_account_ids
+
+    nft = NftId(token_id=token_id, serial_number=5)
+    tx = TokenRejectTransaction()
+    tx.set_owner_id(owner_id)
+    tx.set_nft_ids([nft])
+    tx.transaction_id = TransactionId.generate(operator_id)
+    tx.node_account_id = node_account_id
+    tx.freeze()
+
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
+
+    assert isinstance(reconstructed, TokenRejectTransaction)
+    assert reconstructed.owner_id == owner_id
+    assert reconstructed.token_ids == []
+    assert len(reconstructed.nft_ids) == 1
+    assert reconstructed.nft_ids[0].serial_number == 5

--- a/tests/unit/token_revoke_kyc_transaction_test.py
+++ b/tests/unit/token_revoke_kyc_transaction_test.py
@@ -138,6 +138,23 @@ def test_build_scheduled_body(mock_account_ids):
     assert schedulable_body.tokenRevokeKyc.account == account_id._to_proto()
 
 
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for TokenRevokeKycTransaction."""
+    account_id_sender, _, node_account_id, token_id_1, _ = mock_account_ids
+
+    tx = TokenRevokeKycTransaction()
+    tx.set_token_id(token_id_1)
+    tx.set_account_id(account_id_sender)
+    tx.operator_account_id = account_id_sender
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = TokenRevokeKycTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.token_id == token_id_1
+    assert reconstructed.account_id == account_id_sender
+
+
 def test_revoke_kyc_transaction_from_proto(mock_account_ids):
     """Test that a revoke KYC transaction can be created from a protobuf object."""
     account_id, _, _, token_id, _ = mock_account_ids

--- a/tests/unit/token_revoke_kyc_transaction_test.py
+++ b/tests/unit/token_revoke_kyc_transaction_test.py
@@ -156,6 +156,8 @@ def test_from_bytes(mock_account_ids):
     assert isinstance(reconstructed, TokenRevokeKycTransaction)
     assert reconstructed.token_id == token_id_1
     assert reconstructed.account_id == account_id_sender
+    assert reconstructed.transaction_id == tx.transaction_id
+    assert reconstructed.node_account_id == node_account_id
 
 
 def test_revoke_kyc_transaction_from_proto(mock_account_ids):

--- a/tests/unit/token_revoke_kyc_transaction_test.py
+++ b/tests/unit/token_revoke_kyc_transaction_test.py
@@ -13,6 +13,8 @@ from hiero_sdk_python.hapi.services.transaction_response_pb2 import TransactionR
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.token_id import TokenId
 from hiero_sdk_python.tokens.token_revoke_kyc_transaction import TokenRevokeKycTransaction
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 from tests.unit.mock_server import mock_hedera_servers
 
 
@@ -138,19 +140,20 @@ def test_build_scheduled_body(mock_account_ids):
     assert schedulable_body.tokenRevokeKyc.account == account_id._to_proto()
 
 
-def test_from_protobuf(mock_account_ids):
+def test_from_bytes(mock_account_ids):
     """Test round-trip via _from_protobuf for TokenRevokeKycTransaction."""
     account_id_sender, _, node_account_id, token_id_1, _ = mock_account_ids
 
     tx = TokenRevokeKycTransaction()
     tx.set_token_id(token_id_1)
     tx.set_account_id(account_id_sender)
-    tx.operator_account_id = account_id_sender
+    tx.transaction_id = TransactionId.generate(account_id_sender)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = TokenRevokeKycTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, TokenRevokeKycTransaction)
     assert reconstructed.token_id == token_id_1
     assert reconstructed.account_id == account_id_sender
 

--- a/tests/unit/token_unfreeze_transaction_test.py
+++ b/tests/unit/token_unfreeze_transaction_test.py
@@ -112,6 +112,23 @@ def test_build_scheduled_body(mock_account_ids):
     assert schedulable_body.tokenUnfreeze.account == freeze_id._to_proto()
 
 
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for TokenUnfreezeTransaction."""
+    account_id_sender, _, node_account_id, token_id_1, _ = mock_account_ids
+
+    tx = TokenUnfreezeTransaction()
+    tx.set_token_id(token_id_1)
+    tx.set_account_id(account_id_sender)
+    tx.transaction_id = generate_transaction_id(account_id_sender)
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = TokenUnfreezeTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.token_id == token_id_1
+    assert reconstructed.account_id == account_id_sender
+
+
 def test_to_proto(mock_account_ids, mock_client):
     """Test converting the token unfreeze transaction to protobuf format after signing."""
     account_id, freeze_id, _, token_id, _ = mock_account_ids

--- a/tests/unit/token_unfreeze_transaction_test.py
+++ b/tests/unit/token_unfreeze_transaction_test.py
@@ -9,6 +9,7 @@ from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
     SchedulableTransactionBody,
 )
 from hiero_sdk_python.tokens.token_unfreeze_transaction import TokenUnfreezeTransaction
+from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 
@@ -112,8 +113,8 @@ def test_build_scheduled_body(mock_account_ids):
     assert schedulable_body.tokenUnfreeze.account == freeze_id._to_proto()
 
 
-def test_from_protobuf(mock_account_ids):
-    """Test round-trip via _from_protobuf for TokenUnfreezeTransaction."""
+def test_from_bytes(mock_account_ids):
+    """Test round-trip via Transaction.from_bytes() for TokenUnfreezeTransaction."""
     account_id_sender, _, node_account_id, token_id_1, _ = mock_account_ids
 
     tx = TokenUnfreezeTransaction()
@@ -121,10 +122,11 @@ def test_from_protobuf(mock_account_ids):
     tx.set_account_id(account_id_sender)
     tx.transaction_id = generate_transaction_id(account_id_sender)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = TokenUnfreezeTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, TokenUnfreezeTransaction)
     assert reconstructed.token_id == token_id_1
     assert reconstructed.account_id == account_id_sender
 

--- a/tests/unit/token_unpause_transaction_test.py
+++ b/tests/unit/token_unpause_transaction_test.py
@@ -169,6 +169,21 @@ def test_from_proto(mock_account_ids):
     assert unpause_tx.token_id.num == token_id.num
 
 
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for TokenUnpauseTransaction."""
+    account_id_sender, _, node_account_id, token_id_1, _ = mock_account_ids
+
+    tx = TokenUnpauseTransaction()
+    tx.set_token_id(token_id_1)
+    tx.operator_account_id = account_id_sender
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = TokenUnpauseTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.token_id == token_id_1
+
+
 def test_upause_transaction_can_execute(mock_account_ids):
     """Test that a token upause transaction can be executed successfully."""
     _, _, _, token_id, _ = mock_account_ids

--- a/tests/unit/token_unpause_transaction_test.py
+++ b/tests/unit/token_unpause_transaction_test.py
@@ -12,6 +12,8 @@ from hiero_sdk_python.hapi.services.transaction_response_pb2 import TransactionR
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.token_id import TokenId
 from hiero_sdk_python.tokens.token_unpause_transaction import TokenUnpauseTransaction
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 from tests.unit.mock_server import mock_hedera_servers
 
 
@@ -169,18 +171,19 @@ def test_from_proto(mock_account_ids):
     assert unpause_tx.token_id.num == token_id.num
 
 
-def test_from_protobuf(mock_account_ids):
-    """Test round-trip via _from_protobuf for TokenUnpauseTransaction."""
+def test_from_bytes(mock_account_ids):
+    """Test round-trip via Transaction.from_bytes() for TokenUnpauseTransaction."""
     account_id_sender, _, node_account_id, token_id_1, _ = mock_account_ids
 
     tx = TokenUnpauseTransaction()
     tx.set_token_id(token_id_1)
-    tx.operator_account_id = account_id_sender
+    tx.transaction_id = TransactionId.generate(account_id_sender)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = TokenUnpauseTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, TokenUnpauseTransaction)
     assert reconstructed.token_id == token_id_1
 
 

--- a/tests/unit/token_update_nfts_transaction_test.py
+++ b/tests/unit/token_update_nfts_transaction_test.py
@@ -13,6 +13,8 @@ from hiero_sdk_python.hapi.services.transaction_response_pb2 import TransactionR
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.token_id import TokenId
 from hiero_sdk_python.tokens.token_update_nfts_transaction import TokenUpdateNftsTransaction
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 from tests.unit.mock_server import mock_hedera_servers
 
 
@@ -214,7 +216,7 @@ def test_update_nfts_transaction_from_proto(mock_account_ids):
     assert empty_tx.metadata is empty_proto.metadata.value  # Should be None or empty
 
 
-def test_from_protobuf(mock_account_ids):
+def test_from_bytes(mock_account_ids):
     """Test round-trip via _from_protobuf for TokenUpdateNftsTransaction."""
     operator_id, _, node_account_id, token_id_1, _ = mock_account_ids
     serial_numbers = [1, 2, 3]
@@ -224,12 +226,13 @@ def test_from_protobuf(mock_account_ids):
     tx.set_token_id(token_id_1)
     tx.set_serial_numbers(serial_numbers)
     tx.set_metadata(metadata)
-    tx.operator_account_id = operator_id
+    tx.transaction_id = TransactionId.generate(operator_id)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = TokenUpdateNftsTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, TokenUpdateNftsTransaction)
     assert reconstructed.token_id == token_id_1
     assert list(reconstructed.serial_numbers) == serial_numbers
     assert reconstructed.metadata == metadata

--- a/tests/unit/token_update_nfts_transaction_test.py
+++ b/tests/unit/token_update_nfts_transaction_test.py
@@ -212,3 +212,24 @@ def test_update_nfts_transaction_from_proto(mock_account_ids):
     assert isinstance(empty_tx.token_id, TokenId)
     assert empty_tx.serial_numbers == []
     assert empty_tx.metadata is empty_proto.metadata.value  # Should be None or empty
+
+
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for TokenUpdateNftsTransaction."""
+    operator_id, _, node_account_id, token_id_1, _ = mock_account_ids
+    serial_numbers = [1, 2, 3]
+    metadata = b"newmeta"
+
+    tx = TokenUpdateNftsTransaction()
+    tx.set_token_id(token_id_1)
+    tx.set_serial_numbers(serial_numbers)
+    tx.set_metadata(metadata)
+    tx.operator_account_id = operator_id
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = TokenUpdateNftsTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.token_id == token_id_1
+    assert list(reconstructed.serial_numbers) == serial_numbers
+    assert reconstructed.metadata == metadata

--- a/tests/unit/token_update_transaction_test.py
+++ b/tests/unit/token_update_transaction_test.py
@@ -17,6 +17,8 @@ from hiero_sdk_python.hapi.services.transaction_response_pb2 import TransactionR
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.timestamp import Timestamp
 from hiero_sdk_python.tokens.token_update_transaction import TokenUpdateKeys, TokenUpdateParams, TokenUpdateTransaction
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 from tests.unit.mock_server import mock_hedera_servers
 
 
@@ -468,7 +470,7 @@ def test_build_transaction_body_with_keys(mock_account_ids, key_type, use_privat
     verify_key_in_proto(transaction_body.tokenUpdate.freezeKey, expected_freeze_public, key_type)
 
 
-def test_from_protobuf(mock_account_ids):
+def test_from_bytes(mock_account_ids):
     """Test round-trip via _from_protobuf for TokenUpdateTransaction."""
     operator_id, _, node_account_id, token_id_1, _ = mock_account_ids
 
@@ -476,12 +478,13 @@ def test_from_protobuf(mock_account_ids):
     tx.set_token_id(token_id_1)
     tx.set_token_name("NewName")
     tx.set_token_symbol("NNS")
-    tx.operator_account_id = operator_id
+    tx.transaction_id = TransactionId.generate(operator_id)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = TokenUpdateTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, TokenUpdateTransaction)
     assert reconstructed.token_id == token_id_1
     assert reconstructed.token_name == "NewName"
     assert reconstructed.token_symbol == "NNS"

--- a/tests/unit/token_update_transaction_test.py
+++ b/tests/unit/token_update_transaction_test.py
@@ -466,3 +466,22 @@ def test_build_transaction_body_with_keys(mock_account_ids, key_type, use_privat
     assert transaction_body.tokenUpdate.name == new_token_data["name"]
     verify_key_in_proto(transaction_body.tokenUpdate.adminKey, expected_admin_public, key_type)
     verify_key_in_proto(transaction_body.tokenUpdate.freezeKey, expected_freeze_public, key_type)
+
+
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for TokenUpdateTransaction."""
+    operator_id, _, node_account_id, token_id_1, _ = mock_account_ids
+
+    tx = TokenUpdateTransaction()
+    tx.set_token_id(token_id_1)
+    tx.set_token_name("NewName")
+    tx.set_token_symbol("NNS")
+    tx.operator_account_id = operator_id
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = TokenUpdateTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.token_id == token_id_1
+    assert reconstructed.token_name == "NewName"
+    assert reconstructed.token_symbol == "NNS"

--- a/tests/unit/token_update_transaction_test.py
+++ b/tests/unit/token_update_transaction_test.py
@@ -470,14 +470,22 @@ def test_build_transaction_body_with_keys(mock_account_ids, key_type, use_privat
     verify_key_in_proto(transaction_body.tokenUpdate.freezeKey, expected_freeze_public, key_type)
 
 
-def test_from_bytes(mock_account_ids):
+def test_from_bytes(mock_account_ids, new_token_data):
     """Test round-trip via _from_protobuf for TokenUpdateTransaction."""
     operator_id, _, node_account_id, token_id_1, _ = mock_account_ids
+    key = PrivateKey.generate().public_key()
 
     tx = TokenUpdateTransaction()
     tx.set_token_id(token_id_1)
     tx.set_token_name("NewName")
     tx.set_token_symbol("NNS")
+    tx.set_token_memo(new_token_data["memo"])
+    tx.set_metadata(new_token_data["metadata"])
+    tx.set_treasury_account_id(operator_id)
+    tx.set_auto_renew_account_id(operator_id)
+    tx.set_auto_renew_period(new_token_data["auto_renew_period"])
+    tx.set_expiration_time(new_token_data["expiration_time"])
+    tx.set_admin_key(key)
     tx.transaction_id = TransactionId.generate(operator_id)
     tx.node_account_id = node_account_id
     tx.freeze()
@@ -488,3 +496,10 @@ def test_from_bytes(mock_account_ids):
     assert reconstructed.token_id == token_id_1
     assert reconstructed.token_name == "NewName"
     assert reconstructed.token_symbol == "NNS"
+    assert reconstructed.token_memo == new_token_data["memo"]
+    assert reconstructed.metadata == new_token_data["metadata"]
+    assert reconstructed.treasury_account_id == operator_id
+    assert reconstructed.auto_renew_account_id == operator_id
+    assert reconstructed.auto_renew_period.seconds == new_token_data["auto_renew_period"].seconds
+    assert reconstructed.expiration_time.seconds == new_token_data["expiration_time"].seconds
+    assert reconstructed.admin_key.to_bytes_raw() == key.to_bytes_raw()

--- a/tests/unit/token_wipe_transaction_test.py
+++ b/tests/unit/token_wipe_transaction_test.py
@@ -12,6 +12,7 @@ from hiero_sdk_python.hapi.services.transaction_receipt_pb2 import TransactionRe
 from hiero_sdk_python.hapi.services.transaction_response_pb2 import TransactionResponse as TransactionResponseProto
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.token_wipe_transaction import TokenWipeTransaction
+from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 from tests.unit.mock_server import mock_hedera_servers
 
@@ -196,7 +197,7 @@ def test_build_scheduled_body_with_serial_numbers(mock_account_ids):
     assert schedulable_body.tokenWipe.serialNumbers == serial_numbers
 
 
-def test_from_protobuf_fungible(mock_account_ids):
+def test_from_bytes_fungible(mock_account_ids):
     """Test round-trip via _from_protobuf for fungible TokenWipeTransaction."""
     account_id_sender, _, node_account_id, token_id_1, _ = mock_account_ids
 
@@ -206,16 +207,18 @@ def test_from_protobuf_fungible(mock_account_ids):
     tx.set_amount(50)
     tx.transaction_id = generate_transaction_id(account_id_sender)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = TokenWipeTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, TokenWipeTransaction)
     assert reconstructed.token_id == token_id_1
     assert reconstructed.account_id == account_id_sender
     assert reconstructed.amount == 50
+    assert reconstructed.serial == []
 
 
-def test_from_protobuf_nft(mock_account_ids):
+def test_from_bytes_nft(mock_account_ids):
     """Test round-trip via _from_protobuf for NFT TokenWipeTransaction."""
     account_id_sender, _, node_account_id, token_id_1, _ = mock_account_ids
     serial = [4, 5]
@@ -226,10 +229,12 @@ def test_from_protobuf_nft(mock_account_ids):
     tx.set_serial(serial)
     tx.transaction_id = generate_transaction_id(account_id_sender)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = TokenWipeTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, TokenWipeTransaction)
     assert reconstructed.token_id == token_id_1
     assert reconstructed.account_id == account_id_sender
     assert list(reconstructed.serial) == serial
+    assert reconstructed.amount is None

--- a/tests/unit/token_wipe_transaction_test.py
+++ b/tests/unit/token_wipe_transaction_test.py
@@ -194,3 +194,42 @@ def test_build_scheduled_body_with_serial_numbers(mock_account_ids):
     assert schedulable_body.tokenWipe.token == token_id._to_proto()
     assert schedulable_body.tokenWipe.account == wipe_account_id._to_proto()
     assert schedulable_body.tokenWipe.serialNumbers == serial_numbers
+
+
+def test_from_protobuf_fungible(mock_account_ids):
+    """Test round-trip via _from_protobuf for fungible TokenWipeTransaction."""
+    account_id_sender, _, node_account_id, token_id_1, _ = mock_account_ids
+
+    tx = TokenWipeTransaction()
+    tx.set_token_id(token_id_1)
+    tx.set_account_id(account_id_sender)
+    tx.set_amount(50)
+    tx.transaction_id = generate_transaction_id(account_id_sender)
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = TokenWipeTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.token_id == token_id_1
+    assert reconstructed.account_id == account_id_sender
+    assert reconstructed.amount == 50
+
+
+def test_from_protobuf_nft(mock_account_ids):
+    """Test round-trip via _from_protobuf for NFT TokenWipeTransaction."""
+    account_id_sender, _, node_account_id, token_id_1, _ = mock_account_ids
+    serial = [4, 5]
+
+    tx = TokenWipeTransaction()
+    tx.set_token_id(token_id_1)
+    tx.set_account_id(account_id_sender)
+    tx.set_serial(serial)
+    tx.transaction_id = generate_transaction_id(account_id_sender)
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = TokenWipeTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.token_id == token_id_1
+    assert reconstructed.account_id == account_id_sender
+    assert list(reconstructed.serial) == serial

--- a/tests/unit/token_wipe_transaction_test.py
+++ b/tests/unit/token_wipe_transaction_test.py
@@ -237,4 +237,4 @@ def test_from_bytes_nft(mock_account_ids):
     assert reconstructed.token_id == token_id_1
     assert reconstructed.account_id == account_id_sender
     assert list(reconstructed.serial) == serial
-    assert reconstructed.amount is None
+    assert reconstructed.amount == 0

--- a/tests/unit/token_wipe_transaction_test.py
+++ b/tests/unit/token_wipe_transaction_test.py
@@ -237,4 +237,4 @@ def test_from_bytes_nft(mock_account_ids):
     assert reconstructed.token_id == token_id_1
     assert reconstructed.account_id == account_id_sender
     assert list(reconstructed.serial) == serial
-    assert reconstructed.amount == 0
+    assert reconstructed.amount is None

--- a/tests/unit/topic_create_transaction_test.py
+++ b/tests/unit/topic_create_transaction_test.py
@@ -9,6 +9,7 @@ from hiero_sdk_python.consensus.topic_create_transaction import TopicCreateTrans
 from hiero_sdk_python.consensus.topic_id import TopicId
 from hiero_sdk_python.crypto.private_key import PrivateKey
 from hiero_sdk_python.crypto.public_key import PublicKey
+from hiero_sdk_python.Duration import Duration
 from hiero_sdk_python.hapi.services import (
     basic_types_pb2,
     response_header_pb2,
@@ -633,9 +634,16 @@ def test_from_protobuf(mock_account_ids):
     """Test round-trip via _from_protobuf for TopicCreateTransaction."""
     account_id_sender, _, node_account_id, _, _ = mock_account_ids
 
+    admin_key = PrivateKey.generate_ed25519().public_key()
+    submit_key = PrivateKey.generate_ed25519().public_key()
+    auto_renew_period = Duration(8000000)
+
     tx = TopicCreateTransaction()
     tx.set_memo("hello")
     tx.set_auto_renew_account(account_id_sender)
+    tx.set_admin_key(admin_key)
+    tx.set_submit_key(submit_key)
+    tx.set_auto_renew_period(auto_renew_period)
     tx.operator_account_id = account_id_sender
     tx.node_account_id = node_account_id
 
@@ -644,3 +652,6 @@ def test_from_protobuf(mock_account_ids):
 
     assert reconstructed.memo == "hello"
     assert reconstructed.auto_renew_account == account_id_sender
+    assert reconstructed.admin_key == admin_key
+    assert reconstructed.submit_key == submit_key
+    assert reconstructed.auto_renew_period == auto_renew_period

--- a/tests/unit/topic_create_transaction_test.py
+++ b/tests/unit/topic_create_transaction_test.py
@@ -627,3 +627,20 @@ def test_freeze_with_leaves_auto_renew_account_unset_without_operator(mock_clien
     body = frozen_tx.build_transaction_body()
 
     assert not body.consensusCreateTopic.HasField("autoRenewAccount")
+
+
+def test_from_protobuf(mock_account_ids):
+    """Test round-trip via _from_protobuf for TopicCreateTransaction."""
+    account_id_sender, _, node_account_id, _, _ = mock_account_ids
+
+    tx = TopicCreateTransaction()
+    tx.set_memo("hello")
+    tx.set_auto_renew_account(account_id_sender)
+    tx.operator_account_id = account_id_sender
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = TopicCreateTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.memo == "hello"
+    assert reconstructed.auto_renew_account == account_id_sender

--- a/tests/unit/topic_create_transaction_test.py
+++ b/tests/unit/topic_create_transaction_test.py
@@ -24,6 +24,7 @@ from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.custom_fixed_fee import CustomFixedFee
 from hiero_sdk_python.tokens.token_id import TokenId
+from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 from tests.unit.mock_server import mock_hedera_servers
 
@@ -630,8 +631,8 @@ def test_freeze_with_leaves_auto_renew_account_unset_without_operator(mock_clien
     assert not body.consensusCreateTopic.HasField("autoRenewAccount")
 
 
-def test_from_protobuf(mock_account_ids):
-    """Test round-trip via _from_protobuf for TopicCreateTransaction."""
+def test_from_bytes(mock_account_ids):
+    """Test round-trip via Transaction.from_bytes() for TopicCreateTransaction."""
     account_id_sender, _, node_account_id, _, _ = mock_account_ids
 
     admin_key = PrivateKey.generate_ed25519().public_key()
@@ -644,12 +645,13 @@ def test_from_protobuf(mock_account_ids):
     tx.set_admin_key(admin_key)
     tx.set_submit_key(submit_key)
     tx.set_auto_renew_period(auto_renew_period)
-    tx.operator_account_id = account_id_sender
+    tx.transaction_id = TransactionId.generate(account_id_sender)
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = TopicCreateTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, TopicCreateTransaction)
     assert reconstructed.memo == "hello"
     assert reconstructed.auto_renew_account == account_id_sender
     assert reconstructed.admin_key == admin_key

--- a/tests/unit/topic_delete_transaction_test.py
+++ b/tests/unit/topic_delete_transaction_test.py
@@ -113,3 +113,17 @@ def test_execute_topic_delete_transaction(topic_id):
 
         # Verify the receipt contains the expected values
         assert receipt.status == ResponseCode.SUCCESS
+
+
+def test_from_protobuf(mock_account_ids, topic_id):
+    """Test round-trip via _from_protobuf for TopicDeleteTransaction."""
+    _, _, node_account_id, _, _ = mock_account_ids
+
+    tx = TopicDeleteTransaction(topic_id=topic_id)
+    tx.operator_account_id = AccountId(0, 0, 2)
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = TopicDeleteTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.topic_id == topic_id

--- a/tests/unit/topic_delete_transaction_test.py
+++ b/tests/unit/topic_delete_transaction_test.py
@@ -17,6 +17,8 @@ from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
     SchedulableTransactionBody,
 )
 from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 from tests.unit.mock_server import mock_hedera_servers
 
 
@@ -115,15 +117,16 @@ def test_execute_topic_delete_transaction(topic_id):
         assert receipt.status == ResponseCode.SUCCESS
 
 
-def test_from_protobuf(mock_account_ids, topic_id):
-    """Test round-trip via _from_protobuf for TopicDeleteTransaction."""
+def test_from_bytes(mock_account_ids, topic_id):
+    """Test round-trip via Transaction.from_bytes() for TopicDeleteTransaction."""
     _, _, node_account_id, _, _ = mock_account_ids
 
     tx = TopicDeleteTransaction(topic_id=topic_id)
-    tx.operator_account_id = AccountId(0, 0, 2)
+    tx.transaction_id = TransactionId.generate(AccountId(0, 0, 2))
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = TopicDeleteTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, TopicDeleteTransaction)
     assert reconstructed.topic_id == topic_id

--- a/tests/unit/topic_message_submit_transaction_test.py
+++ b/tests/unit/topic_message_submit_transaction_test.py
@@ -22,6 +22,7 @@ from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
 )
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.transaction.custom_fee_limit import CustomFeeLimit
+from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 from hiero_sdk_python.transaction.transaction_receipt import TransactionReceipt
 from hiero_sdk_python.transaction.transaction_response import TransactionResponse
@@ -485,19 +486,18 @@ def test_topic_submit_execute_raises_error_with_validation(topic_id):
         assert e.value.status == ResponseCode.INVALID_SIGNATURE
 
 
-def test_from_protobuf(topic_id):
+def test_from_bytes(topic_id):
     """Test round-trip via _from_protobuf for TopicMessageSubmitTransaction."""
-    from hiero_sdk_python.account.account_id import AccountId
-
     tx = TopicMessageSubmitTransaction()
     tx.set_topic_id(topic_id)
     tx.set_message("hello world")
-    tx.operator_account_id = AccountId(0, 0, 1)
+    tx.transaction_id = TransactionId.generate(AccountId(0, 0, 1))
     tx.node_account_id = AccountId(0, 0, 3)
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = TopicMessageSubmitTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, TopicMessageSubmitTransaction)
     assert reconstructed.topic_id == topic_id
     assert reconstructed.message == "hello world"
 

--- a/tests/unit/topic_message_submit_transaction_test.py
+++ b/tests/unit/topic_message_submit_transaction_test.py
@@ -485,6 +485,23 @@ def test_topic_submit_execute_raises_error_with_validation(topic_id):
         assert e.value.status == ResponseCode.INVALID_SIGNATURE
 
 
+def test_from_protobuf(topic_id):
+    """Test round-trip via _from_protobuf for TopicMessageSubmitTransaction."""
+    from hiero_sdk_python.account.account_id import AccountId
+
+    tx = TopicMessageSubmitTransaction()
+    tx.set_topic_id(topic_id)
+    tx.set_message("hello world")
+    tx.operator_account_id = AccountId(0, 0, 1)
+    tx.node_account_id = AccountId(0, 0, 3)
+
+    body = tx.build_transaction_body()
+    reconstructed = TopicMessageSubmitTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.topic_id == topic_id
+    assert reconstructed.message == "hello world"
+
+
 def test_topic_submit_execute_returns_failed_receipt_by_default(topic_id):
     """Test execute returns the failing receipt by default when validation is disabled."""
     message = "Hello Hiero"

--- a/tests/unit/topic_update_transaction_test.py
+++ b/tests/unit/topic_update_transaction_test.py
@@ -22,6 +22,8 @@ from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
 )
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.custom_fixed_fee import CustomFixedFee
+from hiero_sdk_python.transaction.transaction import Transaction
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 from tests.unit.mock_server import mock_hedera_servers
 
 
@@ -316,8 +318,8 @@ def test_execute_topic_update_transaction(topic_id):
         assert receipt.status == ResponseCode.SUCCESS
 
 
-def test_from_protobuf(mock_account_ids, topic_id):
-    """Test round-trip via _from_protobuf for TopicUpdateTransaction."""
+def test_from_bytes(mock_account_ids, topic_id):
+    """Test round-trip via Transaction.from_bytes() for TopicUpdateTransaction."""
     _, _, node_account_id, _, _ = mock_account_ids
 
     admin_key = PrivateKey.generate().public_key()
@@ -332,12 +334,13 @@ def test_from_protobuf(mock_account_ids, topic_id):
     tx.set_submit_key(submit_key)
     tx.set_auto_renew_period(auto_renew_period)
     tx.set_auto_renew_account(auto_renew_account)
-    tx.operator_account_id = AccountId(0, 0, 2)
+    tx.transaction_id = TransactionId.generate(AccountId(0, 0, 2))
     tx.node_account_id = node_account_id
+    tx.freeze()
 
-    body = tx.build_transaction_body()
-    reconstructed = TopicUpdateTransaction._from_protobuf(body, body.SerializeToString(), None)
+    reconstructed = Transaction.from_bytes(tx.to_bytes())
 
+    assert isinstance(reconstructed, TopicUpdateTransaction)
     assert reconstructed.topic_id == topic_id
     assert reconstructed.memo == "Updated Memo"
     assert reconstructed.admin_key == admin_key

--- a/tests/unit/topic_update_transaction_test.py
+++ b/tests/unit/topic_update_transaction_test.py
@@ -320,9 +320,18 @@ def test_from_protobuf(mock_account_ids, topic_id):
     """Test round-trip via _from_protobuf for TopicUpdateTransaction."""
     _, _, node_account_id, _, _ = mock_account_ids
 
+    admin_key = PrivateKey.generate().public_key()
+    submit_key = PrivateKey.generate().public_key()
+    auto_renew_account = AccountId(0, 0, 5678)
+    auto_renew_period = Duration(8000000)
+
     tx = TopicUpdateTransaction()
     tx.set_topic_id(topic_id)
     tx.set_memo("Updated Memo")
+    tx.set_admin_key(admin_key)
+    tx.set_submit_key(submit_key)
+    tx.set_auto_renew_period(auto_renew_period)
+    tx.set_auto_renew_account(auto_renew_account)
     tx.operator_account_id = AccountId(0, 0, 2)
     tx.node_account_id = node_account_id
 
@@ -331,6 +340,10 @@ def test_from_protobuf(mock_account_ids, topic_id):
 
     assert reconstructed.topic_id == topic_id
     assert reconstructed.memo == "Updated Memo"
+    assert reconstructed.admin_key == admin_key
+    assert reconstructed.submit_key == submit_key
+    assert reconstructed.auto_renew_period == auto_renew_period
+    assert reconstructed.auto_renew_account == auto_renew_account
 
 
 # This test uses fixture topic_id as parameter

--- a/tests/unit/topic_update_transaction_test.py
+++ b/tests/unit/topic_update_transaction_test.py
@@ -316,6 +316,23 @@ def test_execute_topic_update_transaction(topic_id):
         assert receipt.status == ResponseCode.SUCCESS
 
 
+def test_from_protobuf(mock_account_ids, topic_id):
+    """Test round-trip via _from_protobuf for TopicUpdateTransaction."""
+    _, _, node_account_id, _, _ = mock_account_ids
+
+    tx = TopicUpdateTransaction()
+    tx.set_topic_id(topic_id)
+    tx.set_memo("Updated Memo")
+    tx.operator_account_id = AccountId(0, 0, 2)
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body()
+    reconstructed = TopicUpdateTransaction._from_protobuf(body, body.SerializeToString(), None)
+
+    assert reconstructed.topic_id == topic_id
+    assert reconstructed.memo == "Updated Memo"
+
+
 # This test uses fixture topic_id as parameter
 def test_topic_update_transaction_with_all_fields(topic_id):
     """Test updating a topic with all available fields."""

--- a/tests/unit/transaction_dispatch_test.py
+++ b/tests/unit/transaction_dispatch_test.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pytest
+
+from hiero_sdk_python.transaction.transaction import _TRANSACTION_TYPE_MAP, Transaction
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_transaction_type_map_is_module_level():
+    """_TRANSACTION_TYPE_MAP must be a module-level constant, not inline."""
+    import hiero_sdk_python.transaction.transaction as tx_module
+
+    assert hasattr(tx_module, "_TRANSACTION_TYPE_MAP")
+    assert isinstance(tx_module._TRANSACTION_TYPE_MAP, dict)
+
+
+def test_transaction_type_map_contains_expected_keys():
+    keys = set(_TRANSACTION_TYPE_MAP.keys())
+    expected = {
+        "cryptoCreateAccount",
+        "cryptoTransfer",
+        "tokenCreation",
+        "consensusCreateTopic",
+        "consensusUpdateTopic",
+        "fileCreate",
+        "contractCreateInstance",
+        "util_prng",
+        "tokenReject",
+        "tokenClaimAirdrop",
+        "tokenCancelAirdrop",
+        "nodeCreate",
+        "nodeUpdate",
+        "nodeDelete",
+        "atomic_batch",
+    }
+    assert expected.issubset(keys)
+
+
+def test_unimplemented_types_map_to_none():
+    assert _TRANSACTION_TYPE_MAP["cryptoAddLiveHash"] is None
+    assert _TRANSACTION_TYPE_MAP["cryptoDeleteLiveHash"] is None
+    assert _TRANSACTION_TYPE_MAP["systemDelete"] is None
+    assert _TRANSACTION_TYPE_MAP["systemUndelete"] is None
+
+
+def test_get_transaction_class_returns_none_for_unimplemented():
+    assert Transaction._get_transaction_class("cryptoAddLiveHash") is None
+    assert Transaction._get_transaction_class("cryptoDeleteLiveHash") is None
+
+
+def test_get_transaction_class_returns_none_for_unknown_type():
+    assert Transaction._get_transaction_class("unknownTransactionType") is None
+
+
+@pytest.mark.parametrize(
+    "tx_type,expected_class_name",
+    [
+        ("cryptoCreateAccount", "AccountCreateTransaction"),
+        ("cryptoTransfer", "TransferTransaction"),
+        ("tokenCreation", "TokenCreateTransaction"),
+        ("consensusCreateTopic", "TopicCreateTransaction"),
+        ("util_prng", "PrngTransaction"),
+        ("tokenClaimAirdrop", "TokenClaimAirdropTransaction"),
+        ("tokenCancelAirdrop", "TokenCancelAirdropTransaction"),
+        ("tokenReject", "TokenRejectTransaction"),
+        ("nodeDelete", "NodeDeleteTransaction"),
+        ("atomic_batch", "BatchTransaction"),
+    ],
+)
+def test_get_transaction_class_returns_correct_class(tx_type, expected_class_name):
+    cls = Transaction._get_transaction_class(tx_type)
+    assert cls is not None
+    assert cls.__name__ == expected_class_name
+
+
+def test_all_non_none_entries_importable():
+    """Every non-None entry in _TRANSACTION_TYPE_MAP must be importable."""
+    for tx_type, class_path in _TRANSACTION_TYPE_MAP.items():
+        if class_path is None:
+            continue
+        cls = Transaction._get_transaction_class(tx_type)
+        assert cls is not None, f"Failed to import class for '{tx_type}'"
+        assert callable(cls), f"Class for '{tx_type}' is not callable"


### PR DESCRIPTION
**Description**:
`Transaction.from_bytes()` silently returned an incomplete object for almost all
transaction types — the deserialization chain worked at the base class level, but
concrete subclasses never implemented `_from_protobuf`, so the result was a
correctly-typed instance with all fields at their default `None`/empty values.

**Original work by @yuval99g (PR #2183):**

* Implement `_from_protobuf` for all 33 missing transaction types across account,
  token, consensus, file, schedule, system, contract, and node domains
* Fix bugs in the `_get_transaction_class` dispatch map — wrong casing on keys
  (`WhichOneof("data")` returns snake_case for newer proto fields like `token_pause`,
  `token_unpause`, `token_fee_schedule_update`, `token_update_nfts`), missing entries
  for `tokenClaimAirdrop`, `token_fee_schedule_update`, and `freeze`, and incorrect
  module paths
* Add `HasField` guards on all inner message-type fields to prevent silent population
  with proto default values when a field is absent
* Add `test_from_protobuf` round-trip tests to every affected transaction test file

**Additional changes addressing reviewer feedback from #2183:**

* Use `Key.from_proto_key()` instead of `PublicKey._from_proto()` for all 8 key
  fields in `TokenCreateTransaction._from_protobuf` to correctly support composite
  key types (KeyList, ThresholdKey)
* Add `None` guard on `amount` field in `TokenWipeTransaction._from_protobuf` so
  NFT wipes (proto default `0`) deserialize to `None` instead of `0`
* Extract inline transaction-type dict to module-level `_TRANSACTION_TYPE_MAP`
  constant in `transaction.py` for readability and testability
* Add `test_from_bytes` round-trip tests for all transaction types that were missing
  them (ContractCreate, ContractDelete, ContractExecute, ContractUpdate,
  EthereumTransaction, NodeDelete, TokenClaimAirdrop, TokenCancelAirdrop,
  TokenReject, PrngTransaction, TokenCreate)
* Add `test_from_bytes_without_auto_renew_period` to `AccountCreateTransaction`
  tests verifying `None` is preserved through round-trip
* Add `tests/unit/transaction_dispatch_test.py` covering `_TRANSACTION_TYPE_MAP`
  structure, unimplemented entries, unknown types, and full import coverage of all
  registered transaction classes

**Related issue(s)**:

Fixes #2179
Supersedes #2183 (originally by @yuval99g)

**Notes for reviewer**:
This is a continuation of #2183, rebased onto current `main` with all inline
reviewer feedback addressed. The `# noqa: PLR0912` suppressions on `_from_protobuf`
methods are intentional — cyclomatic complexity is inherent to the per-field
`HasField` guard pattern, as discussed in #2183.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
