### PR TITLE
feat(tck): implement dissociateToken JSON-RPC method

### DIFF
--- a/tck/handlers/token.py
+++ b/tck/handlers/token.py
@@ -21,6 +21,7 @@ from hiero_sdk_python.tokens.token_airdrop_transaction import TokenAirdropTransa
 from hiero_sdk_python.tokens.token_associate_transaction import TokenAssociateTransaction
 from hiero_sdk_python.tokens.token_create_transaction import TokenCreateTransaction
 from hiero_sdk_python.tokens.token_delete_transaction import TokenDeleteTransaction
+from hiero_sdk_python.tokens.token_dissociate_transaction import TokenDissociateTransaction
 from hiero_sdk_python.tokens.token_freeze_status import TokenFreezeStatus
 from hiero_sdk_python.tokens.token_freeze_transaction import TokenFreezeTransaction
 from hiero_sdk_python.tokens.token_grant_kyc_transaction import TokenGrantKycTransaction
@@ -41,6 +42,7 @@ from tck.param.token import (
     ClaimTokenParams,
     CreateTokenParams,
     DeleteTokenParams,
+    DissociateTokenParams,
     FreezeTokenParams,
     GetTokenInfoParams,
     GrantTokenKycParams,
@@ -55,6 +57,7 @@ from tck.response.token import (
     CreateTokenResponse,
     CustomFeeResponse,
     DeleteTokenResponse,
+    DissociateTokenResponse,
     FreezeTokenResponse,
     GetTokenInfoResponse,
     GrantTokenKycResponse,
@@ -289,6 +292,20 @@ def _build_associate_token_transaction(params: AssociateTokenParams) -> TokenAss
     return transaction
 
 
+def _build_dissociate_token_transaction(params: DissociateTokenParams) -> TokenDissociateTransaction:
+    """Build a TokenDissociateTransaction from TCK params."""
+    transaction = TokenDissociateTransaction().set_grpc_deadline(DEFAULT_GRPC_TIMEOUT)
+
+    if params.accountId is not None:
+        transaction.set_account_id(AccountId.from_string(params.accountId))
+
+    if params.tokenIds is not None:
+        token_ids = [TokenId.from_string(tid) for tid in params.tokenIds]
+        transaction.set_token_ids(token_ids)
+
+    return transaction
+
+
 def _build_delete_token_transaction(params: DeleteTokenParams) -> TokenDeleteTransaction:
     """Build a TokenDeleteTransaction from TCK params."""
     transaction = TokenDeleteTransaction().set_grpc_deadline(DEFAULT_GRPC_TIMEOUT)
@@ -372,6 +389,22 @@ def delete_token(params: DeleteTokenParams) -> DeleteTokenResponse:
     receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
 
     return DeleteTokenResponse(status=ResponseCode(receipt.status).name)
+
+
+@rpc_method("dissociateToken")
+def dissociate_token(params: DissociateTokenParams) -> DissociateTokenResponse:
+    """Dissociate tokens from an account using TCK dissociateToken parameters."""
+    client = get_client(params.sessionId)
+
+    transaction = _build_dissociate_token_transaction(params)
+
+    if params.commonTransactionParams is not None:
+        params.commonTransactionParams.apply_common_params(transaction, client)
+
+    response = transaction.execute(client, wait_for_receipt=False)
+    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+
+    return DissociateTokenResponse(status=ResponseCode(receipt.status).name)
 
 
 @rpc_method("freezeToken")

--- a/tck/param/token.py
+++ b/tck/param/token.py
@@ -167,6 +167,30 @@ class FreezeTokenParams(BaseTransactionParams):
 
 
 @dataclass
+class DissociateTokenParams(BaseTransactionParams):
+    """Request parameters for the dissociateToken endpoint."""
+
+    accountId: str | None = None
+    tokenIds: list[str] | None = None
+
+    @classmethod
+    def parse_json_params(cls, params: dict) -> DissociateTokenParams:
+        """Parse JSON-RPC params into a DissociateTokenParams instance."""
+        token_ids = params.get("tokenIds")
+        if token_ids is not None and not isinstance(token_ids, list):
+            raise ValueError("tokenIds must be a list")
+        if token_ids is not None and any(not isinstance(token_id, str) for token_id in token_ids):
+            raise ValueError("each tokenIds item must be a string")
+
+        return cls(
+            accountId=params.get("accountId"),
+            tokenIds=token_ids,
+            sessionId=parse_session_id(params),
+            commonTransactionParams=parse_common_transaction_params(params),
+        )
+
+
+@dataclass
 class GrantTokenKycParams(BaseTransactionParams):
     """Request parameters for the grantTokenKyc endpoint."""
 

--- a/tck/response/token.py
+++ b/tck/response/token.py
@@ -35,6 +35,11 @@ class DeleteTokenResponse(StatusOnlyResponse):
 
 
 @dataclass
+class DissociateTokenResponse(StatusOnlyResponse):
+    """Response payload for dissociateToken."""
+
+
+@dataclass
 class FreezeTokenResponse(StatusOnlyResponse):
     """Response payload for freezeToken."""
 


### PR DESCRIPTION
## Description

Add support for the `dissociateToken` TCK JSON-RPC method by mirroring the
existing `associateToken` implementation.

- Add `DissociateTokenParams`
- Add `DissociateTokenResponse`
- Add the `dissociateToken` JSON-RPC handler using `TokenDissociateTransaction`

## Related issue(s)

Fixes #2418

## Notes for reviewer

- Implementation mirrors the existing `associateToken` handler.
- Reuses the existing `commonTransactionParams` flow.
- Returns a status-only response, consistent with the TCK specification.

## Checklist

- [x] Documented
- [x] Tested 
