### PR TITLE
Fix 2403 print to logger

### DIFF
--- a/src/hiero_sdk_python/account/account_records_query.py
+++ b/src/hiero_sdk_python/account/account_records_query.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import traceback
+import logging
 
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.channels import _Channel
@@ -14,6 +14,9 @@ from hiero_sdk_python.hapi.services.crypto_get_account_records_pb2 import (
 )
 from hiero_sdk_python.query.query import Query
 from hiero_sdk_python.transaction.transaction_record import TransactionRecord
+
+
+logger = logging.getLogger(__name__)
 
 
 class AccountRecordsQuery(Query):
@@ -76,8 +79,7 @@ class AccountRecordsQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logger.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/client/network.py
+++ b/src/hiero_sdk_python/client/network.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import secrets
 import time
 from typing import Any
@@ -13,6 +14,9 @@ from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.address_book.node_address import NodeAddress
 from hiero_sdk_python.hapi.mirror import consensus_service_pb2_grpc as mirror_consensus_grpc
 from hiero_sdk_python.node import _Node
+
+
+logger = logging.getLogger(__name__)
 
 
 class Network:
@@ -188,7 +192,7 @@ class Network:
         """
         base_url: str | None = self.MIRROR_NODE_URLS.get(self.network)
         if not base_url:
-            print(f"No known mirror node URL for network='{self.network}'. Skipping fetch.")
+            logger.warning("No known mirror node URL for network='%s'. Skipping fetch.", self.network)
             return []
 
         url: str = f"{base_url}/api/v1/network/nodes?limit=100&order=desc"
@@ -209,7 +213,7 @@ class Network:
 
             return nodes
         except requests.RequestException as e:
-            print(f"Error fetching nodes from mirror node API: {e}")
+            logger.error("Error fetching nodes from mirror node API: %s", e)
             return []
 
     def _fetch_nodes_from_default_nodes(self) -> list[_Node]:

--- a/src/hiero_sdk_python/contract/contract_bytecode_query.py
+++ b/src/hiero_sdk_python/contract/contract_bytecode_query.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import traceback
+import logging
 
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
@@ -17,6 +17,9 @@ from hiero_sdk_python.hapi.services.contract_get_bytecode_pb2 import (
     ContractGetBytecodeResponse,
 )
 from hiero_sdk_python.query.query import Query
+
+
+logger = logging.getLogger(__name__)
 
 
 class ContractBytecodeQuery(Query):
@@ -80,8 +83,7 @@ class ContractBytecodeQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logger.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/contract/contract_call_query.py
+++ b/src/hiero_sdk_python/contract/contract_call_query.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import traceback
+import logging
 
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.channels import _Channel
@@ -21,6 +21,9 @@ from hiero_sdk_python.hapi.services import (
     response_pb2,
 )
 from hiero_sdk_python.query.query import Query
+
+
+logger = logging.getLogger(__name__)
 
 
 class ContractCallQuery(Query):
@@ -160,8 +163,7 @@ class ContractCallQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logger.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/contract/contract_info_query.py
+++ b/src/hiero_sdk_python/contract/contract_info_query.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import traceback
+import logging
 
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
@@ -16,6 +16,9 @@ from hiero_sdk_python.hapi.services import (
 )
 from hiero_sdk_python.hapi.services.contract_get_info_pb2 import ContractGetInfoResponse
 from hiero_sdk_python.query.query import Query
+
+
+logger = logging.getLogger(__name__)
 
 
 class ContractInfoQuery(Query):
@@ -76,8 +79,7 @@ class ContractInfoQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logger.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/file/file_contents_query.py
+++ b/src/hiero_sdk_python/file/file_contents_query.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
 from hiero_sdk_python.executable import _Method
@@ -13,6 +15,9 @@ from hiero_sdk_python.hapi.services import (
 )
 from hiero_sdk_python.hapi.services.file_get_contents_pb2 import FileGetContentsResponse
 from hiero_sdk_python.query.query import Query
+
+
+logger = logging.getLogger(__name__)
 
 
 class FileContentsQuery(Query):
@@ -76,7 +81,7 @@ class FileContentsQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
+            logger.error("Exception in _make_request: %s", e)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/file/file_info_query.py
+++ b/src/hiero_sdk_python/file/file_info_query.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import traceback
+import logging
 
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
@@ -12,6 +12,9 @@ from hiero_sdk_python.file.file_info import FileInfo
 from hiero_sdk_python.hapi.services import file_get_info_pb2, query_pb2, response_pb2
 from hiero_sdk_python.hapi.services.file_get_info_pb2 import FileGetInfoResponse
 from hiero_sdk_python.query.query import Query
+
+
+logger = logging.getLogger(__name__)
 
 
 class FileInfoQuery(Query):
@@ -75,8 +78,7 @@ class FileInfoQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logging.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/query/account_balance_query.py
+++ b/src/hiero_sdk_python/query/account_balance_query.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import traceback
+import logging
 from typing import Any
 
 from hiero_sdk_python.account.account_balance import AccountBalance
@@ -11,6 +11,9 @@ from hiero_sdk_python.contract.contract_id import ContractId
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services import crypto_get_account_balance_pb2, query_pb2
 from hiero_sdk_python.query.query import Query
+
+
+logger = logging.getLogger(__name__)
 
 
 class CryptoGetAccountBalanceQuery(Query):
@@ -110,8 +113,7 @@ class CryptoGetAccountBalanceQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logger.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/query/account_info_query.py
+++ b/src/hiero_sdk_python/query/account_info_query.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import logging
+
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.account.account_info import AccountInfo
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services import crypto_get_info_pb2, query_pb2
 from hiero_sdk_python.query.query import Query
+
+
+logger = logging.getLogger(__name__)
 
 
 class AccountInfoQuery(Query):
@@ -67,7 +72,7 @@ class AccountInfoQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
+            logging.error("Exception in _make_request: %s", e)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/query/token_info_query.py
+++ b/src/hiero_sdk_python/query/token_info_query.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
 from hiero_sdk_python.executable import _Method
@@ -7,6 +9,9 @@ from hiero_sdk_python.hapi.services import query_pb2, response_pb2, token_get_in
 from hiero_sdk_python.query.query import Query
 from hiero_sdk_python.tokens.token_id import TokenId
 from hiero_sdk_python.tokens.token_info import TokenInfo
+
+
+logger = logging.getLogger(__name__)
 
 
 class TokenInfoQuery(Query):
@@ -71,7 +76,7 @@ class TokenInfoQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
+            logging.error("Exception in _make_request: %s", e)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/query/token_nft_info_query.py
+++ b/src/hiero_sdk_python/query/token_nft_info_query.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import traceback
+import logging
 
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
@@ -9,6 +9,9 @@ from hiero_sdk_python.hapi.services import query_pb2, response_pb2, token_get_nf
 from hiero_sdk_python.query.query import Query
 from hiero_sdk_python.tokens.nft_id import NftId
 from hiero_sdk_python.tokens.token_nft_info import TokenNftInfo
+
+
+logger = logging.getLogger(__name__)
 
 
 class TokenNftInfoQuery(Query):
@@ -69,8 +72,7 @@ class TokenNftInfoQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logging.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/query/topic_info_query.py
+++ b/src/hiero_sdk_python/query/topic_info_query.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import traceback
+import logging
 from typing import Any
 
 from hiero_sdk_python.channels import _Channel
@@ -11,6 +11,9 @@ from hiero_sdk_python.executable import _ExecutionState, _Method
 from hiero_sdk_python.hapi.services import consensus_get_topic_info_pb2, query_pb2
 from hiero_sdk_python.query.query import Query
 from hiero_sdk_python.response_code import ResponseCode
+
+
+logger = logging.getLogger(__name__)
 
 
 class TopicInfoQuery(Query):
@@ -99,8 +102,7 @@ class TopicInfoQuery(Query):
             return query
 
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logging.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/query/transaction_get_receipt_query.py
+++ b/src/hiero_sdk_python/query/transaction_get_receipt_query.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import traceback
+import logging
 
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
@@ -17,6 +17,9 @@ from hiero_sdk_python.query.query import Query
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 from hiero_sdk_python.transaction.transaction_receipt import TransactionReceipt
+
+
+logger = logging.getLogger(__name__)
 
 
 class TransactionGetReceiptQuery(Query):
@@ -184,8 +187,7 @@ class TransactionGetReceiptQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logging.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/schedule/schedule_info_query.py
+++ b/src/hiero_sdk_python/schedule/schedule_info_query.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import traceback
+import logging
 
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
@@ -12,6 +12,9 @@ from hiero_sdk_python.hapi.services.schedule_get_info_pb2 import ScheduleGetInfo
 from hiero_sdk_python.query.query import Query
 from hiero_sdk_python.schedule.schedule_id import ScheduleId
 from hiero_sdk_python.schedule.schedule_info import ScheduleInfo
+
+
+logger = logging.getLogger(__name__)
 
 
 class ScheduleInfoQuery(Query):
@@ -71,8 +74,7 @@ class ScheduleInfoQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logging.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/tests/unit/query_error_logging_test.py
+++ b/tests/unit/query_error_logging_test.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import inspect
+import logging
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from hiero_sdk_python.account.account_records_query import AccountRecordsQuery
+from hiero_sdk_python.client.network import Network
+from hiero_sdk_python.contract.contract_bytecode_query import ContractBytecodeQuery
+from hiero_sdk_python.contract.contract_call_query import ContractCallQuery
+from hiero_sdk_python.contract.contract_info_query import ContractInfoQuery
+from hiero_sdk_python.file.file_contents_query import FileContentsQuery
+from hiero_sdk_python.file.file_info_query import FileInfoQuery
+from hiero_sdk_python.query.account_balance_query import CryptoGetAccountBalanceQuery
+from hiero_sdk_python.query.account_info_query import AccountInfoQuery
+from hiero_sdk_python.query.token_info_query import TokenInfoQuery
+from hiero_sdk_python.query.token_nft_info_query import TokenNftInfoQuery
+from hiero_sdk_python.query.topic_info_query import TopicInfoQuery
+from hiero_sdk_python.query.transaction_get_receipt_query import TransactionGetReceiptQuery
+from hiero_sdk_python.schedule.schedule_info_query import ScheduleInfoQuery
+
+
+pytestmark = pytest.mark.unit
+
+QUERY_CLASSES = [
+    AccountInfoQuery,
+    FileContentsQuery,
+    TokenInfoQuery,
+    AccountRecordsQuery,
+    ContractBytecodeQuery,
+    ContractCallQuery,
+    ContractInfoQuery,
+    FileInfoQuery,
+    CryptoGetAccountBalanceQuery,
+    TokenNftInfoQuery,
+    TopicInfoQuery,
+    TransactionGetReceiptQuery,
+    ScheduleInfoQuery,
+]
+
+
+@pytest.mark.parametrize("query_cls", QUERY_CLASSES, ids=[c.__name__ for c in QUERY_CLASSES])
+def test_make_request_source_has_no_print_or_traceback_dump(query_cls):
+    """
+    Static regression check preventing accidental reintroduction of
+    print() or traceback.print_exc() in _make_request().
+    """
+    source = inspect.getsource(query_cls._make_request)
+    assert "print(" not in source, f"{query_cls.__name__}._make_request still calls print()"
+    assert "traceback.print_exc()" not in source, (
+        f"{query_cls.__name__}._make_request still calls traceback.print_exc()"
+    )
+
+
+@pytest.mark.parametrize("query_cls", QUERY_CLASSES, ids=[c.__name__ for c in QUERY_CLASSES])
+def test_make_request_logs_exception_via_logging_module(query_cls, caplog):
+    """
+    Verify that _make_request routes exceptions through the logging module
+    instead of printing directly to stdout or stderr.
+
+    The request header is mocked to raise an exception so the error logging
+    path can be exercised consistently across query implementations.
+    """
+    query = query_cls()
+
+    # Some tests disable the SDK's root logger via the shared client fixture.
+    # Override the logger level here so caplog can capture ERROR records.
+    with (
+        patch.object(query_cls, "_make_request_header", side_effect=ValueError("boom")),
+        caplog.at_level(logging.ERROR, logger="hiero_sdk_python"),
+        caplog.at_level(logging.ERROR),
+        pytest.raises(ValueError),
+    ):
+        query._make_request()
+
+    assert any(
+        record.levelno == logging.ERROR and "Exception in _make_request" in record.message for record in caplog.records
+    ), f"No ERROR-level 'Exception in _make_request' log record captured for {query_cls.__name__}"
+
+
+def test_fetch_nodes_from_mirror_node_source_has_no_print(caplog):
+    """
+    Static + dynamic check for the missing-mirror-URL fallback path:
+    no print(), and the warning is captured by the logging module.
+    """
+    source = inspect.getsource(Network._fetch_nodes_from_mirror_node)
+    assert "print(" not in source
+
+    # Bypass __init__ (which would itself raise ValueError for an unknown
+    # network with no mirror URL and no default nodes) -- we only need
+    # `self.network` set to exercise this specific private method.
+    network = Network.__new__(Network)
+    network.network = "not-a-known-network"
+
+    with (
+        caplog.at_level(logging.WARNING, logger="hiero_sdk_python"),
+        caplog.at_level(logging.WARNING, logger="hiero_sdk_python.client.network"),
+    ):
+        result = network._fetch_nodes_from_mirror_node()
+
+    assert result == []
+    assert any(
+        record.levelno == logging.WARNING and "No known mirror node URL" in record.message for record in caplog.records
+    )
+
+
+def test_fetch_nodes_from_mirror_node_logs_request_exception(caplog, monkeypatch):
+    """
+    Static + dynamic check for the mirror-node-fetch-failure fallback path:
+    no print(), and the error is captured by the logging module, with the
+    method still falling back to an empty list rather than raising.
+    """
+    source = inspect.getsource(Network._fetch_nodes_from_mirror_node)
+    assert "print(" not in source
+
+    network = Network.__new__(Network)
+    network.network = "testnet"
+
+    def raise_request_exception(*args, **kwargs):
+        raise requests.RequestException("timeout")
+
+    monkeypatch.setattr("hiero_sdk_python.client.network.requests.get", raise_request_exception)
+
+    with (
+        caplog.at_level(logging.ERROR, logger="hiero_sdk_python"),
+        caplog.at_level(logging.ERROR, logger="hiero_sdk_python.client.network"),
+    ):
+        result = network._fetch_nodes_from_mirror_node()
+
+    assert result == []
+    assert any(
+        record.levelno == logging.ERROR and "Error fetching nodes from mirror node API" in record.message
+        for record in caplog.records
+    )


### PR DESCRIPTION
**Description**:

Replace `print()` and `traceback.print_exc()` calls with structured logging across query and network modules to improve consistency with the SDK's logging practices while preserving existing error-handling behavior.

* Replace `print()` statements with `logger.warning()` and `logger.error()`
* Replace `traceback.print_exc()` with `logger.error(..., exc_info=True)` to preserve stack traces
* Add module-level loggers to the affected query and network modules
* Add regression tests verifying logging behavior using `caplog`
* Add regression tests to prevent reintroduction of `print()` and `traceback.print_exc()` in the affected code paths

**Related issue(s)**:

Fixes #2403

**Notes for reviewer**:
- Ran the local test suite successfully.
- Regression tests cover:
  - Exception logging via the `logging` module
  - Mirror node warning and error logging
  - Prevention of accidental reintroduction of `print()` and `traceback.print_exc()` in the affected methods

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
