### PR TITLE
feat(tck): implement revokeTokenKyc JSON-RPC method

### DIFF
--- a/tck/handlers/token.py
+++ b/tck/handlers/token.py
@@ -23,6 +23,7 @@ from hiero_sdk_python.tokens.token_freeze_transaction import TokenFreezeTransact
 from hiero_sdk_python.tokens.token_id import TokenId
 from hiero_sdk_python.tokens.token_mint_transaction import TokenMintTransaction
 from hiero_sdk_python.tokens.token_pause_transaction import TokenPauseTransaction
+from hiero_sdk_python.tokens.token_revoke_kyc_transaction import TokenRevokeKycTransaction
 from hiero_sdk_python.tokens.token_type import TokenType
 from hiero_sdk_python.transaction.transaction_receipt import TransactionReceipt
 from tck.handlers.registry import rpc_method
@@ -36,6 +37,7 @@ from tck.param.token import (
     FreezeTokenParams,
     MintTokenParams,
     PauseTokenParams,
+    RevokeKycTokenParams,
 )
 from tck.response.token import (
     AirdropTokenResponse,
@@ -46,6 +48,7 @@ from tck.response.token import (
     FreezeTokenResponse,
     MintTokenResponse,
     PauseTokenResponse,
+    RevokeTokenKycResponse,
 )
 from tck.util.client_utils import get_client
 from tck.util.constants import DEFAULT_GRPC_TIMEOUT
@@ -369,6 +372,35 @@ def pause_token(params: PauseTokenParams) -> PauseTokenResponse:
     receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
 
     return PauseTokenResponse(status=ResponseCode(receipt.status).name)
+
+
+def _build_revoke_kyc_token_transaction(params: RevokeKycTokenParams) -> TokenRevokeKycTransaction:
+    """Build a TokenRevokeKycTransaction from TCK params."""
+    transaction = TokenRevokeKycTransaction().set_grpc_deadline(DEFAULT_GRPC_TIMEOUT)
+
+    if params.tokenId is not None:
+        transaction.set_token_id(TokenId.from_string(params.tokenId))
+
+    if params.accountId is not None:
+        transaction.set_account_id(AccountId.from_string(params.accountId))
+
+    return transaction
+
+
+@rpc_method("revokeTokenKyc")
+def revoke_token_kyc(params: RevokeKycTokenParams) -> RevokeTokenKycResponse:
+    """Revoke KYC for an account on a token using TCK revokeTokenKyc parameters."""
+    client = get_client(params.sessionId)
+
+    transaction = _build_revoke_kyc_token_transaction(params)
+
+    if params.commonTransactionParams is not None:
+        params.commonTransactionParams.apply_common_params(transaction, client)
+
+    response = transaction.execute(client, wait_for_receipt=False)
+    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+
+    return RevokeTokenKycResponse(status=ResponseCode(receipt.status).name)
 
 
 def _build_airdrop_token_transaction(params: AirdropTokenParams) -> TokenAirdropTransaction:

--- a/tck/param/token.py
+++ b/tck/param/token.py
@@ -183,6 +183,24 @@ class PauseTokenParams(BaseTransactionParams):
 
 
 @dataclass
+class RevokeKycTokenParams(BaseTransactionParams):
+    """Request parameters for the revokeTokenKyc endpoint."""
+
+    tokenId: str | None = None
+    accountId: str | None = None
+
+    @classmethod
+    def parse_json_params(cls, params: dict) -> RevokeKycTokenParams:
+        """Parse JSON-RPC params into a RevokeKycTokenParams instance."""
+        return cls(
+            tokenId=params.get("tokenId"),
+            accountId=params.get("accountId"),
+            sessionId=parse_session_id(params),
+            commonTransactionParams=parse_common_transaction_params(params),
+        )
+
+
+@dataclass
 class AirdropTokenParams(BaseTransactionParams):
     """Request parameters for the airdropToken endpoint."""
 

--- a/tck/response/token.py
+++ b/tck/response/token.py
@@ -45,6 +45,11 @@ class PauseTokenResponse(StatusOnlyResponse):
 
 
 @dataclass
+class RevokeTokenKycResponse(StatusOnlyResponse):
+    """Response payload for revokeTokenKyc."""
+
+
+@dataclass
 class AirdropTokenResponse(StatusOnlyResponse):
     """Response payload for airdropToken."""
 

--- a/tests/tck/revoke_token_kyc_handler_test.py
+++ b/tests/tck/revoke_token_kyc_handler_test.py
@@ -1,0 +1,201 @@
+"""Unit tests for the revokeTokenKyc TCK handler."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.response_code import ResponseCode
+from hiero_sdk_python.tokens.token_id import TokenId
+from hiero_sdk_python.tokens.token_revoke_kyc_transaction import TokenRevokeKycTransaction
+from tck.handlers.token import _build_revoke_kyc_token_transaction, revoke_token_kyc
+from tck.param.token import RevokeKycTokenParams
+from tck.response.token import RevokeTokenKycResponse
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestRevokeKycTokenParams:
+    """Tests for RevokeKycTokenParams parsing."""
+
+    def test_parse_json_params_with_all_fields(self):
+        """Parse params with tokenId, accountId, and sessionId."""
+        params = RevokeKycTokenParams.parse_json_params({
+            "tokenId": "0.0.1234",
+            "accountId": "0.0.5678",
+            "sessionId": "test-session",
+        })
+
+        assert params.tokenId == "0.0.1234"
+        assert params.accountId == "0.0.5678"
+        assert params.sessionId == "test-session"
+
+    def test_parse_json_params_with_session_id(self):
+        """Parse params with sessionId."""
+        params = RevokeKycTokenParams.parse_json_params({
+            "tokenId": "0.0.1234",
+            "accountId": "0.0.5678",
+            "sessionId": "test-session",
+        })
+
+        assert params.tokenId == "0.0.1234"
+        assert params.accountId == "0.0.5678"
+        assert params.sessionId == "test-session"
+
+    def test_parse_json_params_with_empty_values(self):
+        """Parse params with empty string values (edge case from TCK spec)."""
+        params = RevokeKycTokenParams.parse_json_params({
+            "tokenId": "",
+            "accountId": "",
+            "sessionId": "test-session",
+        })
+
+        assert params.tokenId == ""
+        assert params.accountId == ""
+
+    def test_parse_json_params_with_missing_fields(self):
+        """Parse params with missing tokenId and accountId."""
+        params = RevokeKycTokenParams.parse_json_params({
+            "sessionId": "test-session",
+        })
+
+        assert params.tokenId is None
+        assert params.accountId is None
+
+
+class TestBuildRevokeKycTransaction:
+    """Tests for _build_revoke_kyc_token_transaction."""
+
+    def test_build_with_token_and_account_id(self):
+        """Transaction should be built with correct token and account IDs."""
+        params = RevokeKycTokenParams(
+            tokenId="0.0.1234",
+            accountId="0.0.5678",
+        )
+
+        transaction = _build_revoke_kyc_token_transaction(params)
+
+        assert isinstance(transaction, TokenRevokeKycTransaction)
+        assert transaction.token_id == TokenId.from_string("0.0.1234")
+        assert transaction.account_id == AccountId.from_string("0.0.5678")
+
+    def test_build_with_no_token_id(self):
+        """Transaction should be built even without tokenId (deferred validation)."""
+        params = RevokeKycTokenParams(accountId="0.0.5678")
+
+        transaction = _build_revoke_kyc_token_transaction(params)
+
+        assert isinstance(transaction, TokenRevokeKycTransaction)
+        assert transaction.token_id is None
+        assert transaction.account_id == AccountId.from_string("0.0.5678")
+
+    def test_build_with_no_account_id(self):
+        """Transaction should be built even without accountId (deferred validation)."""
+        params = RevokeKycTokenParams(tokenId="0.0.1234")
+
+        transaction = _build_revoke_kyc_token_transaction(params)
+
+        assert isinstance(transaction, TokenRevokeKycTransaction)
+        assert transaction.token_id == TokenId.from_string("0.0.1234")
+        assert transaction.account_id is None
+
+
+class TestRevokeTokenKycHandler:
+    """Tests for the revoke_token_kyc RPC handler."""
+
+    @patch("tck.handlers.token.get_client")
+    def test_handler_returns_success_status(self, mock_get_client):
+        """Handler should return the receipt status as response."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_receipt = MagicMock()
+        mock_receipt.status = ResponseCode.SUCCESS
+
+        mock_response = MagicMock()
+        mock_response.get_receipt.return_value = mock_receipt
+
+        with patch.object(TokenRevokeKycTransaction, "execute", return_value=mock_response):
+            params = RevokeKycTokenParams(
+                tokenId="0.0.1234",
+                accountId="0.0.5678",
+            )
+
+            result = revoke_token_kyc(params)
+
+        assert isinstance(result, RevokeTokenKycResponse)
+        assert result.status == "SUCCESS"
+
+    @patch("tck.handlers.token.get_client")
+    def test_handler_returns_failure_status(self, mock_get_client):
+        """Handler should propagate non-SUCCESS status codes."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_receipt = MagicMock()
+        mock_receipt.status = ResponseCode.TOKEN_HAS_NO_KYC_KEY
+
+        mock_response = MagicMock()
+        mock_response.get_receipt.return_value = mock_receipt
+
+        with patch.object(TokenRevokeKycTransaction, "execute", return_value=mock_response):
+            params = RevokeKycTokenParams(
+                tokenId="0.0.1234",
+                accountId="0.0.5678",
+            )
+
+            result = revoke_token_kyc(params)
+
+        assert isinstance(result, RevokeTokenKycResponse)
+        assert result.status == "TOKEN_HAS_NO_KYC_KEY"
+
+    @patch("tck.handlers.token.get_client")
+    def test_handler_applies_common_transaction_params(self, mock_get_client):
+        """Handler should apply common transaction params when present."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_receipt = MagicMock()
+        mock_receipt.status = ResponseCode.SUCCESS
+
+        mock_response = MagicMock()
+        mock_response.get_receipt.return_value = mock_receipt
+
+        mock_common_params = MagicMock()
+
+        with patch.object(TokenRevokeKycTransaction, "execute", return_value=mock_response):
+            params = RevokeKycTokenParams(
+                tokenId="0.0.1234",
+                accountId="0.0.5678",
+                commonTransactionParams=mock_common_params,
+            )
+
+            revoke_token_kyc(params)
+
+        mock_common_params.apply_common_params.assert_called_once()
+
+    @patch("tck.handlers.token.get_client")
+    def test_handler_skips_common_params_when_none(self, mock_get_client):
+        """Handler should not fail when commonTransactionParams is None."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_receipt = MagicMock()
+        mock_receipt.status = ResponseCode.SUCCESS
+
+        mock_response = MagicMock()
+        mock_response.get_receipt.return_value = mock_receipt
+
+        with patch.object(TokenRevokeKycTransaction, "execute", return_value=mock_response):
+            params = RevokeKycTokenParams(
+                tokenId="0.0.1234",
+                accountId="0.0.5678",
+                commonTransactionParams=None,
+            )
+
+            result = revoke_token_kyc(params)
+
+        assert result.status == "SUCCESS"


### PR DESCRIPTION
## What

Implements the `revokeTokenKyc` JSON-RPC method for the TCK (Technology Compatibility Kit) server, enabling the TCK test driver to run `TokenRevokeKycTransaction` test suites.

Resolves #2422

## Why

The `revokeTokenKyc` method was missing from the TCK server, which meant the driver's `TokenRevokeKycTransaction` test specification could not be executed against the Python SDK.

## How

- Added `RevokeKycTokenParams` dataclass in `tck/param/token.py` (mirrors `FreezeTokenParams` — same `tokenId` + `accountId` shape per the [TCK spec](https://github.com/hiero-ledger/hiero-sdk-tck/blob/main/docs/test-specifications/token-service/TokenRevokeKycTransaction.md))
- Added `RevokeTokenKycResponse` dataclass in `tck/response/token.py` (extends `StatusOnlyResponse`)
- Added `revoke_token_kyc` handler and `_build_revoke_kyc_token_transaction` builder in `tck/handlers/token.py`, registered via `@rpc_method("revokeTokenKyc")`
- The handler uses the existing `TokenRevokeKycTransaction` SDK class which already provides `set_token_id` and `set_account_id`
- Added 11 unit tests in `tests/tck/revoke_token_kyc_handler_test.py` covering:
  - Param parsing (all fields, session ID, empty values, missing fields)
  - Transaction building (with/without token ID, with/without account ID)
  - Handler execution (success status, failure status, common params applied, common params skipped)

All tests pass:
```
11 passed in 0.55s
```

The handler is registered alongside existing methods:
```
revokeTokenKyc handler registered: True
All registered methods: [..., revokeTokenKyc, ...]
```

## Notes

- The implementation follows the same pattern as `freezeToken` since both share identical parameter shape and response type
- DCO signed
- No breaking changes