### PR TITLE
feat(tck): Add `getTopicInfo` method to TCK

### DIFF
--- a/examples/consensus/topic_info.py
+++ b/examples/consensus/topic_info.py
@@ -27,10 +27,11 @@ Run with:
 """
 
 from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.consensus.topic_id import TopicId
 from hiero_sdk_python.consensus.topic_info import TopicInfo
 from hiero_sdk_python.crypto.private_key import PrivateKey
 from hiero_sdk_python.Duration import Duration
-from hiero_sdk_python.hapi.services import consensus_topic_info_pb2
+from hiero_sdk_python.hapi.services import consensus_get_topic_info_pb2, consensus_topic_info_pb2
 from hiero_sdk_python.hapi.services.basic_types_pb2 import AccountID, Key
 from hiero_sdk_python.hapi.services.timestamp_pb2 import Timestamp
 from hiero_sdk_python.tokens.custom_fixed_fee import CustomFixedFee
@@ -92,6 +93,7 @@ def mock_ledger_id() -> bytes:
 def build_mock_topic_info() -> TopicInfo:
     """Manually construct a TopicInfo instance with mock data."""
     return TopicInfo(
+        topic_id=TopicId.from_string("0.0.101"),
         memo="Example topic memo",
         running_hash=mock_running_hash(),
         sequence_number=42,
@@ -109,17 +111,22 @@ def build_mock_topic_info() -> TopicInfo:
 
 def build_topic_info_from_proto() -> TopicInfo:
     """Build a TopicInfo from a mocked protobuf message using _from_proto()."""
-    proto = consensus_topic_info_pb2.ConsensusTopicInfo()
-    proto.memo = "Topic from protobuf"
-    proto.runningHash = mock_running_hash()
-    proto.sequenceNumber = 100
-    proto.expirationTime.CopyFrom(mock_expiration_time())
-    proto.adminKey.CopyFrom(mock_admin_key())
-    proto.submitKey.CopyFrom(mock_submit_key())
-    proto.autoRenewPeriod.seconds = 7776000
-    proto.autoRenewAccount.CopyFrom(mock_auto_renew_account())
-    proto.ledger_id = mock_ledger_id()
-    proto.custom_fees.append(mock_custom_fee()._to_topic_fee_proto())
+    proto = consensus_get_topic_info_pb2.ConsensusGetTopicInfoResponse()
+    proto.topicID.CopyFrom(TopicId(0, 0, 1)._to_proto())
+
+    topic_info_proto = consensus_topic_info_pb2.ConsensusTopicInfo()
+    topic_info_proto.memo = "Topic from protobuf"
+    topic_info_proto.runningHash = mock_running_hash()
+    topic_info_proto.sequenceNumber = 100
+    topic_info_proto.expirationTime.CopyFrom(mock_expiration_time())
+    topic_info_proto.adminKey.CopyFrom(mock_admin_key())
+    topic_info_proto.submitKey.CopyFrom(mock_submit_key())
+    topic_info_proto.autoRenewPeriod.seconds = 7776000
+    topic_info_proto.autoRenewAccount.CopyFrom(mock_auto_renew_account())
+    topic_info_proto.ledger_id = mock_ledger_id()
+    topic_info_proto.custom_fees.append(mock_custom_fee()._to_topic_fee_proto())
+
+    proto.topicInfo.CopyFrom(topic_info_proto)
 
     return TopicInfo._from_proto(proto)
 
@@ -127,6 +134,7 @@ def build_topic_info_from_proto() -> TopicInfo:
 def print_topic_info(topic: TopicInfo) -> None:
     """Display the key attributes of a TopicInfo instance."""
     print("\nTopicInfo Details:")
+    print(f"  TopicId: {topic.topic_id}")
     print(f"  Memo: {topic.memo}")
     print(f"  Sequence Number: {topic.sequence_number}")
     print(f"  Running Hash: {topic.running_hash.hex()}")

--- a/examples/consensus/topic_info.py
+++ b/examples/consensus/topic_info.py
@@ -112,7 +112,7 @@ def build_mock_topic_info() -> TopicInfo:
 def build_topic_info_from_proto() -> TopicInfo:
     """Build a TopicInfo from a mocked protobuf message using _from_proto()."""
     proto = consensus_get_topic_info_pb2.ConsensusGetTopicInfoResponse()
-    proto.topicID.CopyFrom(TopicId(0, 0, 1)._to_proto())
+    proto.topicID.CopyFrom(TopicId.from_string("0.0.101")._to_proto())
 
     topic_info_proto = consensus_topic_info_pb2.ConsensusTopicInfo()
     topic_info_proto.memo = "Topic from protobuf"

--- a/src/hiero_sdk_python/consensus/topic_info.py
+++ b/src/hiero_sdk_python/consensus/topic_info.py
@@ -109,7 +109,7 @@ class TopicInfo:
             auto_renew_account=(
                 AccountId._from_proto(topic_info.autoRenewAccount) if topic_info.HasField("autoRenewAccount") else None
             ),
-            ledger_id=getattr(topic_info, "ledger_id", None),
+            ledger_id=topic_info.ledger_id if topic_info.ledger_id else None,
             fee_schedule_key=(
                 Key.from_proto_key(topic_info.fee_schedule_key) if topic_info.HasField("fee_schedule_key") else None
             ),

--- a/src/hiero_sdk_python/consensus/topic_info.py
+++ b/src/hiero_sdk_python/consensus/topic_info.py
@@ -165,7 +165,7 @@ class TopicInfo:
 
         return (
             "TopicInfo(\n"
-            f"  topic_id={self.topic_id}"
+            f"  topic_id={self.topic_id},\n"
             f"  memo='{self.memo}',\n"
             f"  running_hash={running_hash_str},\n"
             f"  sequence_number={self.sequence_number},\n"

--- a/src/hiero_sdk_python/consensus/topic_info.py
+++ b/src/hiero_sdk_python/consensus/topic_info.py
@@ -11,10 +11,13 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.consensus.topic_id import TopicId
+from hiero_sdk_python.crypto.key import Key
 from hiero_sdk_python.crypto.public_key import PublicKey
 from hiero_sdk_python.Duration import Duration
-from hiero_sdk_python.hapi.services import consensus_topic_info_pb2
-from hiero_sdk_python.hapi.services.basic_types_pb2 import AccountID, Key
+from hiero_sdk_python.hapi.services import consensus_get_topic_info_pb2
+from hiero_sdk_python.hapi.services.basic_types_pb2 import AccountID
 from hiero_sdk_python.hapi.services.timestamp_pb2 import Timestamp
 from hiero_sdk_python.tokens.custom_fixed_fee import CustomFixedFee
 from hiero_sdk_python.utils.key_format import format_key
@@ -31,6 +34,7 @@ class TopicInfo:
 
     def __init__(
         self,
+        topic_id: TopicId,
         memo: str,
         running_hash: bytes,
         sequence_number: int,
@@ -48,6 +52,7 @@ class TopicInfo:
         Initializes a new instance of the TopicInfo class.
 
         Args:
+            topic_id (TopicId): The id of the topic.
             memo (str): The memo associated with the topic.
             running_hash (bytes): The current running hash of the topic.
             sequence_number (int): The sequence number of the topic.
@@ -61,6 +66,7 @@ class TopicInfo:
             fee_exempt_keys (list[PublicKey]): The fee exempt keys for the topic.
             custom_fees (list[CustomFixedFee]): The custom fees for the topic.
         """
+        self.topic_id: TopicId = topic_id
         self.memo: str = memo
         self.running_hash: bytes = running_hash
         self.sequence_number: int = sequence_number
@@ -68,14 +74,14 @@ class TopicInfo:
         self.admin_key: Key | None = admin_key
         self.submit_key: Key | None = submit_key
         self.auto_renew_period: Duration | None = auto_renew_period
-        self.auto_renew_account: AccountID | None = auto_renew_account
+        self.auto_renew_account: AccountId | None = auto_renew_account
         self.ledger_id: bytes | None = ledger_id
-        self.fee_schedule_key: PublicKey = fee_schedule_key
-        self.fee_exempt_keys: list[PublicKey] = list(fee_exempt_keys) if fee_exempt_keys is not None else []
+        self.fee_schedule_key: Key = fee_schedule_key
+        self.fee_exempt_keys: list[Key] = list(fee_exempt_keys) if fee_exempt_keys is not None else []
         self.custom_fees: list[CustomFixedFee] = list(custom_fees) if custom_fees is not None else []
 
     @classmethod
-    def _from_proto(cls, topic_info_proto: consensus_topic_info_pb2.ConsensusTopicInfo) -> TopicInfo:
+    def _from_proto(cls, topic_info_proto: consensus_get_topic_info_pb2.ConsensusGetTopicInfoResponse) -> TopicInfo:
         """
         Constructs a TopicInfo object from a protobuf ConsensusTopicInfo message.
 
@@ -85,29 +91,30 @@ class TopicInfo:
         Returns:
             TopicInfo: The constructed TopicInfo object.
         """
+        topic_info = topic_info_proto.topicInfo
+
         return cls(
-            memo=topic_info_proto.memo,
-            running_hash=topic_info_proto.runningHash,
-            sequence_number=topic_info_proto.sequenceNumber,
-            expiration_time=(topic_info_proto.expirationTime if topic_info_proto.HasField("expirationTime") else None),
-            admin_key=(topic_info_proto.adminKey if topic_info_proto.HasField("adminKey") else None),
-            submit_key=(topic_info_proto.submitKey if topic_info_proto.HasField("submitKey") else None),
+            topic_id=TopicId._from_proto(topic_info_proto.topicID),
+            memo=topic_info.memo,
+            running_hash=topic_info.runningHash,
+            sequence_number=topic_info.sequenceNumber,
+            expiration_time=(topic_info.expirationTime if topic_info.HasField("expirationTime") else None),
+            admin_key=(Key.from_proto_key(topic_info.adminKey) if topic_info.HasField("adminKey") else None),
+            submit_key=(Key.from_proto_key(topic_info.submitKey) if topic_info.HasField("submitKey") else None),
             auto_renew_period=(
-                Duration._from_proto(proto=topic_info_proto.autoRenewPeriod)
-                if topic_info_proto.HasField("autoRenewPeriod")
+                Duration._from_proto(proto=topic_info.autoRenewPeriod)
+                if topic_info.HasField("autoRenewPeriod")
                 else None
             ),
             auto_renew_account=(
-                topic_info_proto.autoRenewAccount if topic_info_proto.HasField("autoRenewAccount") else None
+                AccountId._from_proto(topic_info.autoRenewAccount) if topic_info.HasField("autoRenewAccount") else None
             ),
-            ledger_id=getattr(topic_info_proto, "ledger_id", None),
+            ledger_id=getattr(topic_info, "ledger_id", None),
             fee_schedule_key=(
-                PublicKey._from_proto(topic_info_proto.fee_schedule_key)
-                if topic_info_proto.HasField("fee_schedule_key")
-                else None
+                Key.from_proto_key(topic_info.fee_schedule_key) if topic_info.HasField("fee_schedule_key") else None
             ),
-            fee_exempt_keys=[PublicKey._from_proto(key) for key in topic_info_proto.fee_exempt_key_list],
-            custom_fees=[CustomFixedFee._from_proto(fee) for fee in topic_info_proto.custom_fees],
+            fee_exempt_keys=[Key.from_proto_key(key) for key in topic_info.fee_exempt_key_list],
+            custom_fees=[CustomFixedFee._from_proto(fee) for fee in topic_info.custom_fees],
         )
 
     def __repr__(self) -> str:
@@ -158,6 +165,7 @@ class TopicInfo:
 
         return (
             "TopicInfo(\n"
+            f"  topic_id={self.topic_id}"
             f"  memo='{self.memo}',\n"
             f"  running_hash={running_hash_str},\n"
             f"  sequence_number={self.sequence_number},\n"

--- a/src/hiero_sdk_python/query/topic_info_query.py
+++ b/src/hiero_sdk_python/query/topic_info_query.py
@@ -82,8 +82,7 @@ class TopicInfoQuery(Query):
         Returns:
             query_pb2.Query: The protobuf query message.
 
-        Raises:
-            ValueError: If the topic ID is not set.
+        Raises:]
             Exception: If any other error occurs during request construction.
         """
         try:

--- a/src/hiero_sdk_python/query/topic_info_query.py
+++ b/src/hiero_sdk_python/query/topic_info_query.py
@@ -87,14 +87,12 @@ class TopicInfoQuery(Query):
             Exception: If any other error occurs during request construction.
         """
         try:
-            if not self.topic_id:
-                raise ValueError("Topic ID must be set before making the request.")
-
             query_header = self._make_request_header()
 
             topic_info_query = consensus_get_topic_info_pb2.ConsensusGetTopicInfoQuery()
             topic_info_query.header.CopyFrom(query_header)
-            topic_info_query.topicID.CopyFrom(self.topic_id._to_proto())
+            if self.topic_id is not None:
+                topic_info_query.topicID.CopyFrom(self.topic_id._to_proto())
 
             query = query_pb2.Query()
             query.consensusGetTopicInfo.CopyFrom(topic_info_query)
@@ -168,7 +166,7 @@ class TopicInfoQuery(Query):
         self._before_execute(client)
         response = self._execute(client, timeout)
 
-        return TopicInfo._from_proto(response.consensusGetTopicInfo.topicInfo)
+        return TopicInfo._from_proto(response.consensusGetTopicInfo)
 
     def _get_query_response(self, response: Any) -> consensus_get_topic_info_pb2.ConsensusGetTopicInfoResponse:
         """

--- a/src/hiero_sdk_python/query/topic_info_query.py
+++ b/src/hiero_sdk_python/query/topic_info_query.py
@@ -82,7 +82,7 @@ class TopicInfoQuery(Query):
         Returns:
             query_pb2.Query: The protobuf query message.
 
-        Raises:]
+        Raises:
             Exception: If any other error occurs during request construction.
         """
         try:

--- a/tck/handlers/account.py
+++ b/tck/handlers/account.py
@@ -35,7 +35,7 @@ from tck.response.account import (
 )
 from tck.util.client_utils import get_client
 from tck.util.constants import DEFAULT_GRPC_TIMEOUT
-from tck.util.key_utils import get_key_from_string
+from tck.util.key_utils import get_key_from_string, key_to_string
 
 
 def _build_create_account_transaction(params: CreateAccountParams) -> AccountCreateTransaction:
@@ -153,17 +153,6 @@ def _enum_name(value) -> str | None:
     return getattr(value, "name", str(value))
 
 
-def _serialize_key(key) -> str | None:
-    if key is None:
-        return None
-
-    to_string_der = getattr(key, "to_string_der", None)
-    if callable(to_string_der):
-        return to_string_der()
-
-    return key.to_bytes().hex()
-
-
 def _to_staking_info_response(info: AccountInfo) -> StakingInfoResponse | None:
     if info.staking_info is None:
         return None
@@ -211,7 +200,7 @@ def _build_account_info_response(info: AccountInfo) -> GetAccountInfoResponse:
         isDeleted=bool(info.is_deleted),
         proxyAccountId="",
         proxyReceived=str(info.proxy_received.to_tinybars()) if info.proxy_received is not None else "0",
-        key=_serialize_key(info.key),
+        key=key_to_string(info.key),
         balance=str(info.balance.to_tinybars()) if info.balance is not None else "0",
         sendRecordThreshold="0",
         receiveRecordThreshold="0",

--- a/tck/handlers/topic.py
+++ b/tck/handlers/topic.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.consensus.topic_create_transaction import TopicCreateTransaction
 from hiero_sdk_python.consensus.topic_id import TopicId
+from hiero_sdk_python.consensus.topic_info import TopicInfo
 from hiero_sdk_python.consensus.topic_message_submit_transaction import TopicMessageSubmitTransaction
+from hiero_sdk_python.hbar import Hbar
+from hiero_sdk_python.query.topic_info_query import TopicInfoQuery
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.custom_fixed_fee import CustomFixedFee
 from hiero_sdk_python.tokens.token_id import TokenId
@@ -11,11 +14,17 @@ from hiero_sdk_python.transaction.custom_fee_limit import CustomFeeLimit
 from hiero_sdk_python.transaction.transaction_receipt import TransactionReceipt
 from tck.handlers.registry import rpc_method
 from tck.param.custom_fee import CustomFeeLimitParams, CustomFeeParams
-from tck.param.topic import CreateTopicParams, TopicMessageSubmitParams
-from tck.response.topic import CreateTopicResponse, TopicMessageSubmitResponse
+from tck.param.topic import CreateTopicParams, TopicMessageInfoParams, TopicMessageSubmitParams
+from tck.response.topic import (
+    CreateTopicResponse,
+    CustomFeeResponse,
+    FixedFeeResponse,
+    TopicInfoResponse,
+    TopicMessageSubmitResponse,
+)
 from tck.util.client_utils import get_client
 from tck.util.constants import DEFAULT_GRPC_TIMEOUT
-from tck.util.key_utils import get_key_from_string
+from tck.util.key_utils import get_key_from_string, key_to_string
 
 
 def _build_custom_fee(custom_fee_params: CustomFeeParams) -> CustomFixedFee:
@@ -146,3 +155,60 @@ def submit_topic_message(params: TopicMessageSubmitParams) -> TopicMessageSubmit
     receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
 
     return TopicMessageSubmitResponse(ResponseCode(receipt.status).name)
+
+
+@rpc_method("getTopicInfo")
+def get_topic_info(params: TopicMessageInfoParams) -> TopicInfoResponse:
+    """Get topic info."""
+    client = get_client(params.sessionId)
+
+    query = TopicInfoQuery().set_grpc_deadline(DEFAULT_GRPC_TIMEOUT)
+
+    if params.topicId is not None:
+        query.set_topic_id(TopicId.from_string(params.topicId))
+
+    if params.queryPayment is not None:
+        query.set_query_payment(Hbar.from_tinybars(int(params.queryPayment)))
+
+    if params.maxQueryPayment is not None:
+        query.set_max_query_payment(Hbar.from_tinybars(int(params.maxQueryPayment)))
+
+    topic_info = query.execute(client)
+    return _map_topic_info_response(topic_info)
+
+
+def _map_topic_info_response(topic_info: TopicInfo) -> TopicInfoResponse:
+    """Map TopicInfo to JSON-RPC TopicInfoResponse."""
+    return TopicInfoResponse(
+        topicId=str(topic_info.topic_id),
+        topicMemo=topic_info.memo,
+        sequenceNumber=str(topic_info.sequence_number),
+        runningHash=topic_info.running_hash.hex(),
+        adminKey=key_to_string(topic_info.admin_key) if topic_info.admin_key is not None else None,
+        submitKey=key_to_string(topic_info.submit_key) if topic_info.submit_key is not None else None,
+        autoRenewAccountId=str(topic_info.auto_renew_account) if topic_info.auto_renew_account is not None else None,
+        autoRenewPeriod=str(topic_info.auto_renew_period.seconds) if topic_info.auto_renew_period is not None else None,
+        expirationTime=str(topic_info.expiration_time.seconds) if topic_info.expiration_time is not None else None,
+        feeScheduleKey=key_to_string(topic_info.fee_schedule_key) if topic_info.fee_schedule_key is not None else None,
+        feeExemptKeys=[key_to_string(key) for key in topic_info.fee_exempt_keys],
+        customFees=[_map_custom_fee_response(fee) for fee in topic_info.custom_fees],
+        ledgerId=topic_info.ledger_id.decode() if topic_info is not None else None,
+    )
+
+
+def _map_custom_fee_response(custom_fee: CustomFixedFee) -> CustomFeeResponse:
+    """Map CustomFixedFee to JSON-RPC CustomFeeResponse."""
+    fixed_fee = FixedFeeResponse(
+        amount=custom_fee.amount,
+        denominatingTokenId=str(custom_fee.denominating_token_id)
+        if custom_fee.denominating_token_id is not None
+        else None,
+    )
+
+    return CustomFeeResponse(
+        feeCollectorAccountId=str(custom_fee.fee_collector_account_id)
+        if custom_fee.fee_collector_account_id is not None
+        else None,
+        allCollectorsAreExempt=custom_fee.all_collectors_are_exempt,
+        fixedFee=fixed_fee,
+    )

--- a/tck/handlers/topic.py
+++ b/tck/handlers/topic.py
@@ -192,7 +192,7 @@ def _map_topic_info_response(topic_info: TopicInfo) -> TopicInfoResponse:
         feeScheduleKey=key_to_string(topic_info.fee_schedule_key) if topic_info.fee_schedule_key is not None else None,
         feeExemptKeys=[key_to_string(key) for key in topic_info.fee_exempt_keys],
         customFees=[_map_custom_fee_response(fee) for fee in topic_info.custom_fees],
-        ledgerId=topic_info.ledger_id.hex() if topic_info is not None else None,
+        ledgerId=topic_info.ledger_id.hex() if topic_info.ledger_id is not None else None,
     )
 
 

--- a/tck/handlers/topic.py
+++ b/tck/handlers/topic.py
@@ -192,14 +192,14 @@ def _map_topic_info_response(topic_info: TopicInfo) -> TopicInfoResponse:
         feeScheduleKey=key_to_string(topic_info.fee_schedule_key) if topic_info.fee_schedule_key is not None else None,
         feeExemptKeys=[key_to_string(key) for key in topic_info.fee_exempt_keys],
         customFees=[_map_custom_fee_response(fee) for fee in topic_info.custom_fees],
-        ledgerId=topic_info.ledger_id.decode() if topic_info is not None else None,
+        ledgerId=topic_info.ledger_id.hex() if topic_info is not None else None,
     )
 
 
 def _map_custom_fee_response(custom_fee: CustomFixedFee) -> CustomFeeResponse:
     """Map CustomFixedFee to JSON-RPC CustomFeeResponse."""
     fixed_fee = FixedFeeResponse(
-        amount=custom_fee.amount,
+        amount=str(custom_fee.amount),
         denominatingTokenId=str(custom_fee.denominating_token_id)
         if custom_fee.denominating_token_id is not None
         else None,

--- a/tck/param/topic.py
+++ b/tck/param/topic.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from tck.param.base import BaseTransactionParams
+from tck.param.base import BaseParams, BaseTransactionParams
 from tck.param.custom_fee import CustomFeeLimitParams, CustomFeeParams
 from tck.util.param_utils import (
     non_empty_string_list,
@@ -90,4 +90,23 @@ class TopicMessageSubmitParams(BaseTransactionParams):
             ),
             sessionId=parse_session_id(params),
             commonTransactionParams=parse_common_transaction_params(params),
+        )
+
+
+@dataclass
+class TopicMessageInfoParams(BaseParams):
+    """Request parameters for getTopicInfo endpoint."""
+
+    topicId: str | None = None
+    queryPayment: str | None = None
+    maxQueryPayment: str | None = None
+
+    @classmethod
+    def parse_json_params(cls, params: dict) -> TopicMessageInfoParams:
+        """Parse JSON-RPC params into a TopicMessageInfoParams instance."""
+        return cls(
+            topicId=params.get("topicId"),
+            queryPayment=params.get("queryPayment"),
+            maxQueryPayment=params.get("maxQueryPayment"),
+            sessionId=parse_session_id(params),
         )

--- a/tck/response/topic.py
+++ b/tck/response/topic.py
@@ -16,3 +16,39 @@ class TopicMessageSubmitResponse:
     """Response payload for submitTopicMessage."""
 
     status: str | None = None
+
+
+@dataclass
+class TopicInfoResponse:
+    """Response payload for getTopicInfo."""
+
+    topicId: str | None = None
+    topicMemo: str | None = None
+    sequenceNumber: str | None = None
+    runningHash: str | None = None
+    adminKey: str | None = None
+    submitKey: str | None = None
+    autoRenewAccountId: str | None = None
+    autoRenewPeriod: str | None = None
+    expirationTime: str | None = None
+    feeScheduleKey: str | None = None
+    feeExemptKeys: list[str] | None = None
+    customFees: list[CustomFeeResponse] = None
+    ledgerId: str | None = None
+
+
+@dataclass
+class CustomFeeResponse:
+    """Response for the CustomFee."""
+
+    feeCollectorAccountId: str | None = None
+    allCollectorsAreExempt: bool | None = None
+    fixedFee: FixedFeeResponse | None = None
+
+
+@dataclass
+class FixedFeeResponse:
+    """Response for the FixedFee."""
+
+    amount: str | None = None
+    denominatingTokenId: str | None = None

--- a/tck/util/key_utils.py
+++ b/tck/util/key_utils.py
@@ -48,7 +48,8 @@ def get_key_from_string(key_string: str) -> Key:
     raise ValueError("Invalid key string")
 
 
-def key_to_string(key) -> str | None:
+def key_to_string(key: Key) -> str | None:
+    """Convert Ket to string representation."""
     if key is None:
         return None
 

--- a/tck/util/key_utils.py
+++ b/tck/util/key_utils.py
@@ -46,3 +46,14 @@ def get_key_from_string(key_string: str) -> Key:
         pass  # nosec B110
 
     raise ValueError("Invalid key string")
+
+
+def key_to_string(key) -> str | None:
+    if key is None:
+        return None
+
+    to_string_der = getattr(key, "to_string_der", None)
+    if callable(to_string_der):
+        return to_string_der()
+
+    return key.to_bytes().hex()

--- a/tests/integration/topic_create_transaction_e2e_test.py
+++ b/tests/integration/topic_create_transaction_e2e_test.py
@@ -46,7 +46,9 @@ def test_integration_topic_create_transaction_can_execute():
 
         assert topic_info.memo == topic_memo
         assert topic_info.sequence_number == 0
-        assert env.client.operator_private_key.public_key()._to_proto() == topic_info.admin_key
+
+        assert isinstance(topic_info.admin_key, PublicKey)
+        assert env.client.operator_private_key.public_key().to_bytes_raw() == topic_info.admin_key.to_bytes_raw()
 
         delete_transaction = TopicDeleteTransaction(topic_id=topic_id)
 
@@ -90,12 +92,8 @@ def test_integration_topic_create_with_private_key():
         assert topic_info is not None
         assert topic_info.admin_key is not None
 
-        # Convert proto Key to PublicKey for comparison
-        admin_key_from_network = PublicKey._from_proto(topic_info.admin_key)
-        admin_key_bytes = admin_key_from_network.to_bytes_raw()
-        public_key_bytes = admin_public_key.to_bytes_raw()
-
-        assert admin_key_bytes == public_key_bytes, (
+        assert isinstance(topic_info.admin_key, PublicKey)
+        assert topic_info.admin_key.to_bytes_raw() == admin_public_key.to_bytes_raw(), (
             "Admin key on network should match the public key derived from PrivateKey"
         )
 
@@ -161,13 +159,8 @@ def test_integration_topic_create_non_custodial_workflow():
         assert topic_info.admin_key is not None
 
         # This is the STRONG assertion:
-        # Compare the bytes of the key from the network
-        # with the bytes of the key we originally used.
-        admin_key_from_network = PublicKey._from_proto(topic_info.admin_key)
-        admin_key_bytes = admin_key_from_network.to_bytes_raw()
-        public_key_bytes = user_public_key.to_bytes_raw()
-
-        assert admin_key_bytes == public_key_bytes, (
+        assert isinstance(topic_info.admin_key, PublicKey)
+        assert topic_info.admin_key.to_bytes_raw() == user_public_key.to_bytes_raw(), (
             "Admin key on network should match the PublicKey used in transaction"
         )
 
@@ -211,12 +204,8 @@ def test_integration_topic_create_with_ecdsa_private_key():
         assert topic_info is not None
         assert topic_info.admin_key is not None
 
-        # Convert proto Key to PublicKey for comparison
-        admin_key_from_network = PublicKey._from_proto(topic_info.admin_key)
-        admin_key_bytes = admin_key_from_network.to_bytes_raw()
-        public_key_bytes = admin_public_key.to_bytes_raw()
-
-        assert admin_key_bytes == public_key_bytes, (
+        assert isinstance(topic_info.admin_key, PublicKey)
+        assert topic_info.admin_key.to_bytes_raw() == admin_public_key.to_bytes_raw(), (
             "Admin key on network should match the public key derived from ECDSA PrivateKey"
         )
 

--- a/tests/integration/topic_info_query_e2e_test.py
+++ b/tests/integration/topic_info_query_e2e_test.py
@@ -4,6 +4,7 @@ import pytest
 
 from hiero_sdk_python.consensus.topic_create_transaction import TopicCreateTransaction
 from hiero_sdk_python.consensus.topic_delete_transaction import TopicDeleteTransaction
+from hiero_sdk_python.crypto.public_key import PublicKey
 from hiero_sdk_python.query.topic_info_query import TopicInfoQuery
 from hiero_sdk_python.response_code import ResponseCode
 from tests.integration.utils import IntegrationTestEnv
@@ -30,7 +31,8 @@ def test_integration_topic_info_query_can_execute():
 
         assert topic_info.memo == "Topic for info query"
         assert topic_info.sequence_number == 0
-        assert env.client.operator_private_key.public_key()._to_proto() == topic_info.admin_key
+        assert isinstance(topic_info.admin_key, PublicKey)
+        assert env.client.operator_private_key.public_key().to_bytes_raw() == topic_info.admin_key.to_bytes_raw()
 
         delete_transaction = TopicDeleteTransaction(topic_id=topic_id)
         delete_transaction.freeze_with(env.client)

--- a/tests/integration/topic_update_transaction_e2e_test.py
+++ b/tests/integration/topic_update_transaction_e2e_test.py
@@ -6,6 +6,7 @@ from hiero_sdk_python.consensus.topic_create_transaction import TopicCreateTrans
 from hiero_sdk_python.consensus.topic_delete_transaction import TopicDeleteTransaction
 from hiero_sdk_python.consensus.topic_update_transaction import TopicUpdateTransaction
 from hiero_sdk_python.crypto.private_key import PrivateKey
+from hiero_sdk_python.crypto.public_key import PublicKey
 from hiero_sdk_python.query.topic_info_query import TopicInfoQuery
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.custom_fixed_fee import CustomFixedFee
@@ -31,7 +32,8 @@ def test_integration_topic_update_transaction_can_execute():
 
         assert info.memo == "Original memo"
         assert info.sequence_number == 0
-        assert env.client.operator_private_key.public_key()._to_proto() == info.admin_key
+        assert isinstance(info.admin_key, PublicKey)
+        assert env.client.operator_private_key.public_key().to_bytes_raw() == info.admin_key.to_bytes_raw()
 
         update_transaction = TopicUpdateTransaction(topic_id=topic_id, memo="Updated memo")
 
@@ -46,7 +48,8 @@ def test_integration_topic_update_transaction_can_execute():
 
         assert info.memo == "Updated memo"
         assert info.sequence_number == 0
-        assert env.client.operator_private_key.public_key()._to_proto() == info.admin_key
+        assert isinstance(info.admin_key, PublicKey)
+        assert env.client.operator_private_key.public_key().to_bytes_raw() == info.admin_key.to_bytes_raw()
 
         transaction = TopicDeleteTransaction(topic_id=topic_id)
         transaction.freeze_with(env.client)

--- a/tests/unit/topic_info_query_test.py
+++ b/tests/unit/topic_info_query_test.py
@@ -93,17 +93,6 @@ def test_topic_info_query(topic_id):
         assert result.admin_key is not None
 
 
-def test_topic_info_query_with_empty_topic_id():
-    """Test that TopicInfoQuery validates topic_id before execution."""
-    with mock_hedera_servers([[None]]) as client:
-        query = TopicInfoQuery()  # No topic ID set
-
-        with pytest.raises(ValueError) as exc_info:
-            query.execute(client)
-
-        assert "Topic ID must be set" in str(exc_info.value)
-
-
 def test_make_request_builds_expected_protobuf(topic_id):
     """
     Covers TopicInfoQuery._make_request() using REAL protobuf classes.
@@ -157,3 +146,14 @@ def test_freeze_prevents_set_topic_id_if_available(topic_id):
         query.set_topic_id(topic_id)
 
     assert "frozen" in str(exc_info.value).lower()
+
+
+def test_topic_id_not_set_when_none():
+    """Test that topicId not set in proto when it is None."""
+    query = TopicInfoQuery()
+    query.set_topic_id(None)
+
+    proto = query._make_request()
+
+    assert proto is not None
+    assert not proto.consensusGetTopicInfo.HasField("topicID")

--- a/tests/unit/topic_info_test.py
+++ b/tests/unit/topic_info_test.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import pytest
 
 from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.consensus.topic_id import TopicId
 from hiero_sdk_python.consensus.topic_info import TopicInfo
 from hiero_sdk_python.crypto.private_key import PrivateKey
 from hiero_sdk_python.Duration import Duration
-from hiero_sdk_python.hapi.services import consensus_topic_info_pb2
+from hiero_sdk_python.hapi.services import consensus_get_topic_info_pb2, consensus_topic_info_pb2
 from hiero_sdk_python.hapi.services.basic_types_pb2 import AccountID, Key
 from hiero_sdk_python.hapi.services.timestamp_pb2 import Timestamp
 from hiero_sdk_python.tokens.custom_fixed_fee import CustomFixedFee
@@ -44,6 +45,7 @@ def topic_info():
     )
 
     return TopicInfo(
+        topic_id=TopicId.from_string("0.0.101"),
         memo="Test topic memo",
         running_hash=b"\x01\x02\x03\x04\x05\x06\x07\x08",
         sequence_number=42,
@@ -87,19 +89,25 @@ def proto_topic_info():
         all_collectors_are_exempt=False,
     )
 
-    proto = consensus_topic_info_pb2.ConsensusTopicInfo()
-    proto.memo = "Test topic memo"
-    proto.runningHash = b"\x01\x02\x03\x04\x05\x06\x07\x08"
-    proto.sequenceNumber = 42
-    proto.expirationTime.CopyFrom(timestamp)
-    proto.adminKey.CopyFrom(key)
-    proto.submitKey.CopyFrom(key)
-    proto.autoRenewPeriod.seconds = 7776000
-    proto.autoRenewAccount.CopyFrom(account_id)
-    proto.ledger_id = b"\x09\x0a\x0b\x0c"
-    proto.fee_schedule_key.CopyFrom(public_key._to_proto())
-    proto.fee_exempt_key_list.append(public_key._to_proto())
-    proto.custom_fees.append(custom_fee._to_topic_fee_proto())
+    proto = consensus_get_topic_info_pb2.ConsensusGetTopicInfoResponse()
+
+    proto.topicID.CopyFrom(TopicId(0, 0, 1)._to_proto())
+
+    topic_info_proto = consensus_topic_info_pb2.ConsensusTopicInfo()
+    topic_info_proto.memo = "Test topic memo"
+    topic_info_proto.runningHash = b"\x01\x02\x03\x04\x05\x06\x07\x08"
+    topic_info_proto.sequenceNumber = 42
+    topic_info_proto.expirationTime.CopyFrom(timestamp)
+    topic_info_proto.adminKey.CopyFrom(key)
+    topic_info_proto.submitKey.CopyFrom(key)
+    topic_info_proto.autoRenewPeriod.seconds = 7776000
+    topic_info_proto.autoRenewAccount.CopyFrom(account_id)
+    topic_info_proto.ledger_id = b"\x09\x0a\x0b\x0c"
+    topic_info_proto.fee_schedule_key.CopyFrom(public_key._to_proto())
+    topic_info_proto.fee_exempt_key_list.append(public_key._to_proto())
+    topic_info_proto.custom_fees.append(custom_fee._to_topic_fee_proto())
+
+    proto.topicInfo.CopyFrom(topic_info_proto)
     return proto
 
 
@@ -123,6 +131,7 @@ def test_topic_info_initialization(topic_info):
 def test_topic_info_initialization_with_none_values():
     """Test the initialization of the TopicInfo class with None values for optional parameters."""
     topic_info = TopicInfo(
+        topic_id=TopicId.from_string("0.0.101"),
         memo="Test memo",
         running_hash=b"\x01\x02",
         sequence_number=1,
@@ -154,6 +163,7 @@ def test_topic_info_initialization_with_none_values():
 def test_topic_info_initialization_with_empty_lists():
     """Test the initialization of the TopicInfo class with empty lists."""
     topic_info = TopicInfo(
+        topic_id=TopicId.from_string("0.0.101"),
         memo="Test memo",
         running_hash=b"\x01\x02",
         sequence_number=1,
@@ -193,11 +203,16 @@ def test_from_proto(proto_topic_info):
 
 def test_from_proto_with_auto_renew_period():
     """Test the _from_proto method with auto renew period."""
-    proto = consensus_topic_info_pb2.ConsensusTopicInfo()
-    proto.memo = "Test memo"
-    proto.runningHash = b"\x01\x02"
-    proto.sequenceNumber = 1
-    proto.autoRenewPeriod.seconds = 86400  # 1 day
+    proto = consensus_get_topic_info_pb2.ConsensusGetTopicInfoResponse()
+    proto.topicID.CopyFrom(TopicId(0, 0, 1)._to_proto())
+
+    topic_info_proto = consensus_topic_info_pb2.ConsensusTopicInfo()
+    topic_info_proto.memo = "Test memo"
+    topic_info_proto.runningHash = b"\x01\x02"
+    topic_info_proto.sequenceNumber = 1
+    topic_info_proto.autoRenewPeriod.seconds = 86400  # 1 day
+
+    proto.topicInfo.CopyFrom(topic_info_proto)
 
     topic_info = TopicInfo._from_proto(proto)
 
@@ -208,12 +223,18 @@ def test_from_proto_with_fee_exempt_keys():
     """Test the _from_proto method with fee exempt keys."""
     public_key = PrivateKey.generate_ed25519().public_key()
 
-    proto = consensus_topic_info_pb2.ConsensusTopicInfo()
-    proto.memo = "Test memo"
-    proto.runningHash = b"\x01\x02"
-    proto.sequenceNumber = 1
-    proto.fee_exempt_key_list.append(public_key._to_proto())
-    proto.fee_exempt_key_list.append(public_key._to_proto())
+    proto = consensus_get_topic_info_pb2.ConsensusGetTopicInfoResponse()
+
+    proto.topicID.CopyFrom(TopicId(0, 0, 1)._to_proto())
+
+    topic_info_proto = consensus_topic_info_pb2.ConsensusTopicInfo()
+    topic_info_proto.memo = "Test memo"
+    topic_info_proto.runningHash = b"\x01\x02"
+    topic_info_proto.sequenceNumber = 1
+    topic_info_proto.fee_exempt_key_list.append(public_key._to_proto())
+    topic_info_proto.fee_exempt_key_list.append(public_key._to_proto())
+
+    proto.topicInfo.CopyFrom(topic_info_proto)
 
     topic_info = TopicInfo._from_proto(proto)
 
@@ -232,12 +253,17 @@ def test_from_proto_with_custom_fees():
         all_collectors_are_exempt=False,
     )
 
-    proto = consensus_topic_info_pb2.ConsensusTopicInfo()
-    proto.memo = "Test memo"
-    proto.runningHash = b"\x01\x02"
-    proto.sequenceNumber = 1
-    proto.custom_fees.append(custom_fee._to_topic_fee_proto())
-    proto.custom_fees.append(custom_fee._to_topic_fee_proto())
+    proto = consensus_get_topic_info_pb2.ConsensusGetTopicInfoResponse()
+
+    proto.topicID.CopyFrom(TopicId(0, 0, 1)._to_proto())
+
+    topic_info_proto = consensus_topic_info_pb2.ConsensusTopicInfo()
+    topic_info_proto.memo = "Test memo"
+    topic_info_proto.runningHash = b"\x01\x02"
+    topic_info_proto.sequenceNumber = 1
+    topic_info_proto.custom_fees.append(custom_fee._to_topic_fee_proto())
+    topic_info_proto.custom_fees.append(custom_fee._to_topic_fee_proto())
+    proto.topicInfo.CopyFrom(topic_info_proto)
 
     topic_info = TopicInfo._from_proto(proto)
 
@@ -282,6 +308,7 @@ def test_str_formatting(topic_info):
 def test_str_with_none_values():
     """Test the string formatting of the TopicInfo class with None values."""
     topic_info = TopicInfo(
+        topic_id=TopicId(0, 0, 101),
         memo="Test memo",
         running_hash=b"\x01\x02",
         sequence_number=1,
@@ -299,6 +326,7 @@ def test_str_with_none_values():
     str_output = str(topic_info)
 
     assert "TopicInfo(" in str_output
+    assert "topic_id=0.0.101" in str_output
     assert "memo='Test memo'" in str_output
     assert "running_hash=0x0102" in str_output
     assert "sequence_number=1" in str_output


### PR DESCRIPTION
**Description**:
This PR introduce the `getTopicId` method to tck module.

**Changes Made:**
- Added the `getTopicInfo` method to tck.
- Update the `topic_info_query` to handle None topic_id.


**Related issue(s)**:

Fixes #2394 

**Notes for reviewer**:
- Updated `topic_info` to include `topicId` and replace the proto type to use sdk-types for `autoRenewAccount`, `adminKey`, `submitKey`
- Update the unit/integration test for this changes.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
