### PR TITLE
chore: Replace print statements with logger

### DIFF
--- a/src/hiero_sdk_python/account/account_records_query.py
+++ b/src/hiero_sdk_python/account/account_records_query.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import traceback
+import logging
 
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.channels import _Channel
@@ -14,6 +14,9 @@ from hiero_sdk_python.hapi.services.crypto_get_account_records_pb2 import (
 )
 from hiero_sdk_python.query.query import Query
 from hiero_sdk_python.transaction.transaction_record import TransactionRecord
+
+
+logger = logging.getLogger(__name__)
 
 
 class AccountRecordsQuery(Query):
@@ -76,8 +79,7 @@ class AccountRecordsQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logger.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/client/network.py
+++ b/src/hiero_sdk_python/client/network.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import secrets
 import time
 from typing import Any
@@ -13,6 +14,9 @@ from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.address_book.node_address import NodeAddress
 from hiero_sdk_python.hapi.mirror import consensus_service_pb2_grpc as mirror_consensus_grpc
 from hiero_sdk_python.node import _Node
+
+
+logger = logging.getLogger(__name__)
 
 
 class Network:
@@ -188,7 +192,7 @@ class Network:
         """
         base_url: str | None = self.MIRROR_NODE_URLS.get(self.network)
         if not base_url:
-            print(f"No known mirror node URL for network='{self.network}'. Skipping fetch.")
+            logger.warning("No known mirror node URL for network='%s'. Skipping fetch.", self.network)
             return []
 
         url: str = f"{base_url}/api/v1/network/nodes?limit=100&order=desc"
@@ -209,7 +213,7 @@ class Network:
 
             return nodes
         except requests.RequestException as e:
-            print(f"Error fetching nodes from mirror node API: {e}")
+            logger.error("Error fetching nodes from mirror node API: %s", e)
             return []
 
     def _fetch_nodes_from_default_nodes(self) -> list[_Node]:

--- a/src/hiero_sdk_python/client/network.py
+++ b/src/hiero_sdk_python/client/network.py
@@ -215,6 +215,9 @@ class Network:
         except requests.RequestException as e:
             logger.error("Error fetching nodes from mirror node API: %s", e)
             return []
+        except (ValueError, KeyError, TypeError, IndexError, AttributeError) as e:
+            logger.error("Error parsing mirror node API response: %s", e, exc_info=True)
+            return []
 
     def _fetch_nodes_from_default_nodes(self) -> list[_Node]:
         """Fetches the list of nodes from the default nodes for the network."""

--- a/src/hiero_sdk_python/contract/contract_bytecode_query.py
+++ b/src/hiero_sdk_python/contract/contract_bytecode_query.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import traceback
+import logging
 
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
@@ -17,6 +17,9 @@ from hiero_sdk_python.hapi.services.contract_get_bytecode_pb2 import (
     ContractGetBytecodeResponse,
 )
 from hiero_sdk_python.query.query import Query
+
+
+logger = logging.getLogger(__name__)
 
 
 class ContractBytecodeQuery(Query):
@@ -80,8 +83,7 @@ class ContractBytecodeQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logger.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/contract/contract_call_query.py
+++ b/src/hiero_sdk_python/contract/contract_call_query.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import traceback
+import logging
 
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.channels import _Channel
@@ -21,6 +21,9 @@ from hiero_sdk_python.hapi.services import (
     response_pb2,
 )
 from hiero_sdk_python.query.query import Query
+
+
+logger = logging.getLogger(__name__)
 
 
 class ContractCallQuery(Query):
@@ -160,8 +163,7 @@ class ContractCallQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logger.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/contract/contract_info_query.py
+++ b/src/hiero_sdk_python/contract/contract_info_query.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import traceback
+import logging
 
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
@@ -16,6 +16,9 @@ from hiero_sdk_python.hapi.services import (
 )
 from hiero_sdk_python.hapi.services.contract_get_info_pb2 import ContractGetInfoResponse
 from hiero_sdk_python.query.query import Query
+
+
+logger = logging.getLogger(__name__)
 
 
 class ContractInfoQuery(Query):
@@ -76,8 +79,7 @@ class ContractInfoQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logger.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/file/file_contents_query.py
+++ b/src/hiero_sdk_python/file/file_contents_query.py
@@ -81,7 +81,7 @@ class FileContentsQuery(Query):
 
             return query
         except Exception as e:
-            logger.error("Exception in _make_request: %s", e)
+            logger.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/file/file_contents_query.py
+++ b/src/hiero_sdk_python/file/file_contents_query.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
 from hiero_sdk_python.executable import _Method
@@ -13,6 +15,9 @@ from hiero_sdk_python.hapi.services import (
 )
 from hiero_sdk_python.hapi.services.file_get_contents_pb2 import FileGetContentsResponse
 from hiero_sdk_python.query.query import Query
+
+
+logger = logging.getLogger(__name__)
 
 
 class FileContentsQuery(Query):
@@ -76,7 +81,7 @@ class FileContentsQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
+            logger.error("Exception in _make_request: %s", e)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/file/file_info_query.py
+++ b/src/hiero_sdk_python/file/file_info_query.py
@@ -78,7 +78,7 @@ class FileInfoQuery(Query):
 
             return query
         except Exception as e:
-            logging.error("Exception in _make_request: %s", e, exc_info=True)
+            logger.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/file/file_info_query.py
+++ b/src/hiero_sdk_python/file/file_info_query.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import traceback
+import logging
 
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
@@ -12,6 +12,9 @@ from hiero_sdk_python.file.file_info import FileInfo
 from hiero_sdk_python.hapi.services import file_get_info_pb2, query_pb2, response_pb2
 from hiero_sdk_python.hapi.services.file_get_info_pb2 import FileGetInfoResponse
 from hiero_sdk_python.query.query import Query
+
+
+logger = logging.getLogger(__name__)
 
 
 class FileInfoQuery(Query):
@@ -75,8 +78,7 @@ class FileInfoQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logging.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/query/account_balance_query.py
+++ b/src/hiero_sdk_python/query/account_balance_query.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import traceback
+import logging
 from typing import Any
 
 from hiero_sdk_python.account.account_balance import AccountBalance
@@ -11,6 +11,9 @@ from hiero_sdk_python.contract.contract_id import ContractId
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services import crypto_get_account_balance_pb2, query_pb2
 from hiero_sdk_python.query.query import Query
+
+
+logger = logging.getLogger(__name__)
 
 
 class CryptoGetAccountBalanceQuery(Query):
@@ -110,8 +113,7 @@ class CryptoGetAccountBalanceQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logger.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/query/account_info_query.py
+++ b/src/hiero_sdk_python/query/account_info_query.py
@@ -72,7 +72,7 @@ class AccountInfoQuery(Query):
 
             return query
         except Exception as e:
-            logging.error("Exception in _make_request: %s", e)
+            logger.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/query/account_info_query.py
+++ b/src/hiero_sdk_python/query/account_info_query.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import logging
+
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.account.account_info import AccountInfo
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services import crypto_get_info_pb2, query_pb2
 from hiero_sdk_python.query.query import Query
+
+
+logger = logging.getLogger(__name__)
 
 
 class AccountInfoQuery(Query):
@@ -67,7 +72,7 @@ class AccountInfoQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
+            logging.error("Exception in _make_request: %s", e)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/query/token_info_query.py
+++ b/src/hiero_sdk_python/query/token_info_query.py
@@ -74,7 +74,7 @@ class TokenInfoQuery(Query):
 
             return query
         except Exception as e:
-            logging.error("Exception in _make_request: %s", e)
+            logger.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/query/token_info_query.py
+++ b/src/hiero_sdk_python/query/token_info_query.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
 from hiero_sdk_python.executable import _Method
@@ -7,6 +9,9 @@ from hiero_sdk_python.hapi.services import query_pb2, response_pb2, token_get_in
 from hiero_sdk_python.query.query import Query
 from hiero_sdk_python.tokens.token_id import TokenId
 from hiero_sdk_python.tokens.token_info import TokenInfo
+
+
+logger = logging.getLogger(__name__)
 
 
 class TokenInfoQuery(Query):
@@ -69,7 +74,7 @@ class TokenInfoQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
+            logging.error("Exception in _make_request: %s", e)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/query/token_nft_info_query.py
+++ b/src/hiero_sdk_python/query/token_nft_info_query.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import traceback
+import logging
 
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
@@ -9,6 +9,9 @@ from hiero_sdk_python.hapi.services import query_pb2, response_pb2, token_get_nf
 from hiero_sdk_python.query.query import Query
 from hiero_sdk_python.tokens.nft_id import NftId
 from hiero_sdk_python.tokens.token_nft_info import TokenNftInfo
+
+
+logger = logging.getLogger(__name__)
 
 
 class TokenNftInfoQuery(Query):
@@ -69,8 +72,7 @@ class TokenNftInfoQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logging.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/query/token_nft_info_query.py
+++ b/src/hiero_sdk_python/query/token_nft_info_query.py
@@ -72,7 +72,7 @@ class TokenNftInfoQuery(Query):
 
             return query
         except Exception as e:
-            logging.error("Exception in _make_request: %s", e, exc_info=True)
+            logger.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/query/topic_info_query.py
+++ b/src/hiero_sdk_python/query/topic_info_query.py
@@ -102,7 +102,7 @@ class TopicInfoQuery(Query):
             return query
 
         except Exception as e:
-            logging.error("Exception in _make_request: %s", e, exc_info=True)
+            logger.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/query/topic_info_query.py
+++ b/src/hiero_sdk_python/query/topic_info_query.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import traceback
+import logging
 from typing import Any
 
 from hiero_sdk_python.channels import _Channel
@@ -11,6 +11,9 @@ from hiero_sdk_python.executable import _ExecutionState, _Method
 from hiero_sdk_python.hapi.services import consensus_get_topic_info_pb2, query_pb2
 from hiero_sdk_python.query.query import Query
 from hiero_sdk_python.response_code import ResponseCode
+
+
+logger = logging.getLogger(__name__)
 
 
 class TopicInfoQuery(Query):
@@ -99,8 +102,7 @@ class TopicInfoQuery(Query):
             return query
 
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logging.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/query/transaction_get_receipt_query.py
+++ b/src/hiero_sdk_python/query/transaction_get_receipt_query.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import traceback
+import logging
 
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
@@ -17,6 +17,9 @@ from hiero_sdk_python.query.query import Query
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 from hiero_sdk_python.transaction.transaction_receipt import TransactionReceipt
+
+
+logger = logging.getLogger(__name__)
 
 
 class TransactionGetReceiptQuery(Query):
@@ -184,8 +187,7 @@ class TransactionGetReceiptQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logging.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/query/transaction_get_receipt_query.py
+++ b/src/hiero_sdk_python/query/transaction_get_receipt_query.py
@@ -187,7 +187,7 @@ class TransactionGetReceiptQuery(Query):
 
             return query
         except Exception as e:
-            logging.error("Exception in _make_request: %s", e, exc_info=True)
+            logger.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/schedule/schedule_info_query.py
+++ b/src/hiero_sdk_python/schedule/schedule_info_query.py
@@ -74,7 +74,7 @@ class ScheduleInfoQuery(Query):
 
             return query
         except Exception as e:
-            logging.error("Exception in _make_request: %s", e, exc_info=True)
+            logger.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/src/hiero_sdk_python/schedule/schedule_info_query.py
+++ b/src/hiero_sdk_python/schedule/schedule_info_query.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import traceback
+import logging
 
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.client.client import Client
@@ -12,6 +12,9 @@ from hiero_sdk_python.hapi.services.schedule_get_info_pb2 import ScheduleGetInfo
 from hiero_sdk_python.query.query import Query
 from hiero_sdk_python.schedule.schedule_id import ScheduleId
 from hiero_sdk_python.schedule.schedule_info import ScheduleInfo
+
+
+logger = logging.getLogger(__name__)
 
 
 class ScheduleInfoQuery(Query):
@@ -71,8 +74,7 @@ class ScheduleInfoQuery(Query):
 
             return query
         except Exception as e:
-            print(f"Exception in _make_request: {e}")
-            traceback.print_exc()
+            logging.error("Exception in _make_request: %s", e, exc_info=True)
             raise
 
     def _get_method(self, channel: _Channel) -> _Method:

--- a/tests/unit/query_error_logging_test.py
+++ b/tests/unit/query_error_logging_test.py
@@ -166,3 +166,37 @@ def test_fetch_nodes_from_mirror_node_logs_request_exception(caplog, monkeypatch
     ]
     assert matching
     assert matching[0].name == Network.__module__
+
+
+def test_fetch_nodes_from_mirror_node_logs_malformed_response(caplog, monkeypatch):
+    """Ensure malformed mirror node responses are logged and fall back to an empty list instead of raising."""
+    source = inspect.getsource(Network._fetch_nodes_from_mirror_node)
+    assert "print(" not in source
+
+    network = Network.__new__(Network)
+    network.network = "testnet"
+
+    class _FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            # Missing required fields -> NodeAddress._from_dict raises.
+            return {"nodes": [{"unexpected": "shape"}]}
+
+    monkeypatch.setattr("hiero_sdk_python.client.network.requests.get", lambda *_a, **_k: _FakeResponse())
+
+    with (
+        caplog.at_level(logging.ERROR, logger="hiero_sdk_python"),
+        caplog.at_level(logging.ERROR, logger="hiero_sdk_python.client.network"),
+    ):
+        result = network._fetch_nodes_from_mirror_node()
+
+    assert result == []
+    matching = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.ERROR and "Error parsing mirror node API response" in record.message
+    ]
+    assert matching
+    assert matching[0].name == Network.__module__

--- a/tests/unit/query_error_logging_test.py
+++ b/tests/unit/query_error_logging_test.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import inspect
+import logging
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from hiero_sdk_python.account.account_records_query import AccountRecordsQuery
+from hiero_sdk_python.client.network import Network
+from hiero_sdk_python.contract.contract_bytecode_query import ContractBytecodeQuery
+from hiero_sdk_python.contract.contract_call_query import ContractCallQuery
+from hiero_sdk_python.contract.contract_info_query import ContractInfoQuery
+from hiero_sdk_python.file.file_contents_query import FileContentsQuery
+from hiero_sdk_python.file.file_info_query import FileInfoQuery
+from hiero_sdk_python.query.account_balance_query import CryptoGetAccountBalanceQuery
+from hiero_sdk_python.query.account_info_query import AccountInfoQuery
+from hiero_sdk_python.query.token_info_query import TokenInfoQuery
+from hiero_sdk_python.query.token_nft_info_query import TokenNftInfoQuery
+from hiero_sdk_python.query.topic_info_query import TopicInfoQuery
+from hiero_sdk_python.query.transaction_get_receipt_query import TransactionGetReceiptQuery
+from hiero_sdk_python.schedule.schedule_info_query import ScheduleInfoQuery
+
+
+pytestmark = pytest.mark.unit
+
+QUERY_CLASSES = [
+    AccountInfoQuery,
+    FileContentsQuery,
+    TokenInfoQuery,
+    AccountRecordsQuery,
+    ContractBytecodeQuery,
+    ContractCallQuery,
+    ContractInfoQuery,
+    FileInfoQuery,
+    CryptoGetAccountBalanceQuery,
+    TokenNftInfoQuery,
+    TopicInfoQuery,
+    TransactionGetReceiptQuery,
+    ScheduleInfoQuery,
+]
+
+
+@pytest.mark.parametrize("query_cls", QUERY_CLASSES, ids=[c.__name__ for c in QUERY_CLASSES])
+def test_make_request_source_has_no_print_or_traceback_dump(query_cls):
+    """
+    Static regression check preventing accidental reintroduction of
+    print() or traceback.print_exc() in _make_request().
+    """
+    source = inspect.getsource(query_cls._make_request)
+    assert "print(" not in source, f"{query_cls.__name__}._make_request still calls print()"
+    assert "traceback.print_exc()" not in source, (
+        f"{query_cls.__name__}._make_request still calls traceback.print_exc()"
+    )
+
+
+@pytest.mark.parametrize("query_cls", QUERY_CLASSES, ids=[c.__name__ for c in QUERY_CLASSES])
+def test_make_request_logs_exception_via_logging_module(query_cls, caplog):
+    """
+    Verify that _make_request routes exceptions through the logging module
+    instead of printing directly to stdout or stderr.
+
+    The request header is mocked to raise an exception so the error logging
+    path can be exercised consistently across query implementations.
+    """
+    query = query_cls()
+
+    # Some tests disable the SDK's root logger via the shared client fixture.
+    # Override the logger level here so caplog can capture ERROR records.
+    with (
+        patch.object(query_cls, "_make_request_header", side_effect=ValueError("boom")),
+        caplog.at_level(logging.ERROR, logger="hiero_sdk_python"),
+        caplog.at_level(logging.ERROR),
+        pytest.raises(ValueError),
+    ):
+        query._make_request()
+
+    assert any(
+        record.levelno == logging.ERROR and "Exception in _make_request" in record.message for record in caplog.records
+    ), f"No ERROR-level 'Exception in _make_request' log record captured for {query_cls.__name__}"
+
+
+def test_fetch_nodes_from_mirror_node_source_has_no_print(caplog):
+    """
+    Static + dynamic check for the missing-mirror-URL fallback path:
+    no print(), and the warning is captured by the logging module.
+    """
+    source = inspect.getsource(Network._fetch_nodes_from_mirror_node)
+    assert "print(" not in source
+
+    # Bypass __init__ (which would itself raise ValueError for an unknown
+    # network with no mirror URL and no default nodes) -- we only need
+    # `self.network` set to exercise this specific private method.
+    network = Network.__new__(Network)
+    network.network = "not-a-known-network"
+
+    with (
+        caplog.at_level(logging.WARNING, logger="hiero_sdk_python"),
+        caplog.at_level(logging.WARNING, logger="hiero_sdk_python.client.network"),
+    ):
+        result = network._fetch_nodes_from_mirror_node()
+
+    assert result == []
+    assert any(
+        record.levelno == logging.WARNING and "No known mirror node URL" in record.message for record in caplog.records
+    )
+
+
+def test_fetch_nodes_from_mirror_node_logs_request_exception(caplog, monkeypatch):
+    """
+    Static + dynamic check for the mirror-node-fetch-failure fallback path:
+    no print(), and the error is captured by the logging module, with the
+    method still falling back to an empty list rather than raising.
+    """
+    source = inspect.getsource(Network._fetch_nodes_from_mirror_node)
+    assert "print(" not in source
+
+    network = Network.__new__(Network)
+    network.network = "testnet"
+
+    def raise_request_exception(*args, **kwargs):
+        raise requests.RequestException("timeout")
+
+    monkeypatch.setattr("hiero_sdk_python.client.network.requests.get", raise_request_exception)
+
+    with (
+        caplog.at_level(logging.ERROR, logger="hiero_sdk_python"),
+        caplog.at_level(logging.ERROR, logger="hiero_sdk_python.client.network"),
+    ):
+        result = network._fetch_nodes_from_mirror_node()
+
+    assert result == []
+    assert any(
+        record.levelno == logging.ERROR and "Error fetching nodes from mirror node API" in record.message
+        for record in caplog.records
+    )

--- a/tests/unit/query_error_logging_test.py
+++ b/tests/unit/query_error_logging_test.py
@@ -7,12 +7,16 @@ from unittest.mock import patch
 import pytest
 import requests
 
+from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.account.account_records_query import AccountRecordsQuery
 from hiero_sdk_python.client.network import Network
+from hiero_sdk_python.consensus.topic_id import TopicId
 from hiero_sdk_python.contract.contract_bytecode_query import ContractBytecodeQuery
 from hiero_sdk_python.contract.contract_call_query import ContractCallQuery
+from hiero_sdk_python.contract.contract_id import ContractId
 from hiero_sdk_python.contract.contract_info_query import ContractInfoQuery
 from hiero_sdk_python.file.file_contents_query import FileContentsQuery
+from hiero_sdk_python.file.file_id import FileId
 from hiero_sdk_python.file.file_info_query import FileInfoQuery
 from hiero_sdk_python.query.account_balance_query import CryptoGetAccountBalanceQuery
 from hiero_sdk_python.query.account_info_query import AccountInfoQuery
@@ -20,34 +24,52 @@ from hiero_sdk_python.query.token_info_query import TokenInfoQuery
 from hiero_sdk_python.query.token_nft_info_query import TokenNftInfoQuery
 from hiero_sdk_python.query.topic_info_query import TopicInfoQuery
 from hiero_sdk_python.query.transaction_get_receipt_query import TransactionGetReceiptQuery
+from hiero_sdk_python.schedule.schedule_id import ScheduleId
 from hiero_sdk_python.schedule.schedule_info_query import ScheduleInfoQuery
+from hiero_sdk_python.tokens.nft_id import NftId
+from hiero_sdk_python.tokens.token_id import TokenId
+from hiero_sdk_python.transaction.transaction_id import TransactionId
 
 
 pytestmark = pytest.mark.unit
 
-QUERY_CLASSES = [
-    AccountInfoQuery,
-    FileContentsQuery,
-    TokenInfoQuery,
-    AccountRecordsQuery,
-    ContractBytecodeQuery,
-    ContractCallQuery,
-    ContractInfoQuery,
-    FileInfoQuery,
-    CryptoGetAccountBalanceQuery,
-    TokenNftInfoQuery,
-    TopicInfoQuery,
-    TransactionGetReceiptQuery,
-    ScheduleInfoQuery,
+_ACCOUNT_ID = AccountId(0, 0, 100)
+_TOKEN_ID = TokenId(0, 0, 200)
+
+QUERY_FACTORIES = [
+    (AccountInfoQuery, lambda: AccountInfoQuery(_ACCOUNT_ID), "_make_request_header"),
+    (FileContentsQuery, lambda: FileContentsQuery(FileId(0, 0, 101)), "_make_request_header"),
+    (TokenInfoQuery, lambda: TokenInfoQuery(_TOKEN_ID), "_make_request_header"),
+    (AccountRecordsQuery, lambda: AccountRecordsQuery(_ACCOUNT_ID), "_make_request_header"),
+    (
+        ContractBytecodeQuery,
+        lambda: ContractBytecodeQuery(ContractId(0, 0, 102)),
+        "_make_request_header",
+    ),
+    (ContractCallQuery, lambda: ContractCallQuery(ContractId(0, 0, 102)), "_make_request_header"),
+    (ContractInfoQuery, lambda: ContractInfoQuery(ContractId(0, 0, 102)), "_make_request_header"),
+    (FileInfoQuery, lambda: FileInfoQuery(FileId(0, 0, 101)), "_make_request_header"),
+    (
+        CryptoGetAccountBalanceQuery,
+        lambda: CryptoGetAccountBalanceQuery(_ACCOUNT_ID),
+        "_make_request_header",
+    ),
+    (TokenNftInfoQuery, lambda: TokenNftInfoQuery(NftId(_TOKEN_ID, 1)), "_make_request_header"),
+    (TopicInfoQuery, lambda: TopicInfoQuery(TopicId(0, 0, 103)), "_make_request_header"),
+    (
+        TransactionGetReceiptQuery,
+        lambda: TransactionGetReceiptQuery(TransactionId(_ACCOUNT_ID)),
+        "transaction_id._to_proto",
+    ),
+    (ScheduleInfoQuery, lambda: ScheduleInfoQuery(ScheduleId(0, 0, 104)), "_make_request_header"),
 ]
 
+_IDS = [cls.__name__ for cls, _, _ in QUERY_FACTORIES]
 
-@pytest.mark.parametrize("query_cls", QUERY_CLASSES, ids=[c.__name__ for c in QUERY_CLASSES])
-def test_make_request_source_has_no_print_or_traceback_dump(query_cls):
-    """
-    Static regression check preventing accidental reintroduction of
-    print() or traceback.print_exc() in _make_request().
-    """
+
+@pytest.mark.parametrize("query_cls,factory,patch_target", QUERY_FACTORIES, ids=_IDS)
+def test_make_request_source_has_no_print_or_traceback_dump(query_cls, factory, patch_target):
+    """Ensure _make_request does not use print() or traceback.print_exc()."""
     source = inspect.getsource(query_cls._make_request)
     assert "print(" not in source, f"{query_cls.__name__}._make_request still calls print()"
     assert "traceback.print_exc()" not in source, (
@@ -55,43 +77,49 @@ def test_make_request_source_has_no_print_or_traceback_dump(query_cls):
     )
 
 
-@pytest.mark.parametrize("query_cls", QUERY_CLASSES, ids=[c.__name__ for c in QUERY_CLASSES])
-def test_make_request_logs_exception_via_logging_module(query_cls, caplog):
-    """
-    Verify that _make_request routes exceptions through the logging module
-    instead of printing directly to stdout or stderr.
+@pytest.mark.parametrize("query_cls,factory,patch_target", QUERY_FACTORIES, ids=_IDS)
+def test_make_request_logs_exception_via_module_logger(query_cls, factory, patch_target, caplog):
+    """Ensure _make_request logs exceptions with the module logger and exc_info."""
+    query = factory()
 
-    The request header is mocked to raise an exception so the error logging
-    path can be exercised consistently across query implementations.
-    """
-    query = query_cls()
+    # Patch either the query helper or an inline header builder.
+    if "." in patch_target:
+        attr_name, method_name = patch_target.split(".")
+        patch_obj = type(getattr(query, attr_name))
+        patch_ctx = patch.object(patch_obj, method_name, side_effect=ValueError("boom"))
+    else:
+        patch_ctx = patch.object(query_cls, patch_target, side_effect=ValueError("boom"))
 
-    # Some tests disable the SDK's root logger via the shared client fixture.
-    # Override the logger level here so caplog can capture ERROR records.
+    # Override the parent logger level so ERROR logs are captured.
     with (
-        patch.object(query_cls, "_make_request_header", side_effect=ValueError("boom")),
+        patch_ctx,
         caplog.at_level(logging.ERROR, logger="hiero_sdk_python"),
         caplog.at_level(logging.ERROR),
         pytest.raises(ValueError),
     ):
         query._make_request()
 
-    assert any(
-        record.levelno == logging.ERROR and "Exception in _make_request" in record.message for record in caplog.records
-    ), f"No ERROR-level 'Exception in _make_request' log record captured for {query_cls.__name__}"
+    matching = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.ERROR and "Exception in _make_request" in record.message
+    ]
+    assert matching, f"No ERROR-level 'Exception in _make_request' log record captured for {query_cls.__name__}"
+
+    record = matching[0]
+    assert record.name == query_cls.__module__, (
+        f"Expected log emitted by '{query_cls.__module__}', got '{record.name}' "
+        "(likely used logging.error(...) instead of logger.error(...))"
+    )
+    assert record.exc_info is not None, f"{query_cls.__name__} logged the error without exc_info -- traceback is lost"
 
 
-def test_fetch_nodes_from_mirror_node_source_has_no_print(caplog):
-    """
-    Static + dynamic check for the missing-mirror-URL fallback path:
-    no print(), and the warning is captured by the logging module.
-    """
+def test_fetch_nodes_from_mirror_node_logs_missing_url(caplog):
+    """Ensure missing mirror URL is logged and an empty list is returned."""
     source = inspect.getsource(Network._fetch_nodes_from_mirror_node)
     assert "print(" not in source
 
-    # Bypass __init__ (which would itself raise ValueError for an unknown
-    # network with no mirror URL and no default nodes) -- we only need
-    # `self.network` set to exercise this specific private method.
+    # Bypass __init__; only self.network is needed for this private method.
     network = Network.__new__(Network)
     network.network = "not-a-known-network"
 
@@ -102,17 +130,17 @@ def test_fetch_nodes_from_mirror_node_source_has_no_print(caplog):
         result = network._fetch_nodes_from_mirror_node()
 
     assert result == []
-    assert any(
-        record.levelno == logging.WARNING and "No known mirror node URL" in record.message for record in caplog.records
-    )
+    matching = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.WARNING and "No known mirror node URL" in record.message
+    ]
+    assert matching
+    assert matching[0].name == Network.__module__
 
 
 def test_fetch_nodes_from_mirror_node_logs_request_exception(caplog, monkeypatch):
-    """
-    Static + dynamic check for the mirror-node-fetch-failure fallback path:
-    no print(), and the error is captured by the logging module, with the
-    method still falling back to an empty list rather than raising.
-    """
+    """Ensure request failures are logged and fall back to an empty list."""
     source = inspect.getsource(Network._fetch_nodes_from_mirror_node)
     assert "print(" not in source
 
@@ -131,7 +159,10 @@ def test_fetch_nodes_from_mirror_node_logs_request_exception(caplog, monkeypatch
         result = network._fetch_nodes_from_mirror_node()
 
     assert result == []
-    assert any(
-        record.levelno == logging.ERROR and "Error fetching nodes from mirror node API" in record.message
+    matching = [
+        record
         for record in caplog.records
-    )
+        if record.levelno == logging.ERROR and "Error fetching nodes from mirror node API" in record.message
+    ]
+    assert matching
+    assert matching[0].name == Network.__module__


### PR DESCRIPTION
**Description**:
Replace `print()` and `traceback.print_exc()` with structured logging across query and network modules.

* Add module-level loggers to query and network modules
* Replace `print()`/`traceback.print_exc()` with `logger.error(..., exc_info=True)` or `logger.warning(...)`
* Remove unused `traceback` imports
* Add regression tests to verify no `print()` calls remain, logs use the correct module logger, and tracebacks are preserved

**Related issue(s)**:
Fixes #2403

**Notes for reviewer**:
- No public API changes; internal logging only
- Docstring `print(...)` examples were intentionally left unchanged
- `TransactionGetReceiptQuery` uses a different mock target because it builds its header inline

**Checklist**
- [x] Documented
- [x] Tested