### PR TITLE
fix: refetch issue state before final assignment decision 

### DIFF
--- a/.github/scripts/__tests__/jest/bot-assignment-fresh-issue.test.js
+++ b/.github/scripts/__tests__/jest/bot-assignment-fresh-issue.test.js
@@ -1,0 +1,199 @@
+describe('assignment bots use fresh issue state before assigning', () => {
+  let runGfiAssignBot;
+  let runBeginnerAssignBot;
+
+  beforeAll(() => {
+    runGfiAssignBot = require('../../bot-gfi-assign-on-comment.js');
+    runBeginnerAssignBot = require('../../bot-beginner-assign-on-comment.js');
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function createContext({ labelName, payloadAssignees = [], freshLabels, freshAssignees = [], freshState = 'open' }) {
+    const labels = [{ name: labelName }];
+
+    return {
+      repo: {
+        owner: 'hiero-ledger',
+        repo: 'hiero-sdk-python',
+      },
+      payload: {
+        repository: {
+          owner: { login: 'hiero-ledger' },
+          name: 'hiero-sdk-python',
+        },
+        issue: {
+          number: 123,
+          labels,
+          assignees: payloadAssignees,
+        },
+        comment: {
+          body: '/assign',
+          user: {
+            login: 'new-contributor',
+            type: 'User',
+          },
+        },
+      },
+      freshIssue: {
+        number: 123,
+        title: 'Example issue',
+        state: freshState,
+        labels: freshLabels ?? labels,
+        assignees: freshAssignees,
+      },
+    };
+  }
+
+  function createGithubMock(context, { freshIssueError } = {}) {
+    const calls = {
+      comments: [],
+      assignees: [],
+    };
+
+    const github = {
+      rest: {
+        issues: {
+          get: async () => {
+            if (freshIssueError) {
+              throw freshIssueError;
+            }
+            return { data: context.freshIssue };
+          },
+          createComment: async (params) => {
+            calls.comments.push(params);
+            return { data: {} };
+          },
+          addAssignees: async (params) => {
+            calls.assignees.push(params);
+            return { data: {} };
+          },
+        },
+      },
+      paginate: async () => [],
+      graphql: async () => ({ search: { issueCount: 1 } }),
+    };
+
+    return { github, calls };
+  }
+
+  it('GFI bot does not assign when webhook payload is stale but issue is now assigned', async () => {
+    const context = createContext({
+      labelName: 'Good First Issue',
+      payloadAssignees: [],
+      freshAssignees: [{ login: 'current-assignee' }],
+    });
+    const { github, calls } = createGithubMock(context);
+
+    await runGfiAssignBot({ github, context });
+
+    expect(calls.assignees.length).toBe(0);
+    expect(calls.comments.length).toBe(1);
+    expect(calls.comments[0].body).toMatch(/already assigned/i);
+    expect(calls.comments[0].body).toMatch(/@current-assignee/);
+  });
+
+  it('GFI bot exits safely when fresh issue fetch fails before assignment', async () => {
+    const context = createContext({
+      labelName: 'Good First Issue',
+      payloadAssignees: [],
+    });
+    const { github, calls } = createGithubMock(context, {
+      freshIssueError: Object.assign(new Error('GitHub API unavailable'), { status: 503 }),
+    });
+
+    await runGfiAssignBot({ github, context });
+
+    expect(calls.assignees.length).toBe(0);
+    expect(calls.comments.length).toBe(0);
+  });
+
+  it('GFI bot exits when the fresh issue is no longer a Good First Issue', async () => {
+    const context = createContext({
+      labelName: 'Good First Issue',
+      payloadAssignees: [],
+      freshLabels: [{ name: 'help wanted' }],
+    });
+    const { github, calls } = createGithubMock(context);
+
+    await runGfiAssignBot({ github, context });
+
+    expect(calls.assignees.length).toBe(0);
+    expect(calls.comments.length).toBe(0);
+  });
+
+  it('GFI bot exits when the fresh issue is closed before assignment', async () => {
+    const context = createContext({
+      labelName: 'Good First Issue',
+      payloadAssignees: [],
+      freshState: 'closed',
+    });
+    const { github, calls } = createGithubMock(context);
+
+    await runGfiAssignBot({ github, context });
+
+    expect(calls.assignees.length).toBe(0);
+    expect(calls.comments.length).toBe(0);
+  });
+
+  it('beginner bot does not assign when webhook payload is stale but issue is now assigned', async () => {
+    const context = createContext({
+      labelName: 'skill: beginner',
+      payloadAssignees: [],
+      freshAssignees: [{ login: 'current-assignee' }],
+    });
+    const { github, calls } = createGithubMock(context);
+
+    await runBeginnerAssignBot({ github, context });
+
+    expect(calls.assignees.length).toBe(0);
+    expect(calls.comments.length).toBe(1);
+    expect(calls.comments[0].body).toMatch(/already assigned/i);
+    expect(calls.comments[0].body).toMatch(/@current-assignee/);
+  });
+
+  it('beginner bot exits safely when fresh issue fetch fails before assignment', async () => {
+    const context = createContext({
+      labelName: 'skill: beginner',
+      payloadAssignees: [],
+    });
+    const { github, calls } = createGithubMock(context, {
+      freshIssueError: Object.assign(new Error('GitHub API unavailable'), { status: 503 }),
+    });
+
+    await runBeginnerAssignBot({ github, context });
+
+    expect(calls.assignees.length).toBe(0);
+    expect(calls.comments.length).toBe(0);
+  });
+
+  it('beginner bot exits when the fresh issue no longer has the beginner label', async () => {
+    const context = createContext({
+      labelName: 'skill: beginner',
+      payloadAssignees: [],
+      freshLabels: [{ name: 'help wanted' }],
+    });
+    const { github, calls } = createGithubMock(context);
+
+    await runBeginnerAssignBot({ github, context });
+
+    expect(calls.assignees.length).toBe(0);
+    expect(calls.comments.length).toBe(0);
+  });
+
+  it('beginner bot exits when the fresh issue is closed before assignment', async () => {
+    const context = createContext({
+      labelName: 'skill: beginner',
+      payloadAssignees: [],
+      freshState: 'closed',
+    });
+    const { github, calls } = createGithubMock(context);
+
+    await runBeginnerAssignBot({ github, context });
+
+    expect(calls.assignees.length).toBe(0);
+    expect(calls.comments.length).toBe(0);
+  });
+});

--- a/.github/scripts/bot-beginner-assign-on-comment.js
+++ b/.github/scripts/bot-beginner-assign-on-comment.js
@@ -256,9 +256,48 @@ Please try a GFI first, then come back — we’ll be happy to assign this! 😊
       }
 
       // --- ASSIGNMENT LOGIC ---
-      if (issue.assignees && issue.assignees.length > 0) {
+
+      // Refetch current issue state to avoid race conditions from a stale
+      // webhook payload: an earlier queued run may have already assigned
+      // this issue by the time this run executes.
+      let freshIssue;
+      try {
+        const { data } = await github.rest.issues.get({
+          owner: repo.owner.login,
+          repo: repo.name,
+          issue_number: issue.number,
+        });
+        freshIssue = data;
+      } catch (error) {
+        console.error("[Beginner Bot] Failed to refetch issue state, aborting to avoid a stale assignment decision:", {
+          issue: issue.number,
+          message: error.message,
+        });
+        return;
+      }
+
+      console.log("[Beginner Bot] Fresh issue snapshot:", {
+        state: freshIssue.state,
+        assignees: freshIssue.assignees?.map((a) => a.login),
+      });
+
+      if (freshIssue.state === "closed") {
+        console.log(`[Beginner Bot] Issue #${issue.number} is closed. Skipping assignment.`);
+        return;
+      }
+
+      const freshHasBeginnerLabel =
+        Array.isArray(freshIssue.labels) &&
+        freshIssue.labels.some((label) => label.name?.toLowerCase() === beginnerLabel);
+
+      if (!freshHasBeginnerLabel) {
+        console.log(`[Beginner Bot] Issue #${issue.number} no longer has '${BEGINNER_LABEL}' label. Exiting.`);
+        return;
+      }
+
+      if (freshIssue.assignees && freshIssue.assignees.length > 0) {
         try{
-          const currentAssignee = issue.assignees[0]?.login ?? "another contributor";
+          const currentAssignee = freshIssue.assignees[0]?.login ?? "another contributor";
           await github.rest.issues.createComment({
             owner: repo.owner.login,
             repo: repo.name,

--- a/.github/scripts/bot-gfi-assign-on-comment.js
+++ b/.github/scripts/bot-gfi-assign-on-comment.js
@@ -305,19 +305,61 @@ module.exports = async ({ github, context }) => {
         const requesterUsername = comment.user.login;
         const issueNumber = issue.number;
 
-        console.log('[gfi-assign] Requester:', requesterUsername);
-        console.log('[gfi-assign] Current assignees:', issue.assignees?.map(a => a.login));
+        // -------------------------------
+        // REFETCH ISSUE STATE
+        // -------------------------------
+        // context.payload.issue is a snapshot from the original issue_comment
+        // webhook. In a queued/concurrent run, an earlier run may have already
+        // assigned the issue by the time this run executes, so we refetch the
+        // current issue state from the API instead of trusting the stale payload.
+        let freshIssue;
+        try {
+            const { data } = await github.rest.issues.get({
+                owner,
+                repo,
+                issue_number: issueNumber,
+            });
+            freshIssue = data;
+        } catch (error) {
+            console.error('[gfi-assign] Failed to refetch issue state, aborting to avoid a stale assignment decision:', {
+                message: error.message,
+                status: error.status,
+                issueNumber,
+            });
+            return;
+        }
 
-        // Reject if issue is already assigned
+        console.log('[gfi-assign] Fresh issue snapshot:', {
+            state: freshIssue.state,
+            assignees: freshIssue.assignees?.map(a => a.login),
+            labels: freshIssue.labels?.map(l => l.name ?? l),
+        });
+
+        // Reject if the issue was closed between the comment and now
+        if (freshIssue.state === 'closed') {
+            console.log('[gfi-assign] Exit: issue is closed');
+            return;
+        }
+
+        // Reject if the Good First Issue label was removed between the comment and now
+        if (!issueIsGoodFirstIssue(freshIssue)) {
+            console.log('[gfi-assign] Exit: issue no longer labeled Good First Issue');
+            return;
+        }
+
+        console.log('[gfi-assign] Requester:', requesterUsername);
+        console.log('[gfi-assign] Current assignees (fresh):', freshIssue.assignees?.map(a => a.login));
+
+        // Reject if issue is already assigned (checked against fresh state)
         // Comment failure to the requester
-        if (issue.assignees?.length > 0) {
+        if (freshIssue.assignees?.length > 0) {
             console.log('[gfi-assign] Exit: issue already assigned');
 
             await github.rest.issues.createComment({
                 owner,
                 repo,
                 issue_number: issueNumber,
-                body: commentAlreadyAssigned(requesterUsername, issue),
+                body: commentAlreadyAssigned(requesterUsername, freshIssue),
             });
 
             console.log('[gfi-assign] Posted already-assigned comment');


### PR DESCRIPTION
The GFI and beginner /assign bots decided whether to assign based on context.payload.issue, a snapshot from the original webhook payload. Under concurrency, a queued run could still see a stale assignees/ labels/state and call addAssignees on an issue that was already assigned, closed, or relabeled.

Both bots now refetch the issue via github.rest.issues.get() right before the final assignment decision and recheck assignees, state, and label against that fresh data. If the refetch fails, the bot aborts rather than decide on stale data.

Regression tests added under __tests__/jest/ (repo's existing Jest harness, wired into test-scripts.yml) covering: stale-but-now-assigned, refetch failure, label removed, and issue closed — for both bots.

Closes #2230

**Description**:

Refetch current issue state from the GitHub API before the GFI and beginner assignment bots make their final `addAssignees` decision, instead of trusting the original webhook payload.

* Refetch the issue via `github.rest.issues.get()` immediately before assignment in the GFI bot
* Refetch the issue via `github.rest.issues.get()` immediately before assignment in the beginner bot
* Recheck assignees, state, and label against the fresh data (not the stale webhook payload) in both bots
* Abort safely without assigning if the refetch itself fails, rather than deciding on stale data
* Add regression tests under `.github/scripts/__tests__/jest/` (the repo's existing Jest harness, wired into `test-scripts.yml`) covering: stale-but-now-assigned, refetch failure, label removed, and issue closed — for both bots

**Notes for reviewer**:

The GFI and beginner `/assign` bots previously decided whether to assign based on `context.payload.issue`, a snapshot from the original `issue_comment` webhook payload. Under concurrency, a queued run could still see stale assignees/labels/state and call `addAssignees` on an issue that had already been assigned, closed, or relabeled by an earlier run.

Ran the full existing test suite locally after these changes — all passing, no regressions:

**Related issue(s)**:
Fixes #2230 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
