### PR TITLE
chore: Prevent stack trace exposure in the tck error error response

### DIFF
--- a/tck/errors.py
+++ b/tck/errors.py
@@ -113,11 +113,11 @@ def handle_sdk_errors(func):
             raise JsonRpcError.hiero_error({"status": ResponseCode(e.status).name}) from e
 
         except MaxAttemptsError as e:
-            logger.error(f"MaxAttemptsError (method: {func.__name__}, error: {e.message})")
-            raise JsonRpcError.hiero_error(message=e.message) from e
+            logger.error(f"MaxAttemptsError (method: {func.__name__}, error: {str(e)})")
+            raise JsonRpcError.hiero_error() from e
 
         except Exception as e:
             logger.error(f"InternalError (method: {func.__name__}) error: {str(e)}")
-            raise JsonRpcError.internal_error(message="Internal error") from e
+            raise JsonRpcError.internal_error() from e
 
     return wrapper

--- a/tck/errors.py
+++ b/tck/errors.py
@@ -105,19 +105,19 @@ def handle_sdk_errors(func):
         except JsonRpcError:
             raise
         except PrecheckError as e:
-            logger.error(f"PrecheckError (status: {ResponseCode(e.status).name}, method: {func.__name__})")
+            logger.error(f"PrecheckError (method: {func.__name__}, status: {ResponseCode(e.status).name})")
             raise JsonRpcError.hiero_error({"status": ResponseCode(e.status).name}) from e
 
         except ReceiptStatusError as e:
-            logger.error(f"ReceiptStatusError (status: {ResponseCode(e.status).name}, method: {func.__name__})")
+            logger.error(f"ReceiptStatusError (method: {func.__name__}, status: {ResponseCode(e.status).name})")
             raise JsonRpcError.hiero_error({"status": ResponseCode(e.status).name}) from e
 
         except MaxAttemptsError as e:
-            logger.error(f"MaxAttemptsError in {func.__name__}: {e.message}")
+            logger.error(f"MaxAttemptsError (method: {func.__name__}, error: {e.message})")
             raise JsonRpcError.hiero_error(message=e.message) from e
 
         except Exception as e:
-            logger.exception("Unhandled error in RPC handler")
+            logger.error(f"InternalError (method: {func.__name__}) error: {str(e)}")
             raise JsonRpcError.internal_error(message="Internal error") from e
 
     return wrapper

--- a/tck/errors.py
+++ b/tck/errors.py
@@ -113,8 +113,8 @@ def handle_sdk_errors(func):
             raise JsonRpcError.hiero_error({"status": ResponseCode(e.status).name}) from e
 
         except MaxAttemptsError as e:
-            logger.error(f"MaxAttemptsError (method: {func.__name__})")
-            raise JsonRpcError.hiero_error(message=str(e)) from e
+            logger.error(f"MaxAttemptsError in {func.__name__}: {e.message}")
+            raise JsonRpcError.hiero_error(message=e.message) from e
 
         except Exception as e:
             logger.exception("Unhandled error in RPC handler")

--- a/tck/handlers/registry.py
+++ b/tck/handlers/registry.py
@@ -5,12 +5,16 @@ requests to handlers and transform exceptions into JSON-RPC errors.
 from __future__ import annotations
 
 import inspect
+import logging
 from collections.abc import Callable
 from dataclasses import asdict, fields as dc_fields
 from typing import Any, get_type_hints
 
 from tck.errors import JsonRpcError, handle_sdk_errors
 from tck.protocol import build_json_rpc_error_response
+
+
+logger = logging.getLogger(__name__)
 
 
 # A global _HANDLERS dict to store method name -> handler function mappings
@@ -67,7 +71,8 @@ def dispatch(method_name: str, params: Any) -> Any:
     except JsonRpcError:
         raise
     except Exception as e:
-        raise JsonRpcError.internal_error(data=str(e)) from e
+        logger.exception(f"Unexpected error executing {method_name}")
+        raise JsonRpcError.internal_error(message="An unexpected system error occurred.") from e
 
 
 def safe_dispatch(method_name: str, params: Any, request_id: str | int | None) -> Any | dict[str, Any]:
@@ -76,8 +81,9 @@ def safe_dispatch(method_name: str, params: Any, request_id: str | int | None) -
         return dispatch(method_name, params)
     except JsonRpcError as e:
         return build_json_rpc_error_response(e, request_id)
-    except Exception as e:
-        error = JsonRpcError.internal_error(data=str(e))
+    except Exception:
+        logger.exception("Fatal runtime dispatch error")
+        error = JsonRpcError.internal_error(message="An unexpected system error occurred.")
         return build_json_rpc_error_response(error, request_id)
 
 

--- a/tck/handlers/registry.py
+++ b/tck/handlers/registry.py
@@ -48,7 +48,7 @@ def dispatch(method_name: str, params: Any) -> Any:
 
     if handler is None:
         logger.warning(
-            f"MethodNotFoundError (method: {method_name}) error: The requested RPC method is not registered."
+            f"MethodNotFoundError (method: {repr(method_name)}) error: The requested RPC method is not registered."
         )
         raise JsonRpcError.method_not_found_error(message=f"Method not found: {method_name}")
 
@@ -65,7 +65,7 @@ def dispatch(method_name: str, params: Any) -> Any:
             param_type = hints.get(param_name, parameters[0].annotation)
             params = param_type.parse_json_params(params)
         except (TypeError, ValueError) as e:
-            logger.error(f"InvalidParamsError (method: {method_name}) error: {str(e)}")
+            logger.error(f"InvalidParamsError (method: {repr(method_name)}) error: {str(e)}")
             raise JsonRpcError.invalid_params_error(data=str(e)) from e
 
         result = handler(params)
@@ -75,7 +75,7 @@ def dispatch(method_name: str, params: Any) -> Any:
     except JsonRpcError:
         raise
     except Exception as e:
-        logger.error(f"InternalError (method: {method_name}) error: {str(e)}")
+        logger.error(f"InternalError (method: {repr(method_name)}) error: {str(e)}")
         raise JsonRpcError.internal_error(message="An unexpected system error occurred.") from e
 
 
@@ -86,7 +86,7 @@ def safe_dispatch(method_name: str, params: Any, request_id: str | int | None) -
     except JsonRpcError as e:
         return build_json_rpc_error_response(e, request_id)
     except Exception as e:
-        logger.error(f"InternalError (method: {method_name}) error: {str(e)}")
+        logger.error(f"InternalError (method: {repr(method_name)}) error: {str(e)}")
         error = JsonRpcError.internal_error(message="An unexpected system error occurred.")
         return build_json_rpc_error_response(error, request_id)
 

--- a/tck/handlers/registry.py
+++ b/tck/handlers/registry.py
@@ -47,6 +47,9 @@ def dispatch(method_name: str, params: Any) -> Any:
     handler = get_handler(method_name)
 
     if handler is None:
+        logger.warning(
+            f"MethodNotFoundError (method: {method_name}) error: The requested RPC method is not registered."
+        )
         raise JsonRpcError.method_not_found_error(message=f"Method not found: {method_name}")
 
     try:
@@ -62,6 +65,7 @@ def dispatch(method_name: str, params: Any) -> Any:
             param_type = hints.get(param_name, parameters[0].annotation)
             params = param_type.parse_json_params(params)
         except (TypeError, ValueError) as e:
+            logger.error(f"InvalidParamsError (method: {method_name}) error: {str(e)}")
             raise JsonRpcError.invalid_params_error(data=str(e)) from e
 
         result = handler(params)
@@ -71,7 +75,7 @@ def dispatch(method_name: str, params: Any) -> Any:
     except JsonRpcError:
         raise
     except Exception as e:
-        logger.exception(f"Unexpected error executing {method_name}")
+        logger.error(f"InternalError (method: {method_name}) error: {str(e)}")
         raise JsonRpcError.internal_error(message="An unexpected system error occurred.") from e
 
 
@@ -81,8 +85,8 @@ def safe_dispatch(method_name: str, params: Any, request_id: str | int | None) -
         return dispatch(method_name, params)
     except JsonRpcError as e:
         return build_json_rpc_error_response(e, request_id)
-    except Exception:
-        logger.exception("Fatal runtime dispatch error")
+    except Exception as e:
+        logger.error(f"InternalError (method: {method_name}) error: {str(e)}")
         error = JsonRpcError.internal_error(message="An unexpected system error occurred.")
         return build_json_rpc_error_response(error, request_id)
 

--- a/tck/handlers/registry.py
+++ b/tck/handlers/registry.py
@@ -50,7 +50,7 @@ def dispatch(method_name: str, params: Any) -> Any:
         logger.warning(
             f"MethodNotFoundError (method: {repr(method_name)}) error: The requested RPC method is not registered."
         )
-        raise JsonRpcError.method_not_found_error(message=f"Method not found: {method_name}")
+        raise JsonRpcError.method_not_found_error()
 
     try:
         target_func = getattr(handler, "__wrapped__", handler)
@@ -72,11 +72,12 @@ def dispatch(method_name: str, params: Any) -> Any:
 
         return parse_result(result)
 
-    except JsonRpcError:
+    except JsonRpcError as e:
+        logger.error(f"JsonRpcError (method: {repr(method_name)}) error: {str(e)}")
         raise
     except Exception as e:
         logger.error(f"InternalError (method: {repr(method_name)}) error: {str(e)}")
-        raise JsonRpcError.internal_error(message="An unexpected system error occurred.") from e
+        raise JsonRpcError.internal_error() from e
 
 
 def safe_dispatch(method_name: str, params: Any, request_id: str | int | None) -> Any | dict[str, Any]:
@@ -84,10 +85,11 @@ def safe_dispatch(method_name: str, params: Any, request_id: str | int | None) -
     try:
         return dispatch(method_name, params)
     except JsonRpcError as e:
+        logger.error(f"JsonRpcError (method: {repr(method_name)}) error: {str(e)}")
         return build_json_rpc_error_response(e, request_id)
     except Exception as e:
         logger.error(f"InternalError (method: {repr(method_name)}) error: {str(e)}")
-        error = JsonRpcError.internal_error(message="An unexpected system error occurred.")
+        error = JsonRpcError.internal_error()
         return build_json_rpc_error_response(error, request_id)
 
 


### PR DESCRIPTION
**Description**:
This PR silence error details in JSON-RPC error responses and improve logging for the errors.

**Related issue(s)**:

Fixes #2416

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
