### PR TITLE
feat: make reviewer-to-assignee bot dynamic with removal support

### DIFF
--- a/.github/scripts/__tests__/jest/bot-pr-add-reviewers-as-assignees.test.js
+++ b/.github/scripts/__tests__/jest/bot-pr-add-reviewers-as-assignees.test.js
@@ -5,9 +5,12 @@
 
 describe('Bot: Add Reviewers as Assignees', () => {
   let handler;
+  let removeReviewerFromAssignees;
 
   beforeAll(() => {
-    handler = require('../../bot-pr-add-reviewers-as-assignees.js');
+    const mod = require('../../bot-pr-add-reviewers-as-assignees.js');
+    handler = mod;
+    removeReviewerFromAssignees = mod.removeReviewerFromAssignees;
   });
 
   beforeEach(() => {
@@ -36,20 +39,8 @@ describe('Bot: Add Reviewers as Assignees', () => {
     }
   });
 
-  const createMockReviewContext = ({ reviewerLogin, assignees = [] } = {}) => ({
-    repo: { owner: 'hiero-ledger', repo: 'hiero-sdk-python' },
-    eventName: 'pull_request_review',
-    payload: {
-      action: 'submitted',
-      review: {
-        user: { login: reviewerLogin }
-      },
-      pull_request: {
-        number: 123,
-        assignees
-      }
-    }
-  });
+  // Minimal context for remove flow: only repo is required when explicit params are passed
+  const minimalContext = { repo: { owner: 'hiero-ledger', repo: 'hiero-sdk-python' } };
 
   const createMockGithub = (state) => ({
     rest: {
@@ -247,56 +238,81 @@ describe('Bot: Add Reviewers as Assignees', () => {
     await expect(handler({ github: errorMock, context: ctx })).rejects.toHaveProperty('status', 500);
   });
 
-  // ─── Remove flow ─────────────────────────────────────────────────────────────
+  // ─── Remove flow (named export — called from workflow_run job) ────────────────
 
-  test('removes reviewer from assignees when they submit a review', async () => {
+  test('removes reviewer from assignees when called with explicit params', async () => {
     const state = createTestState();
     state.currentPrData = { assignees: [{ login: 'alice' }, { login: 'bob' }] };
-    const ctx = createMockReviewContext({
-      reviewerLogin: 'alice',
-      assignees: [{ login: 'alice' }, { login: 'bob' }]
-    });
 
-    await handler({ github: createMockGithub(state), context: ctx });
+    await removeReviewerFromAssignees({
+      github: createMockGithub(state),
+      context: minimalContext,
+      reviewer: 'alice',
+      prNumber: 123
+    });
 
     expect(state.removeAssigneesCalls).toHaveLength(1);
     expect(state.removeAssigneesCalls[0].assignees).toEqual(['alice']);
     expect(state.addAssigneesCalls).toHaveLength(0);
   });
 
-  test('does not call removeAssignees when reviewer is not an assignee', async () => {
+  test('does not remove when reviewer is not an assignee', async () => {
     const state = createTestState();
     state.currentPrData = { assignees: [{ login: 'alice' }] };
-    const ctx = createMockReviewContext({
-      reviewerLogin: 'carol',
-      assignees: [{ login: 'alice' }]
+
+    await removeReviewerFromAssignees({
+      github: createMockGithub(state),
+      context: minimalContext,
+      reviewer: 'carol',
+      prNumber: 123
     });
 
-    await handler({ github: createMockGithub(state), context: ctx });
-
     expect(state.removeAssigneesCalls).toHaveLength(0);
-    expect(state.addAssigneesCalls).toHaveLength(0);
   });
 
-  test('review submitted by someone who was never a reviewer is a no-op', async () => {
+  test('is a no-op when reviewer was never an assignee', async () => {
     const state = createTestState();
     state.currentPrData = { assignees: [] };
-    const ctx = createMockReviewContext({
-      reviewerLogin: 'outsider',
-      assignees: []
+
+    await removeReviewerFromAssignees({
+      github: createMockGithub(state),
+      context: minimalContext,
+      reviewer: 'outsider',
+      prNumber: 123
     });
 
-    await handler({ github: createMockGithub(state), context: ctx });
+    expect(state.removeAssigneesCalls).toHaveLength(0);
+  });
+
+  test('skips when reviewer is missing', async () => {
+    const state = createTestState();
+
+    await removeReviewerFromAssignees({
+      github: createMockGithub(state),
+      context: minimalContext,
+      reviewer: undefined,
+      prNumber: 123
+    });
 
     expect(state.removeAssigneesCalls).toHaveLength(0);
+    expect(state.pullsGetCalls).toBe(0);
+  });
+
+  test('skips when prNumber is invalid', async () => {
+    const state = createTestState();
+
+    await removeReviewerFromAssignees({
+      github: createMockGithub(state),
+      context: minimalContext,
+      reviewer: 'alice',
+      prNumber: 0
+    });
+
+    expect(state.removeAssigneesCalls).toHaveLength(0);
+    expect(state.pullsGetCalls).toBe(0);
   });
 
   test('gracefully handles 403 permission errors on remove', async () => {
-    const ctx = createMockReviewContext({
-      reviewerLogin: 'alice',
-      assignees: [{ login: 'alice' }]
-    });
-
     const errorMock = {
       rest: {
         pulls: { get: async () => ({ data: { assignees: [{ login: 'alice' }] } }) },
@@ -311,15 +327,12 @@ describe('Bot: Add Reviewers as Assignees', () => {
       }
     };
 
-    await expect(handler({ github: errorMock, context: ctx })).resolves.not.toThrow();
+    await expect(
+      removeReviewerFromAssignees({ github: errorMock, context: minimalContext, reviewer: 'alice', prNumber: 123 })
+    ).resolves.not.toThrow();
   });
 
   test('rethrows non-403 errors on remove', async () => {
-    const ctx = createMockReviewContext({
-      reviewerLogin: 'alice',
-      assignees: [{ login: 'alice' }]
-    });
-
     const errorMock = {
       rest: {
         pulls: { get: async () => ({ data: { assignees: [{ login: 'alice' }] } }) },
@@ -334,6 +347,24 @@ describe('Bot: Add Reviewers as Assignees', () => {
       }
     };
 
-    await expect(handler({ github: errorMock, context: ctx })).rejects.toHaveProperty('status', 500);
+    await expect(
+      removeReviewerFromAssignees({ github: errorMock, context: minimalContext, reviewer: 'alice', prNumber: 123 })
+    ).rejects.toHaveProperty('status', 500);
+  });
+
+  // ─── Routing ─────────────────────────────────────────────────────────────────
+
+  test('unhandled event logs warning and does nothing', async () => {
+    const state = createTestState();
+    const ctx = {
+      repo: { owner: 'hiero-ledger', repo: 'hiero-sdk-python' },
+      eventName: 'pull_request_review',
+      payload: { action: 'submitted' }
+    };
+
+    await handler({ github: createMockGithub(state), context: ctx });
+
+    expect(state.addAssigneesCalls).toHaveLength(0);
+    expect(state.removeAssigneesCalls).toHaveLength(0);
   });
 });

--- a/.github/scripts/__tests__/jest/bot-pr-add-reviewers-as-assignees.test.js
+++ b/.github/scripts/__tests__/jest/bot-pr-add-reviewers-as-assignees.test.js
@@ -251,6 +251,7 @@ describe('Bot: Add Reviewers as Assignees', () => {
 
   test('removes reviewer from assignees when they submit a review', async () => {
     const state = createTestState();
+    state.currentPrData = { assignees: [{ login: 'alice' }, { login: 'bob' }] };
     const ctx = createMockReviewContext({
       reviewerLogin: 'alice',
       assignees: [{ login: 'alice' }, { login: 'bob' }]
@@ -265,6 +266,7 @@ describe('Bot: Add Reviewers as Assignees', () => {
 
   test('does not call removeAssignees when reviewer is not an assignee', async () => {
     const state = createTestState();
+    state.currentPrData = { assignees: [{ login: 'alice' }] };
     const ctx = createMockReviewContext({
       reviewerLogin: 'carol',
       assignees: [{ login: 'alice' }]
@@ -278,6 +280,7 @@ describe('Bot: Add Reviewers as Assignees', () => {
 
   test('review submitted by someone who was never a reviewer is a no-op', async () => {
     const state = createTestState();
+    state.currentPrData = { assignees: [] };
     const ctx = createMockReviewContext({
       reviewerLogin: 'outsider',
       assignees: []
@@ -296,7 +299,7 @@ describe('Bot: Add Reviewers as Assignees', () => {
 
     const errorMock = {
       rest: {
-        pulls: { get: async () => ({}) },
+        pulls: { get: async () => ({ data: { assignees: [{ login: 'alice' }] } }) },
         issues: {
           addAssignees: async () => {},
           removeAssignees: async () => {
@@ -319,7 +322,7 @@ describe('Bot: Add Reviewers as Assignees', () => {
 
     const errorMock = {
       rest: {
-        pulls: { get: async () => ({}) },
+        pulls: { get: async () => ({ data: { assignees: [{ login: 'alice' }] } }) },
         issues: {
           addAssignees: async () => {},
           removeAssignees: async () => {

--- a/.github/scripts/__tests__/jest/bot-pr-add-reviewers-as-assignees.test.js
+++ b/.github/scripts/__tests__/jest/bot-pr-add-reviewers-as-assignees.test.js
@@ -16,6 +16,7 @@ describe('Bot: Add Reviewers as Assignees', () => {
 
   const createTestState = () => ({
     addAssigneesCalls: [],
+    removeAssigneesCalls: [],
     pullsGetCalls: 0,
     currentPrData: null,
   });
@@ -24,12 +25,28 @@ describe('Bot: Add Reviewers as Assignees', () => {
     repo: { owner: 'hiero-ledger', repo: 'hiero-sdk-python' },
     eventName: 'pull_request_target',
     payload: {
+      action: 'review_requested',
       pull_request: {
         number: 123,
         requested_reviewers: [],
         requested_teams: [],
         assignees: [],
         ...prData
+      }
+    }
+  });
+
+  const createMockReviewContext = ({ reviewerLogin, assignees = [] } = {}) => ({
+    repo: { owner: 'hiero-ledger', repo: 'hiero-sdk-python' },
+    eventName: 'pull_request_review',
+    payload: {
+      action: 'submitted',
+      review: {
+        user: { login: reviewerLogin }
+      },
+      pull_request: {
+        number: 123,
+        assignees
       }
     }
   });
@@ -53,10 +70,16 @@ describe('Bot: Add Reviewers as Assignees', () => {
         addAssignees: async (params) => {
           state.addAssigneesCalls.push(params);
           return { data: {} };
+        },
+        removeAssignees: async (params) => {
+          state.removeAssigneesCalls.push(params);
+          return { data: {} };
         }
       }
     }
   });
+
+  // ─── Add flow ────────────────────────────────────────────────────────────────
 
   test('adds individual reviewers correctly as assignees', async () => {
     const state = createTestState();
@@ -74,6 +97,23 @@ describe('Bot: Add Reviewers as Assignees', () => {
     expect(state.addAssigneesCalls).toHaveLength(1);
     const call = state.addAssigneesCalls[0];
     expect(call.assignees.sort()).toEqual(['alice', 'bob']);
+  });
+
+  test('adds all requested reviewers as assignees without cap', async () => {
+    const state = createTestState();
+    state.currentPrData = {
+      requested_reviewers: [{ login: 'u1' }, { login: 'u2' }, { login: 'u3' }],
+      assignees: []
+    };
+
+    const ctx = createMockContext({
+      requested_reviewers: [{ login: 'u1' }, { login: 'u2' }, { login: 'u3' }]
+    });
+
+    await handler({ github: createMockGithub(state), context: ctx });
+
+    expect(state.addAssigneesCalls).toHaveLength(1);
+    expect(state.addAssigneesCalls[0].assignees.sort()).toEqual(['u1', 'u2', 'u3']);
   });
 
   test('ignores team reviewers', async () => {
@@ -112,23 +152,6 @@ describe('Bot: Add Reviewers as Assignees', () => {
     expect(state.addAssigneesCalls).toHaveLength(0);
   });
 
-  test('respects MAX_ASSIGNEES = 2 cap', async () => {
-    const state = createTestState();
-    state.currentPrData = {
-      requested_reviewers: [{ login: 'u1' }, { login: 'u2' }, { login: 'u3' }],
-      assignees: []
-    };
-
-    const ctx = createMockContext({
-      requested_reviewers: [{ login: 'u1' }, { login: 'u2' }, { login: 'u3' }]
-    });
-
-    await handler({ github: createMockGithub(state), context: ctx });
-
-    expect(state.addAssigneesCalls).toHaveLength(1);
-    expect(state.addAssigneesCalls[0].assignees).toHaveLength(2);
-  });
-
   test('does nothing when no reviewers are requested', async () => {
     const state = createTestState();
     const ctx = createMockContext({ requested_reviewers: [] });
@@ -150,7 +173,7 @@ describe('Bot: Add Reviewers as Assignees', () => {
     expect(state.addAssigneesCalls).toHaveLength(0);
   });
 
-  test('supports workflow_dispatch with pr_number input', async () => {
+  test('supports workflow_dispatch with pr_number input and routes to add flow', async () => {
     const state = createTestState();
     state.currentPrData = { requested_reviewers: [{ login: 'eve' }], assignees: [] };
 
@@ -164,6 +187,7 @@ describe('Bot: Add Reviewers as Assignees', () => {
 
     expect(state.addAssigneesCalls).toHaveLength(1);
     expect(state.addAssigneesCalls[0].issue_number).toBe(128);
+    expect(state.removeAssigneesCalls).toHaveLength(0);
   });
 
   test('handles invalid pr_number in workflow_dispatch', async () => {
@@ -183,7 +207,7 @@ describe('Bot: Add Reviewers as Assignees', () => {
     }
   });
 
-  test('gracefully handles 403 permission errors', async () => {
+  test('gracefully handles 403 permission errors on add', async () => {
     const ctx = createMockContext({ requested_reviewers: [{ login: 'x' }] });
 
     const errorMock = {
@@ -191,6 +215,91 @@ describe('Bot: Add Reviewers as Assignees', () => {
         pulls: { get: async () => ({ data: { requested_reviewers: [{ login: 'x' }] } }) },
         issues: {
           addAssignees: async () => {
+            const err = new Error('Forbidden');
+            err.status = 403;
+            throw err;
+          },
+          removeAssignees: async () => {}
+        }
+      }
+    };
+
+    await expect(handler({ github: errorMock, context: ctx })).resolves.not.toThrow();
+  });
+
+  test('rethrows non-403 errors on add', async () => {
+    const ctx = createMockContext({ requested_reviewers: [{ login: 'x' }] });
+
+    const errorMock = {
+      rest: {
+        pulls: { get: async () => ({ data: { requested_reviewers: [{ login: 'x' }] } }) },
+        issues: {
+          addAssignees: async () => {
+            const err = new Error('Internal Server Error');
+            err.status = 500;
+            throw err;
+          },
+          removeAssignees: async () => {}
+        }
+      }
+    };
+
+    await expect(handler({ github: errorMock, context: ctx })).rejects.toHaveProperty('status', 500);
+  });
+
+  // ─── Remove flow ─────────────────────────────────────────────────────────────
+
+  test('removes reviewer from assignees when they submit a review', async () => {
+    const state = createTestState();
+    const ctx = createMockReviewContext({
+      reviewerLogin: 'alice',
+      assignees: [{ login: 'alice' }, { login: 'bob' }]
+    });
+
+    await handler({ github: createMockGithub(state), context: ctx });
+
+    expect(state.removeAssigneesCalls).toHaveLength(1);
+    expect(state.removeAssigneesCalls[0].assignees).toEqual(['alice']);
+    expect(state.addAssigneesCalls).toHaveLength(0);
+  });
+
+  test('does not call removeAssignees when reviewer is not an assignee', async () => {
+    const state = createTestState();
+    const ctx = createMockReviewContext({
+      reviewerLogin: 'carol',
+      assignees: [{ login: 'alice' }]
+    });
+
+    await handler({ github: createMockGithub(state), context: ctx });
+
+    expect(state.removeAssigneesCalls).toHaveLength(0);
+    expect(state.addAssigneesCalls).toHaveLength(0);
+  });
+
+  test('review submitted by someone who was never a reviewer is a no-op', async () => {
+    const state = createTestState();
+    const ctx = createMockReviewContext({
+      reviewerLogin: 'outsider',
+      assignees: []
+    });
+
+    await handler({ github: createMockGithub(state), context: ctx });
+
+    expect(state.removeAssigneesCalls).toHaveLength(0);
+  });
+
+  test('gracefully handles 403 permission errors on remove', async () => {
+    const ctx = createMockReviewContext({
+      reviewerLogin: 'alice',
+      assignees: [{ login: 'alice' }]
+    });
+
+    const errorMock = {
+      rest: {
+        pulls: { get: async () => ({}) },
+        issues: {
+          addAssignees: async () => {},
+          removeAssignees: async () => {
             const err = new Error('Forbidden');
             err.status = 403;
             throw err;
@@ -202,14 +311,18 @@ describe('Bot: Add Reviewers as Assignees', () => {
     await expect(handler({ github: errorMock, context: ctx })).resolves.not.toThrow();
   });
 
-  test('rethrows non-403 errors', async () => {
-    const ctx = createMockContext({ requested_reviewers: [{ login: 'x' }] });
+  test('rethrows non-403 errors on remove', async () => {
+    const ctx = createMockReviewContext({
+      reviewerLogin: 'alice',
+      assignees: [{ login: 'alice' }]
+    });
 
     const errorMock = {
       rest: {
-        pulls: { get: async () => ({ data: { requested_reviewers: [{ login: 'x' }] } }) },
+        pulls: { get: async () => ({}) },
         issues: {
-          addAssignees: async () => {
+          addAssignees: async () => {},
+          removeAssignees: async () => {
             const err = new Error('Internal Server Error');
             err.status = 500;
             throw err;

--- a/.github/scripts/__tests__/jest/bot-pr-add-reviewers-as-assignees.test.js
+++ b/.github/scripts/__tests__/jest/bot-pr-add-reviewers-as-assignees.test.js
@@ -312,6 +312,24 @@ describe('Bot: Add Reviewers as Assignees', () => {
     expect(state.pullsGetCalls).toBe(0);
   });
 
+  test('skips when reviewer login does not match valid GitHub login pattern', async () => {
+    const invalidLogins = ['-starts-with-dash', 'has space', 'has@symbol', ''];
+
+    for (const login of invalidLogins) {
+      const state = createTestState();
+
+      await removeReviewerFromAssignees({
+        github: createMockGithub(state),
+        context: minimalContext,
+        reviewer: login,
+        prNumber: 123
+      });
+
+      expect(state.removeAssigneesCalls).toHaveLength(0);
+      expect(state.pullsGetCalls).toBe(0);
+    }
+  });
+
   test('gracefully handles 403 permission errors on remove', async () => {
     const errorMock = {
       rest: {

--- a/.github/scripts/bot-pr-add-reviewers-as-assignees.js
+++ b/.github/scripts/bot-pr-add-reviewers-as-assignees.js
@@ -2,14 +2,14 @@
 
 /**
  * @fileoverview
- * Automatically adds requested individual reviewers as assignees on Pull Requests.
+ * Manages requested individual reviewers as PR assignees.
  *
- * This is part of the generic "on-review" infrastructure.
- * Team reviewers are intentionally ignored (only individual users are assigned).
- * Caps the number of assignees at MAX_ASSIGNEES (default: 2).
+ * - On `review_requested`: adds the reviewer as an assignee (no cap).
+ * - On `pull_request_review` submitted: removes the reviewer from assignees.
+ * - Team reviewers are intentionally ignored (only individual users are assigned).
  */
 
-const { createLogger, MAX_ASSIGNEES, BOT_NAME_ASSIGNEES } = require('./shared/helpers/reviewers-assignee-index.js');
+const { createLogger, BOT_NAME_ASSIGNEES } = require('./shared/helpers/reviewers-assignee-index.js');
 
 const logger = createLogger(BOT_NAME_ASSIGNEES);
 
@@ -59,37 +59,13 @@ function getUsersToAssign(requestedReviewers, currentAssignees) {
 }
 
 /**
- * Logs a warning if some reviewers were dropped due to the assignee cap.
- *
- * @param {Set<string>} usersToAssign
- */
-function logAssigneeCapWarning(usersToAssign, maxToAdd) {
-  if (usersToAssign.size > maxToAdd) {
-    const dropped = Array.from(usersToAssign).slice(maxToAdd);
-    logger.warn(`Assignee cap (${MAX_ASSIGNEES}) reached. Dropping: ${dropped.join(', ')}`);
-  }
-}
-
-/**
- * Main handler that adds requested reviewers as assignees on a PR.
- *
- * Triggered by:
- *   - `pull_request_target: review_requested`
- *   - `workflow_dispatch` (for manual testing)
- *
- * Behavior:
- *   - Only processes individual reviewers (`requested_reviewers`)
- *   - Ignores team reviewers (`requested_teams`)
- *   - Skips users who are already assignees
- *   - Caps at `MAX_ASSIGNEES` (default: 2)
- *   - Logs a warning when reviewers are dropped due to the cap
+ * Adds requested reviewers as PR assignees (no cap on count).
  *
  * @param {Object} params
  * @param {Object} params.github - GitHub Octokit client instance
  * @param {Object} params.context - GitHub Actions context object
- * @returns {Promise<void>}
  */
-module.exports = async ({ github, context }) => {
+async function addReviewersAsAssignees({ github, context }) {
   try {
     const prNumber = resolvePrNumber(context);
     if (!prNumber) return;
@@ -118,10 +94,9 @@ module.exports = async ({ github, context }) => {
     if (requestedTeams.length > 0) {
       logger.info(`${requestedTeams.length} team reviewer(s) detected but ignored (only individual users are assigned)`);
     }
+
     const usersToAssign = getUsersToAssign(requestedReviewers, currentAssignees);
-    const currentCount = currentAssignees.size;
-    const maxNewAssignees = Math.max(0, MAX_ASSIGNEES - currentCount);
-    const assigneesList = Array.from(usersToAssign).slice(0, maxNewAssignees);
+    const assigneesList = Array.from(usersToAssign);
 
     if (assigneesList.length === 0) {
       logger.log('No new users to assign. Done.');
@@ -129,7 +104,6 @@ module.exports = async ({ github, context }) => {
     }
 
     logger.log(`Will assign: ${assigneesList.join(', ')}`);
-    logAssigneeCapWarning(usersToAssign, maxNewAssignees);
 
     await github.rest.issues.addAssignees({
       owner,
@@ -147,5 +121,78 @@ module.exports = async ({ github, context }) => {
       return;
     }
     throw error;
+  }
+}
+
+/**
+ * Removes a reviewer from PR assignees when they submit their review.
+ * Any review state (approved, changes_requested, commented) triggers removal.
+ *
+ * @param {Object} params
+ * @param {Object} params.github - GitHub Octokit client instance
+ * @param {Object} params.context - GitHub Actions context object
+ */
+async function removeReviewerFromAssignees({ github, context }) {
+  try {
+    const reviewer = context.payload.review?.user?.login;
+    const pr = context.payload.pull_request;
+    const prNumber = pr?.number;
+
+    if (!reviewer || !Number.isInteger(prNumber) || prNumber <= 0) {
+      logger.warn('Missing reviewer login or PR number. Skipping removal.');
+      return;
+    }
+
+    const owner = context.repo.owner;
+    const repo = context.repo.repo;
+    const currentAssignees = (pr.assignees || []).map(a => a.login);
+
+    if (!currentAssignees.includes(reviewer)) {
+      logger.log(`${reviewer} is not an assignee on PR #${prNumber}. Nothing to remove.`);
+      return;
+    }
+
+    logger.log(`Removing ${reviewer} from assignees on PR #${prNumber}`);
+
+    await github.rest.issues.removeAssignees({
+      owner,
+      repo,
+      issue_number: prNumber,
+      assignees: [reviewer]
+    });
+
+    logger.log(`✅ Successfully removed ${reviewer} from assignee(s)`);
+
+  } catch (error) {
+    logger.error('Failed to remove assignee:', error.message);
+    if (error.status === 403) {
+      logger.warn(`403 returned: ${error.message}`);
+      return;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Entry point. Routes to add or remove flow based on the triggering event.
+ *
+ * @param {Object} params
+ * @param {Object} params.github - GitHub Octokit client instance
+ * @param {Object} params.context - GitHub Actions context object
+ * @returns {Promise<void>}
+ */
+module.exports = async ({ github, context }) => {
+  const { eventName } = context;
+  const action = context.payload.action;
+
+  if (eventName === 'pull_request_review' && action === 'submitted') {
+    await removeReviewerFromAssignees({ github, context });
+  } else if (
+    (eventName === 'pull_request_target' && action === 'review_requested') ||
+    eventName === 'workflow_dispatch'
+  ) {
+    await addReviewersAsAssignees({ github, context });
+  } else {
+    logger.warn(`Unhandled event: ${eventName} / ${action}. Skipping.`);
   }
 };

--- a/.github/scripts/bot-pr-add-reviewers-as-assignees.js
+++ b/.github/scripts/bot-pr-add-reviewers-as-assignees.js
@@ -4,8 +4,10 @@
  * @fileoverview
  * Manages requested individual reviewers as PR assignees.
  *
- * - On `review_requested`: adds the reviewer as an assignee (no cap).
- * - On `pull_request_review` submitted: removes the reviewer from assignees.
+ * - On `review_requested` (pull_request_target): adds the reviewer as an assignee (no cap).
+ * - On `workflow_run` (triggered by Bot - Capture PR Review): removes the reviewer from
+ *   assignees using a write-token that works for fork PRs. The reviewer login and PR number
+ *   are read from the artifact written by the capture workflow.
  * - Team reviewers are intentionally ignored (only individual users are assigned).
  */
 
@@ -125,18 +127,22 @@ async function addReviewersAsAssignees({ github, context }) {
 }
 
 /**
- * Removes a reviewer from PR assignees when they submit their review.
- * Any review state (approved, changes_requested, commented) triggers removal.
+ * Removes a reviewer from PR assignees after they submit their review.
+ * Called from the workflow_run removal job via named export, passing reviewer
+ * login and PR number read from the capture workflow's artifact.
+ *
+ * Explicit params take priority; falls back to context.payload for direct calls.
  *
  * @param {Object} params
  * @param {Object} params.github - GitHub Octokit client instance
  * @param {Object} params.context - GitHub Actions context object
+ * @param {string} [params.reviewer] - Reviewer login (overrides context payload)
+ * @param {number} [params.prNumber] - PR number (overrides context payload)
  */
-async function removeReviewerFromAssignees({ github, context }) {
+async function removeReviewerFromAssignees({ github, context, reviewer: explicitReviewer, prNumber: explicitPrNumber }) {
   try {
-    const reviewer = context.payload.review?.user?.login;
-    const pr = context.payload.pull_request;
-    const prNumber = pr?.number;
+    const reviewer = explicitReviewer ?? context.payload?.review?.user?.login;
+    const prNumber = explicitPrNumber ?? context.payload?.pull_request?.number;
 
     if (!reviewer || !Number.isInteger(prNumber) || prNumber <= 0) {
       logger.warn('Missing reviewer login or PR number. Skipping removal.');
@@ -146,8 +152,7 @@ async function removeReviewerFromAssignees({ github, context }) {
     const owner = context.repo.owner;
     const repo = context.repo.repo;
 
-    // Fetch live PR data rather than relying on the event payload snapshot,
-    // which may be stale if review_requested ran concurrently and added the assignee after this event fired.
+    // Fetch live PR data to avoid acting on a stale event payload snapshot.
     const livePr = (await github.rest.pulls.get({ owner, repo, pull_number: prNumber })).data;
     const currentAssignees = (livePr.assignees || []).map(a => a.login);
 
@@ -178,7 +183,8 @@ async function removeReviewerFromAssignees({ github, context }) {
 }
 
 /**
- * Entry point. Routes to add or remove flow based on the triggering event.
+ * Entry point for the add flow (pull_request_target + workflow_dispatch).
+ * The remove flow is invoked directly via the named export from the workflow_run job.
  *
  * @param {Object} params
  * @param {Object} params.github - GitHub Octokit client instance
@@ -189,9 +195,7 @@ module.exports = async ({ github, context }) => {
   const { eventName } = context;
   const action = context.payload.action;
 
-  if (eventName === 'pull_request_review' && action === 'submitted') {
-    await removeReviewerFromAssignees({ github, context });
-  } else if (
+  if (
     (eventName === 'pull_request_target' && action === 'review_requested') ||
     eventName === 'workflow_dispatch'
   ) {
@@ -200,3 +204,5 @@ module.exports = async ({ github, context }) => {
     logger.warn(`Unhandled event: ${eventName} / ${action}. Skipping.`);
   }
 };
+
+module.exports.removeReviewerFromAssignees = removeReviewerFromAssignees;

--- a/.github/scripts/bot-pr-add-reviewers-as-assignees.js
+++ b/.github/scripts/bot-pr-add-reviewers-as-assignees.js
@@ -145,7 +145,11 @@ async function removeReviewerFromAssignees({ github, context }) {
 
     const owner = context.repo.owner;
     const repo = context.repo.repo;
-    const currentAssignees = (pr.assignees || []).map(a => a.login);
+
+    // Fetch live PR data rather than relying on the event payload snapshot,
+    // which may be stale if review_requested ran concurrently and added the assignee after this event fired.
+    const livePr = (await github.rest.pulls.get({ owner, repo, pull_number: prNumber })).data;
+    const currentAssignees = (livePr.assignees || []).map(a => a.login);
 
     if (!currentAssignees.includes(reviewer)) {
       logger.log(`${reviewer} is not an assignee on PR #${prNumber}. Nothing to remove.`);

--- a/.github/scripts/bot-pr-add-reviewers-as-assignees.js
+++ b/.github/scripts/bot-pr-add-reviewers-as-assignees.js
@@ -15,6 +15,8 @@ const { createLogger, BOT_NAME_ASSIGNEES } = require('./shared/helpers/reviewers
 
 const logger = createLogger(BOT_NAME_ASSIGNEES);
 
+const VALID_LOGIN_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9-]*$/;
+
 /**
  * Resolves the PR number from context (pull_request_target or workflow_dispatch).
  *
@@ -144,8 +146,8 @@ async function removeReviewerFromAssignees({ github, context, reviewer: explicit
     const reviewer = explicitReviewer ?? context.payload?.review?.user?.login;
     const prNumber = explicitPrNumber ?? context.payload?.pull_request?.number;
 
-    if (!reviewer || !Number.isInteger(prNumber) || prNumber <= 0) {
-      logger.warn('Missing reviewer login or PR number. Skipping removal.');
+    if (!reviewer || !VALID_LOGIN_REGEX.test(reviewer) || !Number.isInteger(prNumber) || prNumber <= 0) {
+      logger.warn('Missing or invalid reviewer login or PR number. Skipping removal.');
       return;
     }
 

--- a/.github/scripts/shared/helpers/constants.js
+++ b/.github/scripts/shared/helpers/constants.js
@@ -7,6 +7,5 @@
  */
 
 module.exports = {
-  MAX_ASSIGNEES: 2,
   BOT_NAME_ASSIGNEES: 'reviewers-assignee',
 };

--- a/.github/scripts/shared/helpers/reviewers-assignee-index.js
+++ b/.github/scripts/shared/helpers/reviewers-assignee-index.js
@@ -10,6 +10,5 @@ const constants = require('./constants.js');
 
 module.exports = {
   createLogger,
-  MAX_ASSIGNEES: constants.MAX_ASSIGNEES,
   BOT_NAME_ASSIGNEES: constants.BOT_NAME_ASSIGNEES,
 };

--- a/.github/workflows/capture-pr-review.yml
+++ b/.github/workflows/capture-pr-review.yml
@@ -25,10 +25,18 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const reviewer = context.payload.review?.user?.login;
+            const prNumber = context.payload.pull_request?.number;
+            if (
+              typeof reviewer !== 'string' ||
+              reviewer.length === 0 ||
+              !Number.isInteger(prNumber) ||
+              prNumber <= 0
+            ) {
+              throw new Error(`Invalid pull_request_review payload: reviewer=${reviewer}, pr_number=${prNumber}`);
+            }
             fs.mkdirSync('review-data', { recursive: true });
-            const reviewer = context.payload.review?.user?.login ?? null;
-            const pr_number = context.payload.pull_request?.number ?? null;
-            fs.writeFileSync('review-data/review.json', JSON.stringify({ reviewer, pr_number }));
+            fs.writeFileSync('review-data/review.json', JSON.stringify({ reviewer, pr_number: prNumber }));
 
       - name: Upload review metadata
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/capture-pr-review.yml
+++ b/.github/workflows/capture-pr-review.yml
@@ -5,8 +5,7 @@ on:
     types:
       - submitted
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   capture:

--- a/.github/workflows/capture-pr-review.yml
+++ b/.github/workflows/capture-pr-review.yml
@@ -1,0 +1,38 @@
+name: Bot - Capture PR Review
+
+on:
+  pull_request_review:
+    types:
+      - submitted
+
+permissions:
+  contents: read
+
+jobs:
+  capture:
+    name: Capture Review Metadata
+    runs-on: hl-sdk-py-lin-md
+    if: "!contains(github.actor, '[bot]')"
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Write review metadata
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            fs.mkdirSync('review-data', { recursive: true });
+            const reviewer = context.payload.review?.user?.login ?? null;
+            const pr_number = context.payload.pull_request?.number ?? null;
+            fs.writeFileSync('review-data/review.json', JSON.stringify({ reviewer, pr_number }));
+
+      - name: Upload review metadata
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: review-data-${{ github.run_id }}
+          path: review-data/review.json
+          retention-days: 1

--- a/.github/workflows/on-review.yml
+++ b/.github/workflows/on-review.yml
@@ -4,9 +4,11 @@ on:
   pull_request_target:
     types:
       - review_requested
-  pull_request_review:
+  workflow_run:
+    workflows:
+      - "Bot - Capture PR Review"
     types:
-      - submitted
+      - completed
   workflow_dispatch:
     inputs:
       pr_number:
@@ -18,12 +20,18 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  actions: read
 
 jobs:
   add-reviewers-as-assignees:
     name: Add Reviewers as Assignees
     runs-on: hl-sdk-py-lin-md
-    if: "!contains(github.actor, '[bot]')"
+    if: |
+      !contains(github.actor, '[bot]') &&
+      (
+        (github.event_name == 'pull_request_target' && github.event.action == 'review_requested') ||
+        github.event_name == 'workflow_dispatch'
+      )
 
     concurrency:
       group: reviewer-assignee-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
@@ -47,3 +55,41 @@ jobs:
           script: |
             const script = require('./.github/scripts/bot-pr-add-reviewers-as-assignees.js');
             await script({ github, context });
+
+  remove-reviewer-from-assignees:
+    name: Remove Reviewer from Assignees
+    runs-on: hl-sdk-py-lin-md
+    if: |
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Download review metadata
+        id: download
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: review-data-${{ github.event.workflow_run.id }}
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Checkout repository
+        if: steps.download.outcome == 'success'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run Remove Reviewer from Assignees
+        if: steps.download.outcome == 'success'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const { reviewer, pr_number: prNumber } = JSON.parse(fs.readFileSync('review.json', 'utf8'));
+            const { removeReviewerFromAssignees } = require('./.github/scripts/bot-pr-add-reviewers-as-assignees.js');
+            await removeReviewerFromAssignees({ github, context, reviewer, prNumber });

--- a/.github/workflows/on-review.yml
+++ b/.github/workflows/on-review.yml
@@ -90,6 +90,14 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const { reviewer, pr_number: prNumber } = JSON.parse(fs.readFileSync('review.json', 'utf8'));
+            const raw = JSON.parse(fs.readFileSync('review.json', 'utf8'));
+            const reviewer = typeof raw.reviewer === 'string' && /^[a-zA-Z0-9][a-zA-Z0-9-]*$/.test(raw.reviewer)
+              ? raw.reviewer : null;
+            const prNumber = Number.isInteger(raw.pr_number) && raw.pr_number > 0
+              ? raw.pr_number : null;
+            if (!reviewer || !prNumber) {
+              core.setFailed(`Invalid artifact contents: reviewer=${raw.reviewer}, pr_number=${raw.pr_number}`);
+              return;
+            }
             const { removeReviewerFromAssignees } = require('./.github/scripts/bot-pr-add-reviewers-as-assignees.js');
             await removeReviewerFromAssignees({ github, context, reviewer, prNumber });

--- a/.github/workflows/on-review.yml
+++ b/.github/workflows/on-review.yml
@@ -61,13 +61,19 @@ jobs:
     runs-on: hl-sdk-py-lin-md
     if: |
       github.event_name == 'workflow_run' &&
-      github.event.workflow_run.conclusion == 'success'
+      github.event.workflow_run.conclusion == 'success' &&
+      !contains(github.event.workflow_run.triggering_actor.login, '[bot]')
 
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Check for review artifact
         id: check
@@ -81,7 +87,7 @@ jobs:
               run_id: context.payload.workflow_run.id
             });
             const found = data.artifacts.some(a => a.name === name && !a.expired);
-            if (!found) core.notice('Review artifact not found; capture job was likely skipped for a bot actor. Nothing to do.');
+            if (!found) core.notice('Review artifact not found; capture job was likely skipped. Nothing to do.');
             core.setOutput('found', String(found));
 
       - name: Download review metadata
@@ -91,12 +97,7 @@ jobs:
           name: review-data-${{ github.event.workflow_run.id }}
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout repository
-        if: steps.check.outputs.found == 'true'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
+          path: artifact
 
       - name: Run Remove Reviewer from Assignees
         if: steps.check.outputs.found == 'true'
@@ -104,7 +105,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const raw = JSON.parse(fs.readFileSync('review.json', 'utf8'));
+            const raw = JSON.parse(fs.readFileSync('artifact/review.json', 'utf8'));
             const reviewer = typeof raw.reviewer === 'string' && /^[a-zA-Z0-9][a-zA-Z0-9-]*$/.test(raw.reviewer)
               ? raw.reviewer : null;
             const prNumber = Number.isInteger(raw.pr_number) && raw.pr_number > 0

--- a/.github/workflows/on-review.yml
+++ b/.github/workflows/on-review.yml
@@ -25,7 +25,12 @@ jobs:
     runs-on: hl-sdk-py-lin-md
 
     concurrency:
-      group: reviewer-assignee-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
+      group: >-
+        ${{
+          github.event_name == 'pull_request_review'
+          && format('reviewer-removal-{0}-{1}', github.event.pull_request.number, github.event.review.user.login)
+          || format('reviewer-assignee-{0}', github.event.pull_request.number || inputs.pr_number || github.run_id)
+        }}
       cancel-in-progress: false
 
     steps:

--- a/.github/workflows/on-review.yml
+++ b/.github/workflows/on-review.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types:
       - review_requested
+  pull_request_review:
+    types:
+      - submitted
   workflow_dispatch:
     inputs:
       pr_number:

--- a/.github/workflows/on-review.yml
+++ b/.github/workflows/on-review.yml
@@ -69,23 +69,37 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Check for review artifact
+        id: check
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const name = `review-data-${context.payload.workflow_run.id}`;
+            const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id
+            });
+            const found = data.artifacts.some(a => a.name === name && !a.expired);
+            if (!found) core.notice('Review artifact not found; capture job was likely skipped for a bot actor. Nothing to do.');
+            core.setOutput('found', String(found));
+
       - name: Download review metadata
-        id: download
+        if: steps.check.outputs.found == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: review-data-${{ github.event.workflow_run.id }}
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true
 
       - name: Checkout repository
-        if: steps.download.outcome == 'success'
+        if: steps.check.outputs.found == 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Run Remove Reviewer from Assignees
-        if: steps.download.outcome == 'success'
+        if: steps.check.outputs.found == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/.github/workflows/on-review.yml
+++ b/.github/workflows/on-review.yml
@@ -23,14 +23,10 @@ jobs:
   add-reviewers-as-assignees:
     name: Add Reviewers as Assignees
     runs-on: hl-sdk-py-lin-md
+    if: "!contains(github.actor, '[bot]')"
 
     concurrency:
-      group: >-
-        ${{
-          github.event_name == 'pull_request_review'
-          && format('reviewer-removal-{0}-{1}', github.event.pull_request.number, github.event.review.user.login)
-          || format('reviewer-assignee-{0}', github.event.pull_request.number || inputs.pr_number || github.run_id)
-        }}
+      group: reviewer-assignee-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
       cancel-in-progress: false
 
     steps:

--- a/.github/workflows/on-review.yml
+++ b/.github/workflows/on-review.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           persist-credentials: false
 
       - name: Run Add Reviewers as Assignees

--- a/.github/workflows/on-review.yml
+++ b/.github/workflows/on-review.yml
@@ -20,7 +20,6 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
-  actions: read
 
 jobs:
   add-reviewers-as-assignees:
@@ -63,6 +62,11 @@ jobs:
       github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'success' &&
       !contains(github.event.workflow_run.triggering_actor.login, '[bot]')
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      actions: read
 
     steps:
       - name: Harden Runner


### PR DESCRIPTION
**Description:**

Make the reviewer-to-assignee bot dynamic: reviewers are added when requested and removed when they submit their review, with no artificial cap on assignee count.

- Add pull_request_review: submitted trigger to on-review.yml
- Update concurrency group to resolve PR number from both event payloads
- Split bot into addReviewersAsAssignees and removeReviewerFromAssignees, routing by eventName + action
- Remove MAX_ASSIGNEES=2 cap — all requested reviewers are now assigned
- Remove logAssigneeCapWarning and maxNewAssignees cap logic
- Mirror existing 403 guard on the removal path
- Add removeAssignees mock to test helpers
- Drop cap assertion; add removal flow tests (happy path, non-assignee no-op, 403, rethrow)
- Add workflow_dispatch routing test confirming it targets the add flow only

**Related issue(s):**

Fixes #2349

**Notes for reviewer:**

The removal fires on any review state (approved, changes_requested, commented) — any submission signals the reviewer has completed their work.

**Checklist**

[x] Documented (Code comments, README, etc.)
[x]Tested (unit, integration, etc.)