### PR TITLE
chore: Deprecate the `set_node_account_id` and `node_account_id` for Transaction

### DIFF
--- a/docs/sdk_developers/training/coding_token_transactions.md
+++ b/docs/sdk_developers/training/coding_token_transactions.md
@@ -22,7 +22,7 @@ By inheriting from `Transaction`, your new class automatically gains essential f
 - **Freezing:** `freeze()` and `freeze_with(client)`
 - **Execution:** `execute(client)`
 - **Fee Calculation:** Handling `transaction_fee` and `max_transaction_fee`
-- **ID Management:** `transaction_id`, `node_account_id`
+- **ID Management:** `transaction_id`, `node_account_ids`
 
 Your job in the subclass is to define **what** data is being sent, while the base class handles **how** it is sent.
 

--- a/docs/sdk_developers/training/executable.md
+++ b/docs/sdk_developers/training/executable.md
@@ -140,7 +140,7 @@ Key Steps:
 
   * Used throughout execution:
    ```python
-   logger.trace("Executing", "requestId", self._get_request_id(), "nodeAccountID", self.node_account_id, "attempt", attempt + 1, "maxAttempts", max_attempts)
+   logger.trace("Executing", "requestId", self._get_request_id(), "nodeAccountID", self._node_account_ids.current, "attempt", attempt + 1, "maxAttempts", max_attempts)
    logger.trace("Executing gRPC call", "requestId", self._get_request_id())
    logger.trace("Retrying request attempt", "requestId", request_id, "delay", current_backoff, ...)
    ```
@@ -150,7 +150,7 @@ Key Steps:
    logger.trace(
     "Executing",
     "requestId", self._get_request_id(),
-    "nodeAccountID", self.node_account_id,      # Which node this attempt uses
+    "nodeAccountID", self._node_account_ids.current,      # Which node this attempt uses
     "attempt", attempt + 1,                      # Current attempt (1-based)
     "maxAttempts", max_attempts                  # Total allowed attempts
    )
@@ -163,7 +163,7 @@ Key Steps:
   ```python
     logger.trace(
     f"{self.__class__.__name__} status received",
-    "nodeAccountID", self.node_account_id,
+    "nodeAccountID", self._node_account_ids.current,
     "network", client.network.network,          # Network name (testnet, mainnet)
     "state", execution_state.name,               # RETRY, FINISHED, ERROR, EXPIRED
     "txID", tx_id                                # Transaction ID if available
@@ -183,11 +183,12 @@ Key Steps:
   ```
   * Node switch on gRPC error:
   ```python
+    previous_node = self._node_account_ids.next
     logger.trace(
     "Switched to a different node for the next attempt",
     "error", err_persistant,
-    "from node", self.node_account_id,           # Old node
-    "to node", node._account_id                  # New node
+    "from node", previous_node,                               # Old node
+    "to node", self.node_account_ids.current                  # New node
   )
   ```
   * Final failure:

--- a/docs/sdk_users/transaction_bytes.md
+++ b/docs/sdk_users/transaction_bytes.md
@@ -12,7 +12,7 @@ Freezes a transaction with manually set IDs for **single-node execution**.
 
 **Requirements:**
 - `transaction_id` must be set
-- `node_account_id` must be set
+- `node_account_ids` must be set
 
 **Returns:** `Transaction` (self) for method chaining
 
@@ -27,7 +27,7 @@ from hiero_sdk_python.account.account_id import AccountId
 
 transaction = TransferTransaction().add_hbar_transfer(...)
 transaction.transaction_id = TransactionId.generate(AccountId.from_string("0.0.1234"))
-transaction.node_account_id = AccountId.from_string("0.0.3")
+transaction.set_node_account_ids([AccountId.from_string("0.0.3")])
 transaction.freeze()
 ```
 
@@ -140,12 +140,12 @@ receipt = final_tx.execute(client)
 | Feature | `freeze()` | `freeze_with(client)` |
 |---------|-----------|----------------------|
 | Sets transaction_id | ❌ Manual required | ✅ Automatic |
-| Sets node_account_id | ❌ Manual required | ✅ Automatic |
-| Builds for single node | ✅ Yes | ❌ No |
-| Builds for all nodes | ❌ No | ✅ Yes |
-| Supports node failover | ❌ No | ✅ Yes |
+| Sets node_account_ids | ❌ Manual required | ✅ Automatic (if not already set) |
+| Build transactions for user-provided `node_account_ids` | ✅ Yes | ✅ Yes |
+| Builds transactions for all available client nodes | ❌ No | ✅ Yes (if user does not manually set then) |
+| Supports node retry/failover | ✅ Yes (if multiple node account IDs are provided) | ✅ Yes |
 | Use for offline signing | ✅ Yes | ✅ Yes |
-| Use for execute(client) | ⚠️ Single node only | ✅ Recommended |
+| Use for execute(client) | ⚠️ Requires `transaction_id` and `node_account_ids` to be set | ✅ Recommended |
 
 ## Use Cases
 
@@ -157,7 +157,7 @@ Create transaction bytes on an online system, transfer to an offline system for 
 # Online system
 transaction = TransferTransaction().add_hbar_transfer(...)
 transaction.transaction_id = TransactionId.generate(account_id)
-transaction.node_account_id = AccountId.from_string("0.0.3")
+transaction.set_node_account_ids([AccountId.from_string("0.0.3")])
 transaction.freeze()
 unsigned_bytes = transaction.to_bytes()
 

--- a/examples/transaction/transaction_freeze_manually.py
+++ b/examples/transaction/transaction_freeze_manually.py
@@ -47,7 +47,7 @@ def build_unsigned_tx(executor_client):
     tx = TopicCreateTransaction().set_memo("Test Topic Creation").set_transaction_id(tx_id)
 
     # Explicit node binding (important for deterministic freeze)
-    tx.node_account_id = NODE_ACCOUNT_ID
+    tx.set_node_account_ids([NODE_ACCOUNT_ID])
 
     # Freeze generates a body for ONLY the specified node
     tx.freeze()

--- a/src/hiero_sdk_python/executable.py
+++ b/src/hiero_sdk_python/executable.py
@@ -86,11 +86,26 @@ class _Executable(ABC):
         self._grpc_deadline: float | None = None
         self._request_timeout: float | None = None
 
-        self.node_account_id: AccountId | None = None
+        self._node_account_id: AccountId | None = None
         self.node_account_ids: list[AccountId] = []
 
         self._used_node_account_id: AccountId | None = None
         self._node_account_ids_index: int = 0
+
+    @property
+    def node_account_id(self) -> AccountId | None:
+        warnings.warn(
+            "'node_account_id' is deprecated; use 'node_account_ids' instead.", DeprecationWarning, stacklevel=2
+        )
+        return self.node_account_ids[0] if len(self.node_account_ids) > 0 else None
+
+    @node_account_id.setter
+    def node_account_id(self, account_id: AccountId) -> None:
+        warnings.warn(
+            "'node_account_id' is deprecated; use 'node_account_ids' instead.", DeprecationWarning, stacklevel=2
+        )
+
+        self.node_account_ids = [account_id] if account_id is not None else []
 
     def set_node_account_ids(self, node_account_ids: list[AccountId]):
         """
@@ -115,6 +130,11 @@ class _Executable(ABC):
         Returns:
             The current instance of the class for chaining.
         """
+        warnings.warn(
+            "Method 'set_node_account_id()' is deprecated; use 'set_node_account_ids()' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.set_node_account_ids([node_account_id])
 
     def set_max_attempts(self, max_attempts: int):
@@ -346,12 +366,12 @@ class _Executable(ABC):
             if getattr(self, attr) is None:
                 setattr(self, attr, default)
 
-        # nodes to which the executaion must be run against, if not provided used nodes from client
+        # Temp workaround till the chunk-tx fix
         if not self.node_account_ids:
-            self.node_account_ids = [node._account_id for node in client.network._healthy_nodes]
+            self.node_account_ids = [node._account_id for node in client.network.nodes]
 
         if not self.node_account_ids:
-            raise RuntimeError("No healthy nodes available for execution")
+            raise RuntimeError("No nodes available for execution")
 
     def _should_retry_exponentially(self, err: Exception) -> bool:
         """
@@ -429,10 +449,10 @@ class _Executable(ABC):
             node = client.network._get_node(node_id)
 
             if node is None:
-                raise RuntimeError(f"No node found for node_account_id: {self.node_account_id}")
+                raise RuntimeError(f"No node found for node_account_id: {self._node_account_id}")
 
             # Store for logging and receipts
-            self.node_account_id = node._account_id
+            self._node_account_id = node._account_id
 
             # Create a channel wrapper from the client's channel
             channel = node._get_channel()
@@ -442,7 +462,7 @@ class _Executable(ABC):
                 "requestId",
                 self._get_request_id(),
                 "nodeAccountID",
-                self.node_account_id,
+                self._node_account_id,
                 "attempt",
                 attempt + 1,
                 "maxAttempts",
@@ -483,7 +503,7 @@ class _Executable(ABC):
             logger.trace(
                 f"{self.__class__.__name__} status received",
                 "nodeAccountID",
-                self.node_account_id,
+                self._node_account_id,
                 "network",
                 client.network.network,
                 "state",
@@ -518,7 +538,7 @@ class _Executable(ABC):
                 case _ExecutionState.FINISHED:
                     # If the transaction completed successfully, map the response and return it
                     logger.trace(f"{self.__class__.__name__} finished execution")
-                    return self._map_response(response, self.node_account_id, proto_request)
+                    return self._map_response(response, self._node_account_id, proto_request)
 
         logger.error(
             "Exceeded maximum attempts for request",
@@ -529,7 +549,7 @@ class _Executable(ABC):
         )
         raise MaxAttemptsError(
             "Exceeded maximum attempts or request timeout",
-            self.node_account_id,
+            self._node_account_id,
             err_persistant,
         )
 

--- a/src/hiero_sdk_python/executable.py
+++ b/src/hiero_sdk_python/executable.py
@@ -89,8 +89,6 @@ class _Executable(ABC):
 
         self._node_account_ids: _LockableList[AccountId] = _LockableList[AccountId]()
 
-        self._used_node_account_id: AccountId | None = None
-
     @property
     def node_account_id(self) -> AccountId | None:
         warnings.warn(

--- a/src/hiero_sdk_python/executable.py
+++ b/src/hiero_sdk_python/executable.py
@@ -503,6 +503,7 @@ class _Executable(ABC):
                         client.network._increase_backoff(node)
                         # update nodes from the mirror_node
                         client.update_network()
+                        self._node_account_ids.advance()
 
                     # If we should retry, wait for the backoff period and try again
                     err_persistant = status_error
@@ -513,7 +514,6 @@ class _Executable(ABC):
                         logger,
                         err_persistant,
                     )
-                    self._node_account_ids.advance()
                     continue
                 case _ExecutionState.EXPIRED:
                     raise status_error

--- a/src/hiero_sdk_python/executable.py
+++ b/src/hiero_sdk_python/executable.py
@@ -97,7 +97,7 @@ class _Executable(ABC):
         return self._node_account_ids.current if not self._node_account_ids.is_empty else None
 
     @node_account_id.setter
-    def node_account_id(self, node_account_id: AccountId) -> None:
+    def node_account_id(self, node_account_id: AccountId):
         warnings.warn(
             "'node_account_id' is deprecated; use 'node_account_ids' instead.", DeprecationWarning, stacklevel=2
         )
@@ -128,7 +128,7 @@ class _Executable(ABC):
 
     @node_account_ids.setter
     def node_account_ids(self, node_account_ids: list[AccountId]):
-        return self.set_node_account_ids(node_account_ids)
+        self.set_node_account_ids(node_account_ids)
 
     def set_node_account_ids(self, node_account_ids: list[AccountId]):
         """

--- a/src/hiero_sdk_python/executable.py
+++ b/src/hiero_sdk_python/executable.py
@@ -124,6 +124,7 @@ class _Executable(ABC):
 
     @property
     def node_account_ids(self) -> list[AccountId]:
+        """Return a copy of the node account IDs."""
         return self._node_account_ids.get_list()
 
     @node_account_ids.setter

--- a/src/hiero_sdk_python/executable.py
+++ b/src/hiero_sdk_python/executable.py
@@ -353,7 +353,7 @@ class _Executable(ABC):
             if getattr(self, attr) is None:
                 setattr(self, attr, default)
 
-        # Id _node_account_ids is empty during execution then use all the available node in client
+        # If_node_account_ids is empty during execution then use all the available node in client
         if self._node_account_ids.is_empty:
             self._node_account_ids.set_list([node._account_id for node in client.network.nodes])
 
@@ -391,7 +391,7 @@ class _Executable(ABC):
             )
             return True
 
-        if self._node_account_ids._index == len(self._node_account_ids) - 1:
+        if self._node_account_ids.index == len(self._node_account_ids) - 1:
             raise RuntimeError("All nodes are unhealthy")
 
         self._node_account_ids.advance()

--- a/src/hiero_sdk_python/executable.py
+++ b/src/hiero_sdk_python/executable.py
@@ -15,6 +15,7 @@ from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.exceptions import MaxAttemptsError
 from hiero_sdk_python.hapi.services import query_pb2, transaction_pb2
+from hiero_sdk_python.lockable_list import _LockableList
 from hiero_sdk_python.logger.logger import Logger
 from hiero_sdk_python.response_code import ResponseCode
 
@@ -86,39 +87,25 @@ class _Executable(ABC):
         self._grpc_deadline: float | None = None
         self._request_timeout: float | None = None
 
-        self._node_account_id: AccountId | None = None
-        self.node_account_ids: list[AccountId] = []
+        self._node_account_ids: _LockableList[AccountId] = _LockableList[AccountId]()
 
         self._used_node_account_id: AccountId | None = None
-        self._node_account_ids_index: int = 0
 
     @property
     def node_account_id(self) -> AccountId | None:
         warnings.warn(
             "'node_account_id' is deprecated; use 'node_account_ids' instead.", DeprecationWarning, stacklevel=2
         )
-        return self.node_account_ids[0] if len(self.node_account_ids) > 0 else None
+        return self._node_account_ids.current if not self._node_account_ids.is_empty else None
 
     @node_account_id.setter
-    def node_account_id(self, account_id: AccountId) -> None:
+    def node_account_id(self, node_account_id: AccountId) -> None:
         warnings.warn(
             "'node_account_id' is deprecated; use 'node_account_ids' instead.", DeprecationWarning, stacklevel=2
         )
 
-        self.node_account_ids = [account_id] if account_id is not None else []
-
-    def set_node_account_ids(self, node_account_ids: list[AccountId]):
-        """
-        Explicitly set the node account IDs to execute against.
-
-        Args:
-            node_account_ids (list[AccountId]): List of node account IDs
-
-        Returns:
-            The current instance of the class for chaining.
-        """
-        self.node_account_ids = node_account_ids
-        return self
+        if node_account_id is not None:
+            self.set_node_account_ids([node_account_id])
 
     def set_node_account_id(self, node_account_id: AccountId):
         """
@@ -136,6 +123,27 @@ class _Executable(ABC):
             stacklevel=2,
         )
         return self.set_node_account_ids([node_account_id])
+
+    @property
+    def node_account_ids(self) -> list[AccountId]:
+        return self._node_account_ids.get_list()
+
+    @node_account_ids.setter
+    def node_account_ids(self, node_account_ids: list[AccountId]):
+        return self.set_node_account_ids(node_account_ids)
+
+    def set_node_account_ids(self, node_account_ids: list[AccountId]):
+        """
+        Explicitly set the node account IDs to execute against.
+
+        Args:
+            node_account_ids (list[AccountId]): List of node account IDs
+
+        Returns:
+            The current instance of the class for chaining.
+        """
+        self._node_account_ids.set_list(node_account_ids)
+        return self
 
     def set_max_attempts(self, max_attempts: int):
         """
@@ -259,25 +267,6 @@ class _Executable(ABC):
         self._max_backoff = float(max_backoff)
         return self
 
-    def _select_node_account_id(self) -> AccountId | None:
-        """
-        Select the next node account ID from node_account_ids in a round-robin fashion.
-
-        Returns:
-            Selected AccountId or None if no nodes are configured
-        """
-        if self.node_account_ids:
-            # Use modulo to cycle through the list
-            selected = self.node_account_ids[self._node_account_ids_index % len(self.node_account_ids)]
-            self._used_node_account_id = selected
-            return selected
-        return None
-
-    def _advance_node_index(self):
-        """Advance to the next node in the list."""
-        if self.node_account_ids:
-            self._node_account_ids_index += 1
-
     @abstractmethod
     def _should_retry(self, response) -> _ExecutionState:
         """
@@ -366,11 +355,11 @@ class _Executable(ABC):
             if getattr(self, attr) is None:
                 setattr(self, attr, default)
 
-        # Temp workaround till the chunk-tx fix
-        if not self.node_account_ids:
-            self.node_account_ids = [node._account_id for node in client.network.nodes]
+        # Id _node_account_ids is empty during execution then use all the available node in client
+        if self._node_account_ids.is_empty:
+            self._node_account_ids.set_list([node._account_id for node in client.network.nodes])
 
-        if not self.node_account_ids:
+        if self._node_account_ids.is_empty:
             raise RuntimeError("No nodes available for execution")
 
     def _should_retry_exponentially(self, err: Exception) -> bool:
@@ -404,10 +393,10 @@ class _Executable(ABC):
             )
             return True
 
-        if self._node_account_ids_index == len(self.node_account_ids) - 1:
+        if self._node_account_ids._index == len(self._node_account_ids) - 1:
             raise RuntimeError("All nodes are unhealthy")
 
-        self._advance_node_index()
+        self._node_account_ids.advance()
         return True
 
     def _execute(self, client: Client, timeout: int | float | None = None):
@@ -445,14 +434,11 @@ class _Executable(ABC):
                 break
 
             # Select node
-            node_id = self._select_node_account_id()
+            node_id = self._node_account_ids.current
             node = client.network._get_node(node_id)
 
             if node is None:
-                raise RuntimeError(f"No node found for node_account_id: {self._node_account_id}")
-
-            # Store for logging and receipts
-            self._node_account_id = node._account_id
+                raise RuntimeError(f"No node found for node_account_id: {self._node_account_ids.current}")
 
             # Create a channel wrapper from the client's channel
             channel = node._get_channel()
@@ -462,7 +448,7 @@ class _Executable(ABC):
                 "requestId",
                 self._get_request_id(),
                 "nodeAccountID",
-                self._node_account_id,
+                self._node_account_ids.current,
                 "attempt",
                 attempt + 1,
                 "maxAttempts",
@@ -490,7 +476,7 @@ class _Executable(ABC):
 
                 client.network._increase_backoff(node)
                 err_persistant = e
-                self._advance_node_index()
+                self._node_account_ids.advance()
                 continue
 
             client.network._decrease_backoff(node)
@@ -503,7 +489,7 @@ class _Executable(ABC):
             logger.trace(
                 f"{self.__class__.__name__} status received",
                 "nodeAccountID",
-                self._node_account_id,
+                self._node_account_ids.current,
                 "network",
                 client.network.network,
                 "state",
@@ -529,7 +515,7 @@ class _Executable(ABC):
                         logger,
                         err_persistant,
                     )
-                    self._advance_node_index()
+                    self._node_account_ids.advance()
                     continue
                 case _ExecutionState.EXPIRED:
                     raise status_error
@@ -538,7 +524,7 @@ class _Executable(ABC):
                 case _ExecutionState.FINISHED:
                     # If the transaction completed successfully, map the response and return it
                     logger.trace(f"{self.__class__.__name__} finished execution")
-                    return self._map_response(response, self._node_account_id, proto_request)
+                    return self._map_response(response, self._node_account_ids.current, proto_request)
 
         logger.error(
             "Exceeded maximum attempts for request",
@@ -549,7 +535,7 @@ class _Executable(ABC):
         )
         raise MaxAttemptsError(
             "Exceeded maximum attempts or request timeout",
-            self._node_account_id,
+            self._node_account_ids.current,
             err_persistant,
         )
 

--- a/src/hiero_sdk_python/lockable_list.py
+++ b/src/hiero_sdk_python/lockable_list.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from typing import Generic, TypeVar
+
+
+T = TypeVar("T")
+
+
+class _LockableList(Generic[T]):
+    def __init__(self):
+        self._items: list[T] = []
+        self._index: int = 0
+        self._locked: bool = False
+
+    def _required_not_locked(self) -> None:
+        if self._locked:
+            raise RuntimeError("list in unmutable")
+
+    def set_list(self, items: list[T]) -> _LockableList[T]:
+        self._required_not_locked()
+        self._items = list(items)
+        self._index = 0
+        return self
+
+    def get_list(self) -> list[T]:
+        return self._items
+
+    def append(self, item: T) -> _LockableList[T]:
+        self._required_not_locked()
+        self._items.append(item)
+        return self
+
+    def extend(self, items: Iterable[T]) -> _LockableList[T]:
+        self._required_not_locked()
+        self._items.extend(items)
+        return self
+
+    def clear(self) -> _LockableList[T]:
+        self._require_not_locked()
+        self._items.clear()
+        return self
+
+    def get(self, index: int) -> T:
+        return self._items[index]
+
+    def set(self, index: int, item: T) -> _LockableList[T]:
+        self._require_not_locked()
+
+        if index == len(self._items):
+            self._items.append(item)
+        else:
+            self._items[index] = item
+
+        return self
+
+    def set_if_absent(self, index: int, item: T) -> _LockableList[T]:
+        if index == len(self._items) or self._items[index] is None:
+            self.set(index, item)
+
+        return self
+
+    def advance(self) -> int:
+        current_index = self._index
+
+        if self._items:
+            self._index = (self._index + 1) % len(self._items)
+        return current_index
+
+    def set_lock(self, val: bool) -> _LockableList[T]:
+        self._locked = val
+        return self
+
+    @property
+    def current(self) -> T:
+        return self.get(self._index)
+
+    @property
+    def next(self) -> T:
+        return self.get(self.advance())
+
+    @property
+    def is_empty(self) -> bool:
+        return not self._items
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __iter__(self) -> Iterator[T]:
+        return iter(self._items)

--- a/src/hiero_sdk_python/lockable_list.py
+++ b/src/hiero_sdk_python/lockable_list.py
@@ -16,14 +16,14 @@ class _LockableList(Generic[T]):
         self._index: int = 0
         self._locked: bool = False
 
-    def _required_not_locked(self) -> None:
+    def _require_not_locked(self) -> None:
         """Raise an exception if the list is locked."""
         if self._locked:
-            raise RuntimeError("list in unmutable")
+            raise RuntimeError("list is unmutable")
 
     def set_list(self, items: list[T]) -> _LockableList[T]:
         """Replace the contents of the list and reset the current index."""
-        self._required_not_locked()
+        self._require_not_locked()
         self._items = list(items)
         self._index = 0
         return self
@@ -34,19 +34,19 @@ class _LockableList(Generic[T]):
 
     def append(self, item: T) -> _LockableList[T]:
         """Append an item to the list."""
-        self._required_not_locked()
+        self._require_not_locked()
         self._items.append(item)
         return self
 
     def extend(self, items: Iterable[T]) -> _LockableList[T]:
         """Append all items from an iterable to the list."""
-        self._required_not_locked()
+        self._require_not_locked()
         self._items.extend(items)
         return self
 
     def clear(self) -> _LockableList[T]:
         """Remove all items from the list."""
-        self._required_not_locked()
+        self._require_not_locked()
         self._items.clear()
         return self
 
@@ -56,7 +56,7 @@ class _LockableList(Generic[T]):
 
     def set(self, index: int, item: T) -> _LockableList[T]:
         """Set or append an item at the given index."""
-        self._required_not_locked()
+        self._require_not_locked()
 
         if index == len(self._items):
             self._items.append(item)
@@ -89,6 +89,11 @@ class _LockableList(Generic[T]):
         """Set the current index."""
         self._index = val
         return self
+
+    @property
+    def index(self) -> int:
+        """Return the current index."""
+        return self._index
 
     @property
     def current(self) -> T:

--- a/src/hiero_sdk_python/lockable_list.py
+++ b/src/hiero_sdk_python/lockable_list.py
@@ -103,7 +103,7 @@ class _LockableList(Generic[T]):
 
     @property
     def next(self) -> T:
-        """Advance to the next item and return it."""
+        """Advance the current index and return the previous."""
         return self.get(self.advance())
 
     @property

--- a/src/hiero_sdk_python/lockable_list.py
+++ b/src/hiero_sdk_python/lockable_list.py
@@ -48,6 +48,7 @@ class _LockableList(Generic[T]):
         """Remove all items from the list."""
         self._require_not_locked()
         self._items.clear()
+        self._index = 0
         return self
 
     def get(self, index: int) -> T:

--- a/src/hiero_sdk_python/lockable_list.py
+++ b/src/hiero_sdk_python/lockable_list.py
@@ -8,44 +8,55 @@ T = TypeVar("T")
 
 
 class _LockableList(Generic[T]):
+    """A mutable list with lock to prevent further modifications."""
+
     def __init__(self):
+        """Initialize an empty, unlocked list."""
         self._items: list[T] = []
         self._index: int = 0
         self._locked: bool = False
 
     def _required_not_locked(self) -> None:
+        """Raise an exception if the list is locked."""
         if self._locked:
             raise RuntimeError("list in unmutable")
 
     def set_list(self, items: list[T]) -> _LockableList[T]:
+        """Replace the contents of the list and reset the current index."""
         self._required_not_locked()
         self._items = list(items)
         self._index = 0
         return self
 
     def get_list(self) -> list[T]:
+        """Return the underlying list."""
         return self._items
 
     def append(self, item: T) -> _LockableList[T]:
+        """Append an item to the list."""
         self._required_not_locked()
         self._items.append(item)
         return self
 
     def extend(self, items: Iterable[T]) -> _LockableList[T]:
+        """Append all items from an iterable to the list."""
         self._required_not_locked()
         self._items.extend(items)
         return self
 
     def clear(self) -> _LockableList[T]:
-        self._require_not_locked()
+        """Remove all items from the list."""
+        self._required_not_locked()
         self._items.clear()
         return self
 
     def get(self, index: int) -> T:
+        """Return the item at the given index."""
         return self._items[index]
 
     def set(self, index: int, item: T) -> _LockableList[T]:
-        self._require_not_locked()
+        """Set or append an item at the given index."""
+        self._required_not_locked()
 
         if index == len(self._items):
             self._items.append(item)
@@ -55,12 +66,14 @@ class _LockableList(Generic[T]):
         return self
 
     def set_if_absent(self, index: int, item: T) -> _LockableList[T]:
+        """Set an item if the position is missing or contains None."""
         if index == len(self._items) or self._items[index] is None:
             self.set(index, item)
 
         return self
 
     def advance(self) -> int:
+        """Advance the current index and return the previous index."""
         current_index = self._index
 
         if self._items:
@@ -68,23 +81,34 @@ class _LockableList(Generic[T]):
         return current_index
 
     def set_lock(self, val: bool) -> _LockableList[T]:
+        """Lock or unlock the list."""
         self._locked = val
+        return self
+
+    def set_index(self, val: int) -> _LockableList[T]:
+        """Set the current index."""
+        self._index = val
         return self
 
     @property
     def current(self) -> T:
+        """Return the current item."""
         return self.get(self._index)
 
     @property
     def next(self) -> T:
+        """Advance to the next item and return it."""
         return self.get(self.advance())
 
     @property
     def is_empty(self) -> bool:
+        """Return ``True`` if the list contains no items."""
         return not self._items
 
     def __len__(self) -> int:
+        """Return the number of items in the list."""
         return len(self._items)
 
     def __iter__(self) -> Iterator[T]:
+        """Return an iterator over the list."""
         return iter(self._items)

--- a/src/hiero_sdk_python/lockable_list.py
+++ b/src/hiero_sdk_python/lockable_list.py
@@ -30,7 +30,7 @@ class _LockableList(Generic[T]):
 
     def get_list(self) -> list[T]:
         """Return the underlying list."""
-        return self._items
+        return self._items.copy()
 
     def append(self, item: T) -> _LockableList[T]:
         """Append an item to the list."""

--- a/src/hiero_sdk_python/query/query.py
+++ b/src/hiero_sdk_python/query/query.py
@@ -136,6 +136,9 @@ class Query(_Executable):
         """
         self.operator = self.operator or client.operator
 
+        if not self.node_account_ids:
+            self.node_account_ids = [node._account_id for node in client.network.nodes]
+
         # If no payment amount was specified and payment is required for this query,
         # get the cost from the network and set it as the payment amount
         if self.payment_amount is None and self._is_payment_required():
@@ -294,6 +297,9 @@ class Query(_Executable):
 
         if client is None or client.operator is None:
             raise ValueError("Client and operator must be set to get the cost")
+
+        if not self.node_account_ids:
+            self.node_account_ids = [node._account_id for node in client.network.nodes]
 
         # Here we execute the query to get the cost of it
         resp = self._execute(client)

--- a/src/hiero_sdk_python/query/query.py
+++ b/src/hiero_sdk_python/query/query.py
@@ -136,8 +136,8 @@ class Query(_Executable):
         """
         self.operator = self.operator or client.operator
 
-        if not self.node_account_ids:
-            self.node_account_ids = [node._account_id for node in client.network.nodes]
+        if self._node_account_ids.is_empty:
+            self._node_account_ids.set_list([node._account_id for node in client.network.nodes])
 
         # If no payment amount was specified and payment is required for this query,
         # get the cost from the network and set it as the payment amount
@@ -298,8 +298,8 @@ class Query(_Executable):
         if client is None or client.operator is None:
             raise ValueError("Client and operator must be set to get the cost")
 
-        if not self.node_account_ids:
-            self.node_account_ids = [node._account_id for node in client.network.nodes]
+        if self._node_account_ids.is_empty:
+            self._node_account_ids.set_list([node._account_id for node in client.network.nodes])
 
         # Here we execute the query to get the cost of it
         resp = self._execute(client)

--- a/src/hiero_sdk_python/query/query.py
+++ b/src/hiero_sdk_python/query/query.py
@@ -182,11 +182,11 @@ class Query(_Executable):
             header.responseType = query_header_pb2.ResponseType.COST_ANSWER
             return header
 
-        if self.operator is not None and self.node_account_id is not None and self.payment_amount is not None:
+        if self.operator is not None and not self._node_account_ids.is_empty and self.payment_amount is not None:
             payment_tx = self._build_query_payment_transaction(
                 payer_account_id=self.operator.account_id,
                 payer_private_key=self.operator.private_key,
-                node_account_id=self.node_account_id,
+                node_account_id=self._node_account_ids.current,
                 amount=self.payment_amount,
             )
             header.payment.CopyFrom(payment_tx)

--- a/src/hiero_sdk_python/transaction/query_payment.py
+++ b/src/hiero_sdk_python/transaction/query_payment.py
@@ -21,8 +21,8 @@ def build_query_payment_transaction(
     tx.add_hbar_transfer(node_account_id, amount.to_tinybars())
 
     tx.transaction_fee = 100_000_000
-    tx.node_account_id = node_account_id
-    tx.transaction_id = TransactionId.generate(payer_account_id)
+    tx.set_node_account_ids([node_account_id])
+    tx.set_transaction_id(TransactionId.generate(payer_account_id))
 
     body_bytes = tx.build_transaction_body().SerializeToString()
     tx._transaction_body_bytes.setdefault(node_account_id, body_bytes)

--- a/src/hiero_sdk_python/transaction/transaction.py
+++ b/src/hiero_sdk_python/transaction/transaction.py
@@ -216,9 +216,9 @@ class Transaction(_Executable):
         # We require the transaction to be frozen before converting to protobuf
         self._require_frozen()
 
-        body_bytes = self._transaction_body_bytes.get(self.node_account_id)
+        body_bytes = self._transaction_body_bytes.get(self._node_account_id)
         if body_bytes is None:
-            raise ValueError(f"No transaction body found for node {self.node_account_id}")
+            raise ValueError(f"No transaction body found for node {self._node_account_id}")
 
         # Get signature map, or create empty one if transaction is not signed
         sig_map = self._signature_map.get(body_bytes)
@@ -245,7 +245,7 @@ class Transaction(_Executable):
             )
 
     def _resolve_node_ids(self, client: Client):
-        if self.node_account_id is None and len(self.node_account_ids) == 0 and client is None:
+        if len(self.node_account_ids) == 0 and client is None:
             raise ValueError(
                 "Node account ID must be set before freezing. Use freeze_with(client) or manually set node_account_ids."
             )
@@ -297,27 +297,18 @@ class Transaction(_Executable):
 
         if self.batch_key:
             # For Inner Transaction of batch transaction node_account_id=0.0.0
-            self.node_account_id = AccountId(0, 0, 0)
+            self.node_account_ids = [AccountId(0, 0, 0)]
+            self._node_account_id = AccountId(0, 0, 0)
             self._transaction_body_bytes[AccountId(0, 0, 0)] = self.build_transaction_body().SerializeToString()
             return self
 
-        # Single node
-        if self.node_account_id:
-            self.set_node_account_id(self.node_account_id)
-            self._transaction_body_bytes[self.node_account_id] = self.build_transaction_body().SerializeToString()
-            return self
+        # If not nodes set manually use the all network nodes available in client
+        if len(self.node_account_ids) == 0:
+            self.node_account_ids = [node._account_id for node in client.network.nodes]
 
-        # Multiple node
-        if len(self.node_account_ids) > 0:
-            for node_account_id in self.node_account_ids:
-                self.node_account_id = node_account_id
-                self._transaction_body_bytes[node_account_id] = self.build_transaction_body().SerializeToString()
-
-        else:
-            # Use all nodes from client network
-            for node in client.network.nodes:
-                self.node_account_id = node._account_id
-                self._transaction_body_bytes[node._account_id] = self.build_transaction_body().SerializeToString()
+        for node_account_id in self.node_account_ids:
+            self._node_account_id = node_account_id
+            self._transaction_body_bytes[node_account_id] = self.build_transaction_body().SerializeToString()
 
         return self
 
@@ -405,7 +396,7 @@ class Transaction(_Executable):
         """
         public_key_bytes = public_key.to_bytes_raw()
 
-        sig_map = self._signature_map.get(self._transaction_body_bytes.get(self.node_account_id))
+        sig_map = self._signature_map.get(self._transaction_body_bytes.get(self._node_account_id))
 
         if sig_map is None:
             return False
@@ -459,7 +450,8 @@ class Transaction(_Executable):
 
         transaction_id_proto = self.transaction_id._to_proto()
 
-        selected_node = self.node_account_id or (self.node_account_ids[0] if self.node_account_ids else None)
+        # This will change with the fix for the chunk tx to create bytes on freeze
+        selected_node = self._node_account_id or (self.node_account_ids[0] if self.node_account_ids else None)
         if selected_node is None:
             raise ValueError("Node account ID is not set.")
 
@@ -877,7 +869,8 @@ class Transaction(_Executable):
             transaction.transaction_id = TransactionId._from_proto(transaction_body.transactionID)
 
         if transaction_body.HasField("nodeAccountID"):
-            transaction.node_account_id = AccountId._from_proto(transaction_body.nodeAccountID)
+            transaction._node_account_id = AccountId._from_proto(transaction_body.nodeAccountID)
+            transaction.node_account_ids = [AccountId._from_proto(transaction_body.nodeAccountID)]
 
         transaction.transaction_fee = transaction_body.transactionFee
         transaction.transaction_valid_duration = transaction_body.transactionValidDuration.seconds

--- a/src/hiero_sdk_python/transaction/transaction.py
+++ b/src/hiero_sdk_python/transaction/transaction.py
@@ -216,9 +216,9 @@ class Transaction(_Executable):
         # We require the transaction to be frozen before converting to protobuf
         self._require_frozen()
 
-        body_bytes = self._transaction_body_bytes.get(self._node_account_id)
+        body_bytes = self._transaction_body_bytes.get(self._node_account_ids.current)
         if body_bytes is None:
-            raise ValueError(f"No transaction body found for node {self._node_account_id}")
+            raise ValueError(f"No transaction body found for node {self._node_account_ids.current}")
 
         # Get signature map, or create empty one if transaction is not signed
         sig_map = self._signature_map.get(body_bytes)
@@ -245,10 +245,18 @@ class Transaction(_Executable):
             )
 
     def _resolve_node_ids(self, client: Client):
-        if len(self.node_account_ids) == 0 and client is None:
+        if self._node_account_ids.is_empty and client is None:
             raise ValueError(
                 "Node account ID must be set before freezing. Use freeze_with(client) or manually set node_account_ids."
             )
+
+        # For Inner Transaction of batch transaction node_account_id=0.0.0
+        if self.batch_key:
+            self._node_account_ids.set_list([AccountId(0, 0, 0)])
+
+        # If not nodes set manually use the all network nodes available in client
+        if self._node_account_ids.is_empty:
+            self._node_account_ids.set_list([node._account_id for node in client.network.nodes])
 
     def freeze(self):
         """
@@ -286,29 +294,22 @@ class Transaction(_Executable):
         if self._transaction_body_bytes:
             return self
 
-        # Check transaction_id and node id to be set when using freeze()
+        # Resolve transaction_id and node_accountids to be set when using freeze()
         self._resolve_transaction_id(client)
-
         self._resolve_node_ids(client)
 
-        # We iterate through every node in the client's network
-        # For each node, set the node_account_id and build the transaction body
-        # This allows the transaction to be submitted to any node in the network
+        # We iterate through every node in the node_account_id list and
+        # For each node_account_id build the transaction body
+        # This allows the transaction to be submitted to the given node in the network
 
-        if self.batch_key:
-            # For Inner Transaction of batch transaction node_account_id=0.0.0
-            self.node_account_ids = [AccountId(0, 0, 0)]
-            self._node_account_id = AccountId(0, 0, 0)
-            self._transaction_body_bytes[AccountId(0, 0, 0)] = self.build_transaction_body().SerializeToString()
-            return self
+        # TODO: Should lock the node_account_ids once freeze
+        # self._node_account_ids.set_lock(True)
 
-        # If not nodes set manually use the all network nodes available in client
-        if len(self.node_account_ids) == 0:
-            self.node_account_ids = [node._account_id for node in client.network.nodes]
-
-        for node_account_id in self.node_account_ids:
-            self._node_account_id = node_account_id
+        for node_account_id in self._node_account_ids.get_list():
             self._transaction_body_bytes[node_account_id] = self.build_transaction_body().SerializeToString()
+            self._node_account_ids.advance()
+
+        self._node_account_ids.set_index(0)
 
         return self
 
@@ -396,7 +397,7 @@ class Transaction(_Executable):
         """
         public_key_bytes = public_key.to_bytes_raw()
 
-        sig_map = self._signature_map.get(self._transaction_body_bytes.get(self._node_account_id))
+        sig_map = self._signature_map.get(self._transaction_body_bytes.get(self._node_account_ids.current))
 
         if sig_map is None:
             return False
@@ -450,8 +451,8 @@ class Transaction(_Executable):
 
         transaction_id_proto = self.transaction_id._to_proto()
 
-        # This will change with the fix for the chunk tx to create bytes on freeze
-        selected_node = self._node_account_id or (self.node_account_ids[0] if self.node_account_ids else None)
+        # This will move to freeze_with for the fix for the chunk tx to create bytes on freeze
+        selected_node = self._node_account_ids.current if not self._node_account_ids.is_empty else None
         if selected_node is None:
             raise ValueError("Node account ID is not set.")
 

--- a/src/hiero_sdk_python/transaction/transaction.py
+++ b/src/hiero_sdk_python/transaction/transaction.py
@@ -885,10 +885,11 @@ class Transaction(_Executable):
                 CustomFeeLimit._from_proto(fee) for fee in transaction_body.max_custom_fees
             ]
 
-        if transaction.node_account_id:
+        if not transaction._node_account_ids.is_empty:
             # restore for the original frozen node
-            transaction.set_node_account_id(transaction.node_account_id)
-            transaction._transaction_body_bytes[transaction.node_account_id] = body_bytes
+            # TODO: This will change, Instead of node_account_id use the signature map to decide if we need to freeze
+            # node_account_ids will always contain single id in currrent impl
+            transaction._transaction_body_bytes[transaction._node_account_ids.current] = body_bytes
 
         if sig_map and sig_map.sigPair:
             transaction._signature_map[body_bytes] = sig_map

--- a/src/hiero_sdk_python/transaction/transaction.py
+++ b/src/hiero_sdk_python/transaction/transaction.py
@@ -870,8 +870,7 @@ class Transaction(_Executable):
             transaction.transaction_id = TransactionId._from_proto(transaction_body.transactionID)
 
         if transaction_body.HasField("nodeAccountID"):
-            transaction._node_account_id = AccountId._from_proto(transaction_body.nodeAccountID)
-            transaction.node_account_ids = [AccountId._from_proto(transaction_body.nodeAccountID)]
+            transaction._node_account_ids.set_list([AccountId._from_proto(transaction_body.nodeAccountID)])
 
         transaction.transaction_fee = transaction_body.transactionFee
         transaction.transaction_valid_duration = transaction_body.transactionValidDuration.seconds

--- a/src/hiero_sdk_python/transaction/transaction_response.py
+++ b/src/hiero_sdk_python/transaction/transaction_response.py
@@ -49,7 +49,7 @@ class TransactionResponse:
         return (
             TransactionGetReceiptQuery()
             .set_transaction_id(self.transaction_id)
-            .set_node_account_id(self.node_id)
+            .set_node_account_ids([self.node_id])
             .set_validate_status(validate_status)
         )
 

--- a/tests/fuzz/support/helpers.py
+++ b/tests/fuzz/support/helpers.py
@@ -51,8 +51,8 @@ def build_valid_transaction_bytes() -> tuple[bytes, bytes]:
     receiver_id = AccountId.from_string("0.0.5678")
 
     tx = TransferTransaction().add_hbar_transfer(operator_id, -100_000_000).add_hbar_transfer(receiver_id, 100_000_000)
-    tx.transaction_id = TransactionId.generate(operator_id)
-    tx.node_account_id = node_id
+    tx.set_transaction_id(TransactionId.generate(operator_id))
+    tx.set_node_account_ids([node_id])
     tx.freeze()
     unsigned_bytes = tx.to_bytes()
 

--- a/tests/integration/file_append_transaction_e2e_test.py
+++ b/tests/integration/file_append_transaction_e2e_test.py
@@ -314,7 +314,7 @@ def test_file_append_chunk_transaction_can_execute_with_manual_freeze(env):
         .set_chunk_size(1024)
         .set_contents(content)
         .set_transaction_id(TransactionId.generate(env.client.operator_account_id))
-        .set_node_account_id(AccountId(0, 0, 3))
+        .set_node_account_ids([AccountId(0, 0, 3)])
         .freeze()
     )
 

--- a/tests/integration/topic_message_submit_transaction_e2e_test.py
+++ b/tests/integration/topic_message_submit_transaction_e2e_test.py
@@ -308,7 +308,7 @@ def test_topic_message_submit_transaction_can_submit_a_large_message_manual_free
         .set_topic_id(topic_id)
         .set_message(message)
         .set_transaction_id(TransactionId.generate(env.client.operator_account_id))
-        .set_node_account_id(AccountId(0, 0, 3))
+        .set_node_account_ids([AccountId(0, 0, 3)])
         .freeze()
     )
 

--- a/tests/integration/transaction_freeze_e2e_test.py
+++ b/tests/integration/transaction_freeze_e2e_test.py
@@ -56,7 +56,7 @@ def test_transaction_executes_successfully_with_single_node_account_id(env):
     executor_key = env.operator_key
 
     tx = TopicCreateTransaction().set_memo("Test Topic Creation")
-    tx.set_node_account_id(node_account_id)
+    tx.set_node_account_ids([node_account_id])
     tx.freeze_with(executor_client)
     tx.sign(executor_key)
 
@@ -79,7 +79,7 @@ def test_transaction_executes_successfully_after_manual_freeze(env):
 
     # Manually set Node and ID
     tx.set_transaction_id(tx_id)
-    tx.node_account_id = AccountId.from_string("0.0.3")  # Explicitly set to 0.0.3
+    tx.set_node_account_ids([AccountId.from_string("0.0.3")])  # Explicitly set to 0.0.3
 
     # Manual Freeze (Generates body ONLY for 0.0.3)
     tx.freeze()

--- a/tests/unit/account_create_transaction_test.py
+++ b/tests/unit/account_create_transaction_test.py
@@ -58,7 +58,7 @@ def test_account_create_transaction_build(mock_account_ids):
         .set_account_memo("Test account")
     )
     account_tx.transaction_id = generate_transaction_id(operator_id)
-    account_tx.node_account_id = node_account_id
+    account_tx.set_node_account_ids([node_account_id])
 
     transaction_body = account_tx.build_transaction_body()
 
@@ -85,7 +85,7 @@ def test_account_create_transaction_build_scheduled_body(mock_account_ids):
         .set_receiver_signature_required(True)
     )
     account_tx.transaction_id = generate_transaction_id(operator_id)
-    account_tx.node_account_id = node_account_id
+    account_tx.set_node_account_ids([node_account_id])
 
     # Build the scheduled transaction body
     schedulable_body = account_tx.build_scheduled_body()
@@ -120,7 +120,7 @@ def test_account_create_transaction_sign(mock_account_ids, mock_client):
         .set_account_memo("Test account")
     )
     account_tx.transaction_id = generate_transaction_id(operator_id)
-    account_tx.node_account_id = node_account_id
+    account_tx.set_node_account_ids([node_account_id])
     account_tx.freeze_with(mock_client)
 
     # Add first signiture
@@ -197,7 +197,7 @@ def test_sign_account_create_without_freezing_raises_error(mock_account_ids):
         .set_account_memo("Test account")
     )
     account_tx.transaction_id = generate_transaction_id(operator_id)
-    account_tx.node_account_id = node_account_id
+    account_tx.set_node_account_ids([node_account_id])
 
     with pytest.raises(Exception, match="Transaction is not frozen"):
         account_tx.sign(new_private_key)
@@ -246,7 +246,7 @@ def test_account_create_build_with_max_auto_assoc(mock_account_ids):
         .set_max_automatic_token_associations(-1)  # Test the new value
     )
     account_tx.transaction_id = generate_transaction_id(operator_id)
-    account_tx.node_account_id = node_account_id
+    account_tx.set_node_account_ids([node_account_id])
 
     body = account_tx.build_transaction_body()
 
@@ -264,7 +264,7 @@ def test_create_account_transaction_without_alias(mock_account_ids):
     assert tx.alias is None
 
     tx.operator_account_id = operator_id
-    tx.node_account_id = node_id
+    tx.set_node_account_ids([node_id])
     tx_body = tx.build_transaction_body()
 
     assert tx_body.cryptoCreateAccount.key == public_key._to_proto()
@@ -282,7 +282,7 @@ def test_create_account_transaction_set_key_with_alias(mock_account_ids):
     assert tx.alias == public_key.to_evm_address()
 
     tx.operator_account_id = operator_id
-    tx.node_account_id = node_id
+    tx.set_node_account_ids([node_id])
     tx_body = tx.build_transaction_body()
 
     assert tx_body.cryptoCreateAccount.key == public_key._to_proto()
@@ -303,7 +303,7 @@ def test_create_account_transaction_set_key_with_seperate_key_for_alias(
     assert tx.alias == alias_key.to_evm_address()
 
     tx.operator_account_id = operator_id
-    tx.node_account_id = node_id
+    tx.set_node_account_ids([node_id])
     tx_body = tx.build_transaction_body()
 
     assert tx_body.cryptoCreateAccount.key == public_key._to_proto()
@@ -335,7 +335,7 @@ def test_create_account_transaction_with_set_alias(mock_account_ids):
     assert tx.alias == evm_address
 
     tx.operator_account_id = operator_id
-    tx.node_account_id = node_id
+    tx.set_node_account_ids([node_id])
     tx_body = tx.build_transaction_body()
 
     assert tx_body.cryptoCreateAccount.key == public_key._to_proto()
@@ -358,7 +358,7 @@ def test_create_account_transaction_with_set_alias_from_string(mock_account_ids,
     assert tx.alias == evm_address
 
     tx.operator_account_id = operator_id
-    tx.node_account_id = node_id
+    tx.set_node_account_ids([node_id])
     tx_body = tx.build_transaction_body()
 
     assert tx_body.cryptoCreateAccount.key == public_key._to_proto()
@@ -411,7 +411,7 @@ def test_account_create_transaction_build_with_private_key(mock_account_ids):
     )
 
     tx.transaction_id = generate_transaction_id(operator_id)
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
 
     body = tx.build_transaction_body()
 
@@ -441,7 +441,7 @@ def test_create_account_transaction_set_key_with_alias_private_keys(mock_account
     assert tx.alias == expected_evm_address
 
     tx.operator_account_id = operator_id
-    tx.node_account_id = node_id
+    tx.set_node_account_ids([node_id])
     tx_body = tx.build_transaction_body()
 
     # In the proto we should have account public key
@@ -469,7 +469,7 @@ def test_create_account_transaction_set_key_with_alias_private_key_without_ecdsa
     assert tx.alias == expected_evm_address
 
     tx.operator_account_id = operator_id
-    tx.node_account_id = node_id
+    tx.set_node_account_ids([node_id])
     tx_body = tx.build_transaction_body()
 
     # In the proto we should have account public key

--- a/tests/unit/account_delete_transaction_test.py
+++ b/tests/unit/account_delete_transaction_test.py
@@ -73,7 +73,7 @@ def test_build_transaction_body_with_valid_parameters(mock_account_ids, delete_p
 
     # Set operator and node account IDs needed for building transaction body
     delete_tx.operator_account_id = operator_id
-    delete_tx.node_account_id = node_account_id
+    delete_tx.set_node_account_ids([node_account_id])
 
     transaction_body = delete_tx.build_transaction_body()
 

--- a/tests/unit/account_update_transaction_test.py
+++ b/tests/unit/account_update_transaction_test.py
@@ -232,7 +232,7 @@ def test_build_transaction_body(mock_account_ids):
 
     # Set operator and node account IDs needed for building transaction body
     account_tx.operator_account_id = operator_id
-    account_tx.node_account_id = node_account_id
+    account_tx.set_node_account_ids([node_account_id])
 
     transaction_body = account_tx.build_transaction_body()
 
@@ -254,7 +254,7 @@ def test_build_transaction_body_with_optional_fields(mock_account_ids):
 
     # Set operator and node account IDs needed for building transaction body
     account_tx.operator_account_id = operator_id
-    account_tx.node_account_id = node_account_id
+    account_tx.set_node_account_ids([node_account_id])
 
     transaction_body = account_tx.build_transaction_body()
 
@@ -281,7 +281,7 @@ def test_build_transaction_body_account_memo_variants(mock_account_ids):
 
     # Set operator and node account IDs needed for building transaction body
     account_tx.operator_account_id = operator_id
-    account_tx.node_account_id = node_account_id
+    account_tx.set_node_account_ids([node_account_id])
 
     transaction_body = account_tx.build_transaction_body()
 
@@ -311,7 +311,7 @@ def test_build_transaction_body_receiver_sig_required_variants(mock_account_ids)
 
     # Set operator and node account IDs needed for building transaction body
     account_tx.operator_account_id = operator_id
-    account_tx.node_account_id = node_account_id
+    account_tx.set_node_account_ids([node_account_id])
 
     transaction_body = account_tx.build_transaction_body()
 
@@ -469,7 +469,7 @@ def test_build_transaction_body_with_none_auto_renew_period(mock_account_ids):
     account_tx.set_account_id(account_id)
     account_tx.set_auto_renew_period(None)
     account_tx.operator_account_id = operator_id
-    account_tx.node_account_id = node_account_id
+    account_tx.set_node_account_ids([node_account_id])
 
     transaction_body = account_tx.build_transaction_body()
 
@@ -503,7 +503,7 @@ def test_build_scheduled_body(mock_account_ids):
 
     # Set operator and node account IDs needed for building transaction body
     account_tx.operator_account_id = operator_id
-    account_tx.node_account_id = node_account_id
+    account_tx.set_node_account_ids([node_account_id])
 
     # Build the scheduled body
     schedulable_body = account_tx.build_scheduled_body()
@@ -696,7 +696,7 @@ def test_build_transaction_body_with_new_fields(mock_account_ids):
     account_tx.set_decline_staking_reward(True)
 
     account_tx.operator_account_id = operator_id
-    account_tx.node_account_id = node_account_id
+    account_tx.set_node_account_ids([node_account_id])
 
     transaction_body = account_tx.build_transaction_body()
 
@@ -717,7 +717,7 @@ def test_build_transaction_body_with_staked_node_id(mock_account_ids):
     account_tx.set_staked_node_id(staked_node_id)
 
     account_tx.operator_account_id = operator_id
-    account_tx.node_account_id = node_account_id
+    account_tx.set_node_account_ids([node_account_id])
 
     transaction_body = account_tx.build_transaction_body()
 
@@ -736,7 +736,7 @@ def test_build_transaction_body_with_optional_new_fields_none(mock_account_ids):
     account_tx.set_account_id(account_id)
 
     account_tx.operator_account_id = operator_id
-    account_tx.node_account_id = node_account_id
+    account_tx.set_node_account_ids([node_account_id])
 
     transaction_body = account_tx.build_transaction_body()
 
@@ -756,7 +756,7 @@ def test_build_transaction_body_with_cleared_staking(mock_account_ids):
     account_tx = AccountUpdateTransaction().set_account_id(account_id)
     account_tx.set_staked_account_id(None)
     account_tx.operator_account_id = operator_id
-    account_tx.node_account_id = node_account_id
+    account_tx.set_node_account_ids([node_account_id])
     txn_body = account_tx.build_transaction_body().cryptoUpdateAccount
     assert txn_body.staked_account_id.accountNum == 0
     assert txn_body.staked_account_id.realmNum == 0
@@ -767,7 +767,7 @@ def test_build_transaction_body_with_cleared_staking(mock_account_ids):
     account_tx = AccountUpdateTransaction().set_account_id(account_id)
     account_tx.set_staked_node_id(None)
     account_tx.operator_account_id = operator_id
-    account_tx.node_account_id = node_account_id
+    account_tx.set_node_account_ids([node_account_id])
     txn_body = account_tx.build_transaction_body().cryptoUpdateAccount
     assert txn_body.staked_node_id == -1
     assert not txn_body.HasField("staked_account_id")

--- a/tests/unit/associated_registered_nodes_test.py
+++ b/tests/unit/associated_registered_nodes_test.py
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.unit
 
 def _freeze(tx):
     tx.transaction_id = TransactionId.generate(AccountId(0, 0, 100))
-    tx.node_account_id = AccountId(0, 0, 3)
+    tx.set_node_account_ids([AccountId(0, 0, 3)])
     tx.freeze()
     return tx
 
@@ -41,7 +41,7 @@ class TestNodeCreateAssociatedRegisteredNodes:
         tx = NodeCreateTransaction()
         tx.set_associated_registered_nodes([1, 2, 3])
         tx.operator_account_id = operator_id
-        tx.node_account_id = node_account_id
+        tx.set_node_account_ids([node_account_id])
         body = tx.build_transaction_body()
         assert list(body.nodeCreate.associated_registered_node) == [1, 2, 3]
 
@@ -55,7 +55,7 @@ class TestNodeCreateAssociatedRegisteredNodes:
         assert tx.associated_registered_nodes == [10, 20]
 
         tx.operator_account_id = operator_id
-        tx.node_account_id = node_account_id
+        tx.set_node_account_ids([node_account_id])
         body = tx.build_transaction_body()
         assert list(body.nodeCreate.associated_registered_node) == [10, 20]
 
@@ -82,7 +82,7 @@ class TestNodeCreateAssociatedRegisteredNodes:
         operator_id, _, node_account_id, _, _ = mock_account_ids
         tx = NodeCreateTransaction()
         tx.operator_account_id = operator_id
-        tx.node_account_id = node_account_id
+        tx.set_node_account_ids([node_account_id])
         body = tx.build_transaction_body()
         assert len(body.nodeCreate.associated_registered_node) == 0
 
@@ -113,7 +113,7 @@ class TestNodeUpdateAssociatedRegisteredNodes:
         tx = NodeUpdateTransaction()
         tx.node_id = 1
         tx.operator_account_id = operator_id
-        tx.node_account_id = node_account_id
+        tx.set_node_account_ids([node_account_id])
         body = tx.build_transaction_body()
         assert not body.nodeUpdate.HasField("associated_registered_node_list")
 
@@ -124,7 +124,7 @@ class TestNodeUpdateAssociatedRegisteredNodes:
         tx.node_id = 1
         tx.clear_associated_registered_nodes()
         tx.operator_account_id = operator_id
-        tx.node_account_id = node_account_id
+        tx.set_node_account_ids([node_account_id])
         body = tx.build_transaction_body()
         assert body.nodeUpdate.HasField("associated_registered_node_list")
         assert len(body.nodeUpdate.associated_registered_node_list.associated_registered_node) == 0
@@ -136,7 +136,7 @@ class TestNodeUpdateAssociatedRegisteredNodes:
         tx.node_id = 1
         tx.set_associated_registered_nodes([10, 20])
         tx.operator_account_id = operator_id
-        tx.node_account_id = node_account_id
+        tx.set_node_account_ids([node_account_id])
         body = tx.build_transaction_body()
         assert body.nodeUpdate.HasField("associated_registered_node_list")
         assert list(body.nodeUpdate.associated_registered_node_list.associated_registered_node) == [10, 20]
@@ -198,7 +198,7 @@ class TestNodeUpdateAssociatedRegisteredNodes:
         tx.node_id = 1
         tx.set_description("hello")
         tx.operator_account_id = operator_id
-        tx.node_account_id = node_account_id
+        tx.set_node_account_ids([node_account_id])
         body = tx.build_transaction_body()
         assert body.nodeUpdate.description.value == "hello"
         assert not body.nodeUpdate.HasField("associated_registered_node_list")

--- a/tests/unit/batch_transaction_test.py
+++ b/tests/unit/batch_transaction_test.py
@@ -241,12 +241,12 @@ def test_build_batch_transaction_body(mock_account_ids, mock_client):
     )
 
     # verify inner transaction fields
-    assert inner_tx.node_account_id == AccountId(0, 0, 0)
+    assert inner_tx._node_account_ids.current == AccountId(0, 0, 0)
     assert inner_tx.batch_key == batch_key
 
     batch_tx = BatchTransaction().add_inner_transaction(inner_tx)
     batch_tx.operator_account_id = sender_id
-    batch_tx.node_account_id = node_id
+    batch_tx.set_node_account_ids([node_id])
 
     body = batch_tx._build_proto_body()
 
@@ -269,7 +269,7 @@ def test_batchify_sets_required_fields(mock_account_ids, mock_client):
 
     assert tx._transaction_body_bytes is not None, "batchify should set _transaction_body_bytes"
     assert tx.batch_key == batch_key
-    assert tx.node_account_id == AccountId(0, 0, 0), "node_account_id for batched tx should be 0.0.0"
+    assert tx._node_account_ids.current == AccountId(0, 0, 0), "node_account_id for batched tx should be 0.0.0"
 
 
 def test_round_trip_to_bytes_and_back_preserves_inner_transactions(mock_account_ids, mock_client):

--- a/tests/unit/contract_create_transaction_test.py
+++ b/tests/unit/contract_create_transaction_test.py
@@ -137,7 +137,7 @@ def test_build_transaction_body_with_bytecode_file_id(mock_account_ids, contract
 
     # Set operator and node account IDs needed for building transaction body
     contract_tx.operator_account_id = operator_id
-    contract_tx.node_account_id = node_account_id
+    contract_tx.set_node_account_ids([node_account_id])
 
     transaction_body = contract_tx.build_transaction_body()
 
@@ -164,7 +164,7 @@ def test_build_transaction_body_with_bytecode(mock_account_ids, contract_params)
 
     # Set operator and node account IDs needed for building transaction body
     contract_tx.operator_account_id = operator_id
-    contract_tx.node_account_id = node_account_id
+    contract_tx.set_node_account_ids([node_account_id])
 
     transaction_body = contract_tx.build_transaction_body()
 
@@ -191,7 +191,7 @@ def test_build_scheduled_body(mock_account_ids, contract_params):
 
     # Set operator and node account IDs needed for building transaction body
     contract_tx.operator_account_id = operator_id
-    contract_tx.node_account_id = node_account_id
+    contract_tx.set_node_account_ids([node_account_id])
 
     # Build the scheduled body
     schedulable_body = contract_tx.build_scheduled_body()

--- a/tests/unit/contract_delete_transaction_test.py
+++ b/tests/unit/contract_delete_transaction_test.py
@@ -77,7 +77,7 @@ def test_build_transaction_body_with_valid_parameters(mock_account_ids, delete_p
 
     # Set operator and node account IDs needed for building transaction body
     delete_tx.operator_account_id = operator_id
-    delete_tx.node_account_id = node_account_id
+    delete_tx.set_node_account_ids([node_account_id])
 
     transaction_body = delete_tx.build_transaction_body()
 
@@ -96,7 +96,7 @@ def test_build_transaction_body_with_required_params_only(mock_account_ids, cont
 
     # Set operator and node account IDs needed for building transaction body
     delete_tx.operator_account_id = operator_id
-    delete_tx.node_account_id = node_account_id
+    delete_tx.set_node_account_ids([node_account_id])
 
     transaction_body = delete_tx.build_transaction_body()
 
@@ -116,7 +116,7 @@ def test_build_transaction_body_with_transfer_contract_id_only(mock_account_ids,
     )
 
     delete_tx.operator_account_id = operator_id
-    delete_tx.node_account_id = node_account_id
+    delete_tx.set_node_account_ids([node_account_id])
 
     transaction_body = delete_tx.build_transaction_body()
 
@@ -138,7 +138,7 @@ def test_build_transaction_body_with_transfer_account_id_only(mock_account_ids, 
     )
 
     delete_tx.operator_account_id = operator_id
-    delete_tx.node_account_id = node_account_id
+    delete_tx.set_node_account_ids([node_account_id])
 
     transaction_body = delete_tx.build_transaction_body()
 
@@ -158,7 +158,7 @@ def test_build_transaction_body_with_permanent_removal_only(mock_account_ids, de
     )
 
     delete_tx.operator_account_id = operator_id
-    delete_tx.node_account_id = node_account_id
+    delete_tx.set_node_account_ids([node_account_id])
 
     transaction_body = delete_tx.build_transaction_body()
 

--- a/tests/unit/contract_execute_transaction_test.py
+++ b/tests/unit/contract_execute_transaction_test.py
@@ -83,7 +83,7 @@ def test_build_transaction_body_with_valid_parameters(mock_account_ids, execute_
 
     # Set operator and node account IDs needed for building transaction body
     execute_tx.operator_account_id = operator_id
-    execute_tx.node_account_id = node_account_id
+    execute_tx.set_node_account_ids([node_account_id])
 
     transaction_body = execute_tx.build_transaction_body()
 
@@ -106,7 +106,7 @@ def test_build_scheduled_body_with_valid_parameters(mock_account_ids, execute_pa
 
     # Set operator and node account IDs needed for building transaction body
     execute_tx.operator_account_id = operator_id
-    execute_tx.node_account_id = node_account_id
+    execute_tx.set_node_account_ids([node_account_id])
 
     schedulable_body = execute_tx.build_scheduled_body()
 
@@ -303,7 +303,7 @@ def test_build_transaction_body_with_required_params(mock_account_ids, contract_
 
     # Set operator and node account IDs needed for building transaction body
     execute_tx.operator_account_id = operator_id
-    execute_tx.node_account_id = node_account_id
+    execute_tx.set_node_account_ids([node_account_id])
 
     transaction_body = execute_tx.build_transaction_body()
 

--- a/tests/unit/contract_update_transaction_test.py
+++ b/tests/unit/contract_update_transaction_test.py
@@ -206,7 +206,7 @@ def test_build_transaction_body_success(contract_id, mock_account_ids, transacti
     tx.set_contract_id(contract_id)
     tx.set_contract_memo("Test memo")
     tx.transaction_id = transaction_id
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
 
     transaction_body = tx.build_transaction_body()
 
@@ -241,7 +241,7 @@ def test_build_transaction_body_with_all_parameters(update_params, mock_account_
     )
     tx = ContractUpdateTransaction(contract_params=constructor_params)
     tx.transaction_id = transaction_id
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
 
     transaction_body = tx.build_transaction_body()
 
@@ -271,7 +271,7 @@ def test_build_scheduled_body_with_all_parameters(update_params, mock_account_id
     )
     tx = ContractUpdateTransaction(contract_params=constructor_params)
     tx.transaction_id = transaction_id
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
 
     schedulable_body = tx.build_scheduled_body()
 

--- a/tests/unit/ethereum_transaction_test.py
+++ b/tests/unit/ethereum_transaction_test.py
@@ -68,7 +68,7 @@ def test_build_transaction_body_with_valid_parameters(mock_account_ids, ethereum
 
     # Set operator and node account IDs needed for building transaction body
     ethereum_tx.operator_account_id = operator_id
-    ethereum_tx.node_account_id = node_account_id
+    ethereum_tx.set_node_account_ids([node_account_id])
 
     transaction_body = ethereum_tx.build_transaction_body()
 
@@ -86,7 +86,7 @@ def test_build_transaction_body_with_minimal_parameters(mock_account_ids):
 
     # Set operator and node account IDs needed for building transaction body
     ethereum_tx.operator_account_id = operator_id
-    ethereum_tx.node_account_id = node_account_id
+    ethereum_tx.set_node_account_ids([node_account_id])
 
     transaction_body = ethereum_tx.build_transaction_body()
 

--- a/tests/unit/executable_test.py
+++ b/tests/unit/executable_test.py
@@ -816,7 +816,7 @@ def test_execution_config_inherits_from_client(mock_client):
     mock_client._request_timeout = 20
 
     tx = AccountCreateTransaction()
-
+    tx.set_node_account_ids([AccountId(0, 0, 3)])
     tx._resolve_execution_config(mock_client, None)
 
     assert tx._max_attempts == 7
@@ -831,19 +831,19 @@ def test_executable_overrides_client_config(mock_client):
     mock_client.max_attempts = 10
 
     tx = AccountCreateTransaction().set_max_attempts(3)
+    tx.set_node_account_ids([AccountId(0, 0, 3)])
     tx._resolve_execution_config(mock_client, None)
 
     assert tx._max_attempts == 3
 
 
-def test_no_healthy_nodes_raises(mock_client):
-    """Test that execution fails if no healthy nodes are available."""
-    mock_client.network._healthy_nodes = []
-
+def test_no_nodes_raises_exception(mock_client):
+    """Test that execution fails if no nodes are available."""
+    mock_client.network.nodes = []
     tx = AccountCreateTransaction().set_key_without_alias(PrivateKey.generate().public_key()).set_initial_balance(1)
 
-    with pytest.raises(RuntimeError, match="No healthy nodes available"):
-        tx.execute(mock_client)
+    with pytest.raises(RuntimeError, match="No nodes available for execution"):
+        tx._resolve_execution_config(mock_client, None)
 
 
 def test_set_node_account_ids_overrides_client_nodes(mock_client):
@@ -859,6 +859,7 @@ def test_set_node_account_ids_overrides_client_nodes(mock_client):
 def test_parameter_timeout_overrides_client_default(mock_client):
     """Explicit timeout pass on the executable should override the client default timeout."""
     tx = AccountCreateTransaction()
+    tx.set_node_account_ids([AccountId(0, 0, 3)])
     tx._resolve_execution_config(mock_client, 2)
 
     assert tx._request_timeout == 2
@@ -868,6 +869,7 @@ def test_set_timeout_overrides_parameter_timeout(mock_client):
     """Explicit timeout set on the tx should override the pass timeout."""
     tx = AccountCreateTransaction()
     tx.set_request_timeout(5)
+    tx.set_node_account_ids([AccountId(0, 0, 3)])
     tx._resolve_execution_config(mock_client, 2)
 
     assert tx._request_timeout == 5

--- a/tests/unit/executable_test.py
+++ b/tests/unit/executable_test.py
@@ -846,7 +846,7 @@ def test_set_node_account_ids_overrides_client_nodes(mock_client):
     """Explicit node_account_ids should override client network."""
     node = AccountId(0, 0, 999)
 
-    tx = AccountCreateTransaction().set_node_account_id(node)
+    tx = AccountCreateTransaction().set_node_account_ids([node])
     tx._resolve_execution_config(mock_client, None)
 
     assert tx.node_account_ids == [node]

--- a/tests/unit/executable_test.py
+++ b/tests/unit/executable_test.py
@@ -140,7 +140,7 @@ def test_node_switching_after_single_grpc_error():
         except (Exception, grpc.RpcError) as e:
             pytest.fail(f"Transaction execution should not raise an exception, but raised: {e}")
         # Verify we're now on the second node
-        assert transaction.node_account_ids[transaction._node_account_ids_index] == AccountId(0, 0, 4), (
+        assert transaction._node_account_ids.current == AccountId(0, 0, 4), (
             "Client should have switched to the second node"
         )
 
@@ -179,7 +179,7 @@ def test_node_switching_after_multiple_grpc_errors():
             pytest.fail(f"Transaction execution should not raise an exception, but raised: {e}")
 
         # Verify we're now on the third node
-        assert transaction.node_account_ids[transaction._node_account_ids_index] == AccountId(0, 0, 5), (
+        assert transaction._node_account_ids.current == AccountId(0, 0, 5), (
             "Client should have switched to the third node"
         )
         assert receipt.status == ResponseCode.SUCCESS
@@ -300,7 +300,7 @@ def test_retriable_error_does_not_switch_node():
         except (Exception, grpc.RpcError) as e:
             pytest.fail(f"Transaction execution should not raise an exception, but raised: {e}")
 
-        assert client.network.current_node._account_id == AccountId(0, 0, 3), (
+        assert transaction._node_account_ids.current == AccountId(0, 0, 3), (
             "Client should not switch node on retriable errors"
         )
 
@@ -346,7 +346,7 @@ def test_topic_create_transaction_retry_on_busy():
         assert mock_sleep.call_count == 1, "Should have retried once"
 
         # Verify we didn't switch nodes (BUSY is retriable without node switch)
-        assert client.network.current_node._account_id == AccountId(0, 0, 3), "Should not have switched nodes on BUSY"
+        assert tx._node_account_ids.current == AccountId(0, 0, 3), "Should not have switched nodes on BUSY"
 
 
 def test_topic_create_transaction_fails_on_nonretriable_error():
@@ -389,10 +389,6 @@ def test_transaction_node_switching_body_bytes():
         mock_hedera_servers(response_sequences) as client,
         patch("hiero_sdk_python.executable.time.sleep"),
     ):
-        # We set the current node to 0
-        client.network._node_index = 0
-        client.network.current_node = client.network.nodes[0]
-
         transaction = (
             AccountCreateTransaction()
             .set_key_without_alias(PrivateKey.generate().public_key())
@@ -413,11 +409,14 @@ def test_transaction_node_switching_body_bytes():
             )
 
         try:
+            assert transaction._node_account_ids.current == AccountId(0, 0, 3), (
+                "Current node should be the first configured node"
+            )
             transaction.execute(client)
         except (Exception, grpc.RpcError) as e:
             pytest.fail(f"Transaction execution should not raise an exception, but raised: {e}")
         # Verify we're now on the second node
-        assert transaction.node_account_ids[transaction._node_account_ids_index] == AccountId(0, 0, 4), (
+        assert transaction._node_account_ids.current == AccountId(0, 0, 4), (
             "Client should have switched to the second node"
         )
 
@@ -462,10 +461,6 @@ def test_query_retry_on_busy():
         mock_hedera_servers(response_sequences) as client,
         patch("hiero_sdk_python.executable.time.sleep") as mock_sleep,
     ):
-        # We set the current node to the first node so we are sure it will return BUSY response
-        client.network._node_index = 0
-        client.network.current_node = client.network.nodes[0]
-
         query = CryptoGetAccountBalanceQuery()
         query.set_account_id(AccountId(0, 0, 1234))
 
@@ -476,10 +471,8 @@ def test_query_retry_on_busy():
 
         assert balance.hbars.to_tinybars() == 100000000
         # Verify we switched to the second node
-        assert query._node_account_ids_index == 1
-        assert query.node_account_ids[query._node_account_ids_index] == AccountId(0, 0, 4), (
-            "Client should have switched to the second node"
-        )
+        assert query._node_account_ids._index == 1
+        assert query._node_account_ids.current == AccountId(0, 0, 4), "Client should have switched to the second node"
 
 
 # Set max_attempts
@@ -974,7 +967,7 @@ def test_should_exponential_error_mark_node_unhealty_and_advance(error):
         # No delay_for_attempt backoff call, Node is mark unhealthy and advance
         assert mock_sleep.call_count == 0
         # Node must have changed
-        assert tx._node_account_ids_index == 1
+        assert tx._node_account_ids._index == 1
 
 
 def test_rst_stream_error_marks_node_unhealthy_and_advances_without_backoff():
@@ -1008,7 +1001,7 @@ def test_rst_stream_error_marks_node_unhealthy_and_advances_without_backoff():
         # RST_STREAM exponential retry does not use delay-based backoff
         assert mock_sleep.call_count == 0
         # Node must advance after marking the first node unhealthy
-        assert tx._node_account_ids_index == 1
+        assert tx._node_account_ids._index == 1
 
 
 @pytest.mark.parametrize(
@@ -1062,7 +1055,7 @@ def test_execution_skips_unhealthy_nodes_and_advances():
 
         assert receipt.status == ResponseCode.SUCCESS
         # Ensure the node index advanced past the unhealthy node
-        assert tx._node_account_ids_index == 1
+        assert tx._node_account_ids._index == 1
 
 
 def test_execution_raises_if_all_nodes_unhealthy(mock_client):
@@ -1086,7 +1079,7 @@ def test_execution_raises_if_all_nodes_unhealthy(mock_client):
 )
 def test_unhealthy_node_receipt_request_triggers_delay_and_no_node_change(tx, mock_client):
     """Unhealthy node with transaction receipt/record request calls _delay_for_attempt but does not advance node."""
-    initial_index = tx._node_account_ids_index
+    initial_index = tx._node_account_ids._index
 
     with (
         patch("hiero_sdk_python.node._Node.is_healthy", return_value=False),
@@ -1098,7 +1091,7 @@ def test_unhealthy_node_receipt_request_triggers_delay_and_no_node_change(tx, mo
         # _delay_for_attempt called
         assert mock_delay.call_count > 0
         # Node index did NOT change
-        assert tx._node_account_ids_index == initial_index
+        assert tx._node_account_ids._index == initial_index
 
 
 def test_retry_invalid_node_account_updates_network():
@@ -1144,7 +1137,7 @@ def test_retry_invalid_node_account_updates_network():
         tx.execute(client)
 
         # Node index must advance after INVALID_NODE_ACCOUNT
-        assert tx._node_account_ids_index == 1
+        assert tx._node_account_ids._index == 1
 
         # Recovery actions
         mock_increase_backoff.assert_called_once()

--- a/tests/unit/executable_test.py
+++ b/tests/unit/executable_test.py
@@ -284,7 +284,10 @@ def test_retriable_error_does_not_switch_node():
             receipt=transaction_receipt_pb2.TransactionReceipt(status=ResponseCode.SUCCESS),
         )
     )
-    response_sequences = [[busy_response, ok_response, receipt_response]]
+    response_sequences = [
+        [busy_response, ok_response, receipt_response],
+        [ok_response, receipt_response],  # additonal response to mock extra node
+    ]
     with (
         mock_hedera_servers(response_sequences) as client,
         patch("hiero_sdk_python.executable.time.sleep"),
@@ -453,8 +456,8 @@ def test_query_retry_on_busy():
     # First node returns BUSY, forcing a retry
     # Second node returns OK with the balance
     response_sequences = [
-        [busy_response],
-        [ok_response],
+        [busy_response, ok_response],
+        [ok_response],  # additional response to mimic additional node
     ]
 
     with (
@@ -471,8 +474,8 @@ def test_query_retry_on_busy():
 
         assert balance.hbars.to_tinybars() == 100000000
         # Verify we switched to the second node
-        assert query._node_account_ids._index == 1
-        assert query._node_account_ids.current == AccountId(0, 0, 4), "Client should have switched to the second node"
+        assert query._node_account_ids._index == 0
+        assert query._node_account_ids.current == AccountId(0, 0, 3), "Client should have switched to the second node"
 
 
 # Set max_attempts

--- a/tests/unit/executable_test.py
+++ b/tests/unit/executable_test.py
@@ -474,7 +474,7 @@ def test_query_retry_on_busy():
 
         assert balance.hbars.to_tinybars() == 100000000
         # Verify we switched to the second node
-        assert query._node_account_ids._index == 0
+        assert query._node_account_ids.index == 0
         assert query._node_account_ids.current == AccountId(0, 0, 3), "Client should have switched to the second node"
 
 
@@ -970,7 +970,7 @@ def test_should_exponential_error_mark_node_unhealty_and_advance(error):
         # No delay_for_attempt backoff call, Node is mark unhealthy and advance
         assert mock_sleep.call_count == 0
         # Node must have changed
-        assert tx._node_account_ids._index == 1
+        assert tx._node_account_ids.index == 1
 
 
 def test_rst_stream_error_marks_node_unhealthy_and_advances_without_backoff():
@@ -1004,7 +1004,7 @@ def test_rst_stream_error_marks_node_unhealthy_and_advances_without_backoff():
         # RST_STREAM exponential retry does not use delay-based backoff
         assert mock_sleep.call_count == 0
         # Node must advance after marking the first node unhealthy
-        assert tx._node_account_ids._index == 1
+        assert tx._node_account_ids.index == 1
 
 
 @pytest.mark.parametrize(
@@ -1058,7 +1058,7 @@ def test_execution_skips_unhealthy_nodes_and_advances():
 
         assert receipt.status == ResponseCode.SUCCESS
         # Ensure the node index advanced past the unhealthy node
-        assert tx._node_account_ids._index == 1
+        assert tx._node_account_ids.index == 1
 
 
 def test_execution_raises_if_all_nodes_unhealthy(mock_client):
@@ -1082,7 +1082,7 @@ def test_execution_raises_if_all_nodes_unhealthy(mock_client):
 )
 def test_unhealthy_node_receipt_request_triggers_delay_and_no_node_change(tx, mock_client):
     """Unhealthy node with transaction receipt/record request calls _delay_for_attempt but does not advance node."""
-    initial_index = tx._node_account_ids._index
+    initial_index = tx._node_account_ids.index
 
     with (
         patch("hiero_sdk_python.node._Node.is_healthy", return_value=False),
@@ -1094,7 +1094,7 @@ def test_unhealthy_node_receipt_request_triggers_delay_and_no_node_change(tx, mo
         # _delay_for_attempt called
         assert mock_delay.call_count > 0
         # Node index did NOT change
-        assert tx._node_account_ids._index == initial_index
+        assert tx._node_account_ids.index == initial_index
 
 
 def test_retry_invalid_node_account_updates_network():
@@ -1140,7 +1140,7 @@ def test_retry_invalid_node_account_updates_network():
         tx.execute(client)
 
         # Node index must advance after INVALID_NODE_ACCOUNT
-        assert tx._node_account_ids._index == 1
+        assert tx._node_account_ids.index == 1
 
         # Recovery actions
         mock_increase_backoff.assert_called_once()

--- a/tests/unit/fee_estimate_query_test.py
+++ b/tests/unit/fee_estimate_query_test.py
@@ -227,7 +227,7 @@ def test_topic_message_single_chunk(mock_post):
         TopicMessageSubmitTransaction()
         .set_topic_id(TopicId(0, 0, 4))
         .set_transaction_id(TransactionId.generate(AccountId(0, 0, 3)))
-        .set_node_account_id(AccountId(0, 0, 4))
+        .set_node_account_ids([AccountId(0, 0, 4)])
     )
     tx.set_message("hello")
 
@@ -248,7 +248,7 @@ def test_topic_message_multiple_chunks(mock_post):
         TopicMessageSubmitTransaction()
         .set_topic_id(TopicId(0, 0, 4))
         .set_transaction_id(TransactionId.generate(AccountId(0, 0, 3)))
-        .set_node_account_id(AccountId(0, 0, 4))
+        .set_node_account_ids([AccountId(0, 0, 4)])
     )
     tx.set_message("A" * 2048)  # force chunking
 
@@ -372,7 +372,7 @@ def test_port_replacement_for_localhost_execute_multiple():
         .set_topic_id(TopicId(0, 0, 4))
         .set_message("A" * 2048)
         .set_transaction_id(TransactionId.generate(AccountId(0, 0, 3)))
-        .set_node_account_id(AccountId(0, 0, 4))
+        .set_node_account_ids([AccountId(0, 0, 4)])
     )
 
     query = FeeEstimateQuery().set_transaction(tx).set_mode(FeeEstimateMode.INTRINSIC)

--- a/tests/unit/file_append_transaction_test.py
+++ b/tests/unit/file_append_transaction_test.py
@@ -392,7 +392,7 @@ def test_chunk_transaction_id_nanosecond_overflow(file_id):
         .set_contents("a" * 20)
         .set_chunk_size(10)
         .set_transaction_id(tx_id)
-        .set_node_account_id(AccountId(0, 0, 3))
+        .set_node_account_ids([AccountId(0, 0, 3)])
         .freeze()
     )
 

--- a/tests/unit/file_create_transaction_test.py
+++ b/tests/unit/file_create_transaction_test.py
@@ -82,7 +82,7 @@ def test_build_transaction_body(mock_account_ids):
 
     # Set operator and node account IDs needed for building transaction body
     file_tx.operator_account_id = operator_id
-    file_tx.node_account_id = node_account_id
+    file_tx.set_node_account_ids([node_account_id])
 
     transaction_body = file_tx.build_transaction_body()
 
@@ -108,7 +108,7 @@ def test_build_scheduled_body(mock_account_ids):
 
     # Set operator and node account IDs needed for building transaction body
     file_tx.operator_account_id = operator_id
-    file_tx.node_account_id = node_account_id
+    file_tx.set_node_account_ids([node_account_id])
 
     schedulable_body = file_tx.build_scheduled_body()
 

--- a/tests/unit/file_delete_transaction_test.py
+++ b/tests/unit/file_delete_transaction_test.py
@@ -21,7 +21,7 @@ def test_build_transaction_body(mock_account_ids, file_id):
     """Test building a file delete transaction body with a valid value."""
     account_id, _, node_account_id, _, _ = mock_account_ids
     delete_tx = FileDeleteTransaction(file_id=file_id)
-    delete_tx.node_account_id = node_account_id
+    delete_tx.set_node_account_ids([node_account_id])
     delete_tx.operator_account_id = account_id
 
     transaction_body = delete_tx.build_transaction_body()
@@ -103,7 +103,7 @@ def test_build_scheduled_body(mock_account_ids, file_id):
     """Test building a schedulable file delete transaction body."""
     account_id, _, node_account_id, _, _ = mock_account_ids
     delete_tx = FileDeleteTransaction(file_id=file_id)
-    delete_tx.node_account_id = node_account_id
+    delete_tx.set_node_account_ids([node_account_id])
     delete_tx.operator_account_id = account_id
 
     # Build the scheduled body

--- a/tests/unit/file_update_transaction_test.py
+++ b/tests/unit/file_update_transaction_test.py
@@ -169,7 +169,7 @@ def test_build_transaction_body(mock_account_ids, file_id):
 
     # Set operator and node account IDs needed for building transaction body
     file_tx.operator_account_id = operator_id
-    file_tx.node_account_id = node_account_id
+    file_tx.set_node_account_ids([node_account_id])
 
     transaction_body = file_tx.build_transaction_body()
 
@@ -187,7 +187,7 @@ def test_build_transaction_body_with_optional_fields(mock_account_ids, file_id):
 
     file_tx = FileUpdateTransaction(file_id=file_id)
     file_tx.operator_account_id = operator_id
-    file_tx.node_account_id = node_account_id
+    file_tx.set_node_account_ids([node_account_id])
 
     transaction_body = file_tx.build_transaction_body()
 
@@ -223,7 +223,7 @@ def test_build_scheduled_body(mock_account_ids, file_id):
 
     # Set operator and node account IDs needed for building transaction body
     file_tx.operator_account_id = operator_id
-    file_tx.node_account_id = node_account_id
+    file_tx.set_node_account_ids([node_account_id])
 
     # Build the scheduled body
     schedulable_body = file_tx.build_scheduled_body()

--- a/tests/unit/freeze_transaction_test.py
+++ b/tests/unit/freeze_transaction_test.py
@@ -72,7 +72,7 @@ def test_build_transaction_body_with_valid_parameters(mock_account_ids, freeze_p
 
     # Set operator and node account IDs needed for building transaction body
     freeze_tx.operator_account_id = operator_id
-    freeze_tx.node_account_id = node_account_id
+    freeze_tx.set_node_account_ids([node_account_id])
 
     transaction_body = freeze_tx.build_transaction_body()
 
@@ -95,7 +95,7 @@ def test_build_transaction_body_with_none_values(mock_account_ids):
 
     # Set operator and node account IDs needed for building transaction body
     freeze_tx.operator_account_id = operator_id
-    freeze_tx.node_account_id = node_account_id
+    freeze_tx.set_node_account_ids([node_account_id])
 
     transaction_body = freeze_tx.build_transaction_body()
 

--- a/tests/unit/lockable_list_test.py
+++ b/tests/unit/lockable_list_test.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import pytest
+
+from hiero_sdk_python.lockable_list import _LockableList
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_list_initialization():
+    """Test a new created list is empty."""
+    lst = _LockableList[int]()
+
+    assert lst.is_empty
+    assert len(lst) == 0
+    assert lst.get_list() == []
+
+
+def test_set_list():
+    """Test set_list() replace the list contents."""
+    lst = _LockableList[int]().set_list([1, 2, 3])
+
+    assert lst.get_list() == [1, 2, 3]
+    assert lst.current == 1
+
+
+def test_set_list_resets_index():
+    """Test set_list() resets the current index."""
+    lst = _LockableList[int]()
+    lst.set_list([1, 2, 3])
+    assert lst.get_list() == [1, 2, 3]
+
+    lst.set_index(2)
+    lst.set_list([10, 20])
+
+    assert lst.get_list() == [10, 20]
+    assert lst.current == 10
+
+
+def test_append():
+    """Test appending an item."""
+    lst = _LockableList[int]()
+
+    returned = lst.append(1).append(2)
+
+    assert returned is lst
+    assert lst.get_list() == [1, 2]
+
+
+def test_extend():
+    """Test extending the list with multiple items."""
+    lst = _LockableList[int]()
+
+    returned = lst.extend([1, 2, 3])
+
+    assert returned is lst
+    assert lst.get_list() == [1, 2, 3]
+
+
+def test_extend_append_with_existing_items():
+    """Test extending the multiple items with list contents not empty."""
+    lst = _LockableList[int]()
+    lst.set_list([1, 2])
+
+    assert lst.get_list() == [1, 2]
+
+    returned = lst.extend([3, 4])
+
+    assert returned is lst
+    assert lst.get_list() == [1, 2, 3, 4]
+
+
+def test_clear():
+    """Test clearing all items."""
+    lst = _LockableList[int]().set_list([1, 2])
+    assert lst.get_list() == [1, 2]
+
+    lst.clear()
+
+    assert lst.is_empty
+
+
+def test_get():
+    """Test retrieving an item by index."""
+    lst = _LockableList[int]().set_list([5, 6])
+
+    assert lst.get(0) == 5
+    assert lst.get(1) == 6
+
+
+def test_get_invalid_index():
+    """Test get() raises IndexError for an invalid index."""
+    lst = _LockableList[int]()
+
+    with pytest.raises(IndexError):
+        lst.get(0)
+
+
+def test_set_existing_index():
+    """Test replacing an existing item."""
+    lst = _LockableList[int]().set_list([1, 2])
+    lst.set(1, 99)
+
+    assert lst.get_list() == [1, 99]
+
+
+def test_set_append():
+    """Test appending when index equals the list length."""
+    lst = _LockableList[int]().set_list([1])
+    lst.set(1, 2)
+
+    assert lst.get_list() == [1, 2]
+
+
+def test_set_invalid_index():
+    """Test set() raises IndexError when the index is too large."""
+    lst = _LockableList[int]().set_list([1])
+
+    with pytest.raises(IndexError):
+        lst.set(5, 10)
+
+
+def test_set_if_absent_appends():
+    """Test set_if_absent() appends a missing item."""
+    lst = _LockableList[int]()
+
+    lst.set_if_absent(0, 5)
+
+    assert lst.get_list() == [5]
+
+
+def test_set_if_absent_sets_none():
+    """Test set_if_absent() replaces a None value."""
+    lst = _LockableList[int | None]().set_list([None])
+
+    lst.set_if_absent(0, 10)
+
+    assert lst.get_list() == [10]
+
+
+def test_set_if_absent_does_not_replace_existing():
+    """Test set_if_absent() leaves existing values unchanged."""
+    lst = _LockableList[int]().set_list([1])
+
+    lst.set_if_absent(0, 2)
+
+    assert lst.get_list() == [1]
+
+
+def test_current():
+    """Test retrieving the current item."""
+    lst = _LockableList[int]().set_list([1, 2, 3])
+    assert lst.current == 1
+
+    lst.set_index(2)
+    assert lst.current == 3
+
+
+def test_advance():
+    """Test advancing to the next item."""
+    lst = _LockableList[int]().set_list([1, 2, 3])
+
+    assert lst.advance() == 0
+    assert lst.current == 2
+
+
+def test_advance_wraps():
+    """Test advance() wraps to the beginning."""
+    lst = _LockableList[int]().set_list([1, 2])
+    lst.set_index(1)
+
+    assert lst.advance() == 1
+    assert lst.current == 1
+
+
+def test_advance_empty():
+    """Test advance() on an empty list."""
+    lst = _LockableList[int]()
+
+    assert lst.advance() == 0
+    assert lst.is_empty
+
+
+def test_next():
+    """Test the next property advances the current index."""
+    lst = _LockableList[int]().set_list([1, 2, 3])
+
+    assert lst.next == 1
+    assert lst.current == 2
+
+
+def test_set_index():
+    """Test updating the current index."""
+    lst = _LockableList[int]().set_list([1, 2, 3])
+    lst.set_index(2)
+
+    assert lst.current == 3
+
+
+def test_len():
+    """Test retrieving the list length."""
+    lst = _LockableList[int]().set_list([1, 2, 3])
+
+    assert len(lst) == 3
+
+
+def test_iter():
+    """Test iterating over the list."""
+    lst = _LockableList[int]().set_list([1, 2, 3])
+
+    assert list(lst) == [1, 2, 3]
+
+
+def test_append_locked():
+    """Test append() raises RuntimeError when the list is locked."""
+    lst = _LockableList[int]().set_lock(True)
+
+    with pytest.raises(RuntimeError):
+        lst.append(1)
+
+
+def test_extend_locked():
+    """Test extend() raises RuntimeError when the list is locked."""
+    lst = _LockableList[int]().set_lock(True)
+
+    with pytest.raises(RuntimeError):
+        lst.extend([1])
+
+
+def test_set_list_locked():
+    """Test set_list() raises RuntimeError when the list is locked."""
+    lst = _LockableList[int]().set_lock(True)
+
+    with pytest.raises(RuntimeError):
+        lst.set_list([1])
+
+
+def test_clear_locked():
+    """Test clear() raises RuntimeError when the list is locked."""
+    lst = _LockableList[int]().set_list([1]).set_lock(True)
+
+    with pytest.raises(RuntimeError):
+        lst.clear()
+
+
+def test_set_locked():
+    """Test set() raises RuntimeError when the list is locked."""
+    lst = _LockableList[int]().set_list([1]).set_lock(True)
+
+    with pytest.raises(RuntimeError):
+        lst.set(0, 2)

--- a/tests/unit/lockable_list_test.py
+++ b/tests/unit/lockable_list_test.py
@@ -38,6 +38,18 @@ def test_set_list_resets_index():
     assert lst.current == 10
 
 
+def test_get_list_returns_copy():
+    """Test that get_list returns a copy of the underlying list."""
+    lockable_list = _LockableList[int]()
+    lockable_list.set_list([1, 2])
+
+    items = lockable_list.get_list()
+    items.append(3)
+
+    assert items == [1, 2, 3]
+    assert lockable_list.get_list() == [1, 2]
+
+
 def test_append():
     """Test appending an item."""
     lst = _LockableList[int]()

--- a/tests/unit/node_create_transaction_test.py
+++ b/tests/unit/node_create_transaction_test.py
@@ -91,7 +91,7 @@ def test_build_transaction_body_with_valid_parameters(mock_account_ids, node_par
 
     # Set operator and node account IDs needed for building transaction body
     node_tx.operator_account_id = operator_id
-    node_tx.node_account_id = node_account_id
+    node_tx.set_node_account_ids([node_account_id])
 
     transaction_body = node_tx.build_transaction_body()
 

--- a/tests/unit/node_delete_transaction_test.py
+++ b/tests/unit/node_delete_transaction_test.py
@@ -45,7 +45,7 @@ def test_build_transaction_body(mock_account_ids, node_id):
 
     # Set operator and node account IDs needed for building transaction body
     node_tx.operator_account_id = operator_id
-    node_tx.node_account_id = node_account_id
+    node_tx.set_node_account_ids([node_account_id])
 
     transaction_body = node_tx.build_transaction_body()
 
@@ -65,7 +65,7 @@ def test_build_transaction_body_missing_node_id(mock_account_ids):
 
     # Set operator and node account IDs needed for building transaction body
     node_tx.operator_account_id = operator_id
-    node_tx.node_account_id = node_account_id
+    node_tx.set_node_account_ids([node_account_id])
 
     with pytest.raises(ValueError, match="Missing required NodeID"):
         node_tx.build_transaction_body()

--- a/tests/unit/node_update_transaction_test.py
+++ b/tests/unit/node_update_transaction_test.py
@@ -95,7 +95,7 @@ def test_build_transaction_body(mock_account_ids, node_params):
 
     # Set operator and node account IDs needed for building transaction body
     node_tx.operator_account_id = operator_id
-    node_tx.node_account_id = node_account_id
+    node_tx.set_node_account_ids([node_account_id])
 
     transaction_body = node_tx.build_transaction_body()
 

--- a/tests/unit/prng_transaction_test.py
+++ b/tests/unit/prng_transaction_test.py
@@ -53,7 +53,7 @@ def test_build_transaction_body_with_valid_parameters(mock_account_ids, prng_par
 
     # Set operator and node account IDs needed for building transaction body
     prng_tx.operator_account_id = operator_id
-    prng_tx.node_account_id = node_account_id
+    prng_tx.set_node_account_ids([node_account_id])
 
     transaction_body = prng_tx.build_transaction_body()
 
@@ -70,7 +70,7 @@ def test_build_transaction_body_without_range(mock_account_ids):
 
     # Set operator and node account IDs needed for building transaction body
     prng_tx.operator_account_id = operator_id
-    prng_tx.node_account_id = node_account_id
+    prng_tx.set_node_account_ids([node_account_id])
 
     transaction_body = prng_tx.build_transaction_body()
 

--- a/tests/unit/query_nodes_test.py
+++ b/tests/unit/query_nodes_test.py
@@ -8,9 +8,30 @@ def test_set_single_node_account_id():
     q = Query()
     node = AccountId(0, 0, 3)
 
+    # Test deprecated for backward compatiblity
     q.set_node_account_id(node)
 
     assert q.node_account_ids == [node]
+
+
+def test_set_single_node_account_id_using_setter():
+    q = Query()
+    node = AccountId(0, 0, 3)
+
+    # Test deprecated for backward compatiblity
+    q.node_account_id = node
+
+    assert q.node_account_ids == [node]
+
+
+def test_get_single_node_account_id():
+    q = Query()
+    node = AccountId(0, 0, 3)
+
+    q.set_node_account_ids([node])
+
+    # Test deprecated for backward compatiblity
+    assert q.node_account_id == node
 
 
 def test_set_multiple_node_account_ids():
@@ -18,6 +39,15 @@ def test_set_multiple_node_account_ids():
     nodes = [AccountId(0, 0, 3), AccountId(0, 0, 4)]
 
     q.set_node_account_ids(nodes)
+
+    assert q.node_account_ids == nodes
+
+
+def test_set_multiple_node_account_ids_using_setters():
+    q = Query()
+    nodes = [AccountId(0, 0, 3), AccountId(0, 0, 4)]
+
+    q.node_account_ids = nodes
 
     assert q.node_account_ids == nodes
 

--- a/tests/unit/query_nodes_test.py
+++ b/tests/unit/query_nodes_test.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import re
+
+import pytest
+
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.query.query import Query
 
@@ -9,7 +13,11 @@ def test_set_single_node_account_id():
     node = AccountId(0, 0, 3)
 
     # Test deprecated for backward compatiblity
-    q.set_node_account_id(node)
+    with pytest.warns(
+        DeprecationWarning,
+        match=re.escape("Method 'set_node_account_id()' is deprecated; use 'set_node_account_ids()' instead."),
+    ):
+        q.set_node_account_id(node)
 
     assert q.node_account_ids == [node]
 
@@ -19,7 +27,8 @@ def test_set_single_node_account_id_using_setter():
     node = AccountId(0, 0, 3)
 
     # Test deprecated for backward compatiblity
-    q.node_account_id = node
+    with pytest.warns(DeprecationWarning, match="'node_account_id' is deprecated"):
+        q.node_account_id = node
 
     assert q.node_account_ids == [node]
 
@@ -31,7 +40,8 @@ def test_get_single_node_account_id():
     q.set_node_account_ids([node])
 
     # Test deprecated for backward compatiblity
-    assert q.node_account_id == node
+    with pytest.warns(DeprecationWarning, match="'node_account_id' is deprecated"):
+        assert q.node_account_id == node
 
 
 def test_set_multiple_node_account_ids():

--- a/tests/unit/query_nodes_test.py
+++ b/tests/unit/query_nodes_test.py
@@ -27,10 +27,10 @@ def test_node_account_id_advance_method():
     nodes = [AccountId(0, 0, 3), AccountId(0, 0, 4)]
     q.set_node_account_ids(nodes)
 
-    assert q._node_account_ids._index == 0
+    assert q._node_account_ids.index == 0
     assert q._node_account_ids.current == nodes[0]
 
     index = q._node_account_ids.advance()
     assert index == 0  # returns current index
-    assert q._node_account_ids._index == 1
+    assert q._node_account_ids.index == 1
     assert q._node_account_ids.current == nodes[1]

--- a/tests/unit/query_nodes_test.py
+++ b/tests/unit/query_nodes_test.py
@@ -24,12 +24,15 @@ def test_set_multiple_node_account_ids():
     assert q._used_node_account_id is None
 
 
-def test_select_node_account_id():
+def test_node_account_id_advance_method():
     q = Query()
     nodes = [AccountId(0, 0, 3), AccountId(0, 0, 4)]
     q.set_node_account_ids(nodes)
 
-    selected = q._select_node_account_id()
+    assert q._node_account_ids._index == 0
+    assert q._node_account_ids.current == nodes[0]
 
-    assert selected == nodes[0]
-    assert q._used_node_account_id == nodes[0]
+    index = q._node_account_ids.advance()
+    assert index == 0  # returns current index
+    assert q._node_account_ids._index == 1
+    assert q._node_account_ids.current == nodes[1]

--- a/tests/unit/query_nodes_test.py
+++ b/tests/unit/query_nodes_test.py
@@ -11,7 +11,6 @@ def test_set_single_node_account_id():
     q.set_node_account_id(node)
 
     assert q.node_account_ids == [node]
-    assert q._used_node_account_id is None  # not selected until execution
 
 
 def test_set_multiple_node_account_ids():
@@ -21,7 +20,6 @@ def test_set_multiple_node_account_ids():
     q.set_node_account_ids(nodes)
 
     assert q.node_account_ids == nodes
-    assert q._used_node_account_id is None
 
 
 def test_node_account_id_advance_method():

--- a/tests/unit/query_test.py
+++ b/tests/unit/query_test.py
@@ -61,9 +61,9 @@ def test_before_execute_payment_not_required(query, mock_client):
     # payment_amount is None, should not set payment_amount
     query._before_execute(mock_client)
 
-    # since node_account_ids is not set it will be empty
-    # query internally use node form client
-    assert query.node_account_ids == []
+    # since node_account_ids is not set it will use node form client
+    assert len(query.node_account_ids) == len(mock_client.network.nodes)
+    assert query.node_account_ids == [node._account_id for node in mock_client.network.nodes]
     assert query.operator == mock_client.operator
     assert query.payment_amount is None
 
@@ -79,9 +79,9 @@ def test_before_execute_payment_required(query_requires_payment, mock_client):
     # payment_amount is None, should set payment_amount to 2 Hbars
     query_requires_payment._before_execute(mock_client)
 
-    # since node_account_ids is not set it will be empty
-    # query internally use node form client
-    assert query_requires_payment.node_account_ids == []
+    # since node_account_ids is not set it will use node form client
+    assert len(query_requires_payment.node_account_ids) == len(mock_client.network.nodes)
+    assert query_requires_payment.node_account_ids == [node._account_id for node in mock_client.network.nodes]
     assert query_requires_payment.operator == mock_client.operator
     assert query_requires_payment.payment_amount.to_tinybars() == Hbar(2).to_tinybars()
 

--- a/tests/unit/query_test.py
+++ b/tests/unit/query_test.py
@@ -115,7 +115,7 @@ def test_request_header_payment_set(query, mock_client):
 def test_request_header_node_account_set(query, mock_client):
     """Test combinations with node account set"""
     # Test with just node account set
-    query.node_account_id = mock_client.network.current_node._account_id
+    query.set_node_account_ids([mock_client.network.current_node._account_id])
 
     header = query._make_request_header()
     assert not header.HasField("payment"), "Payment field should not be present when only node account is set"
@@ -137,7 +137,7 @@ def test_request_header_operator_set(query, mock_client):
     assert not header.HasField("payment"), "Payment field should not be present when only operator is set"
 
     # Test with operator and node account set
-    query.node_account_id = mock_client.network.current_node._account_id
+    query.set_node_account_ids([mock_client.network.current_node._account_id])
 
     header = query._make_request_header()
     assert not header.HasField("payment"), (
@@ -149,7 +149,7 @@ def test_request_header_payment_zero(query, mock_client):
     """Test that payment field is not present in request header when payment amount is 0"""
     # Set up operator and node account ID from mock client
     query.operator = mock_client.operator
-    query.node_account_id = mock_client.network.current_node._account_id
+    query.set_node_account_ids([mock_client.network.current_node._account_id])
 
     # Test with payment amount set to 0 Hbar
     query.payment_amount = Hbar(0)
@@ -160,7 +160,7 @@ def test_request_header_payment_zero(query, mock_client):
 def test_make_request_header_with_payment(query_requires_payment, mock_client):
     """Test making request header with payment transaction for queries that require payment"""
     query_requires_payment.operator = mock_client.operator
-    query_requires_payment.node_account_id = mock_client.network.current_node._account_id
+    query_requires_payment.set_node_account_ids([mock_client.network.current_node._account_id])
     query_requires_payment.set_query_payment(Hbar(1))
 
     header = query_requires_payment._make_request_header()
@@ -175,7 +175,7 @@ def test_make_request_header_with_payment(query_requires_payment, mock_client):
 def test_request_header_excludes_payment_for_free_query(query, mock_client):
     """Test that payment is not included in request header for queries that don't require payment"""
     query.operator = mock_client.operator
-    query.node_account_id = mock_client.network.current_node._account_id
+    query.set_node_account_ids([mock_client.network.current_node._account_id])
     # Set query payment to 1 Hbar
     query.set_query_payment(Hbar(1))
 

--- a/tests/unit/registered_node_transaction_test.py
+++ b/tests/unit/registered_node_transaction_test.py
@@ -41,7 +41,7 @@ def _make_mirror_endpoint():
 def _freeze(tx):
     """Freeze a transaction with minimal required fields."""
     tx.transaction_id = TransactionId.generate(AccountId(0, 0, 100))
-    tx.node_account_id = AccountId(0, 0, 3)
+    tx.set_node_account_ids([AccountId(0, 0, 3)])
     tx.freeze()
     return tx
 
@@ -65,7 +65,7 @@ class TestRegisteredNodeCreateTransaction:
         tx.set_service_endpoints([_make_block_endpoint()])
 
         tx.operator_account_id = operator_id
-        tx.node_account_id = node_account_id
+        tx.set_node_account_ids([node_account_id])
         body = tx.build_transaction_body()
 
         assert body.HasField("registeredNodeCreate")
@@ -83,7 +83,7 @@ class TestRegisteredNodeCreateTransaction:
         tx.set_service_endpoints([_make_block_endpoint(), _make_mirror_endpoint()])
 
         tx.operator_account_id = operator_id
-        tx.node_account_id = node_account_id
+        tx.set_node_account_ids([node_account_id])
         body = tx.build_transaction_body()
         assert len(body.registeredNodeCreate.service_endpoint) == 2
 
@@ -99,7 +99,7 @@ class TestRegisteredNodeCreateTransaction:
         tx.set_admin_key(PrivateKey.generate_ed25519().public_key())
         tx.set_service_endpoints([ep])
         tx.operator_account_id = operator_id
-        tx.node_account_id = node_account_id
+        tx.set_node_account_ids([node_account_id])
         body = tx.build_transaction_body()
         block_node = body.registeredNodeCreate.service_endpoint[0].block_node
         assert len(block_node.endpoint_api) == 3
@@ -136,7 +136,7 @@ class TestRegisteredNodeCreateTransaction:
         tx = RegisteredNodeCreateTransaction()
         tx.set_admin_key(PrivateKey.generate_ed25519().public_key())
         tx.operator_account_id = operator_id
-        tx.node_account_id = node_account_id
+        tx.set_node_account_ids([node_account_id])
         body = tx.build_transaction_body()
         assert len(body.registeredNodeCreate.service_endpoint) == 0
 
@@ -148,7 +148,7 @@ class TestRegisteredNodeCreateTransaction:
         tx.set_admin_key(PrivateKey.generate_ed25519().public_key())
         tx.set_service_endpoints(endpoints)
         tx.operator_account_id = operator_id
-        tx.node_account_id = node_account_id
+        tx.set_node_account_ids([node_account_id])
         body = tx.build_transaction_body()
         assert len(body.registeredNodeCreate.service_endpoint) == 51
 
@@ -160,7 +160,7 @@ class TestRegisteredNodeCreateTransaction:
         tx.set_description("x" * 101)
         tx.set_service_endpoints([_make_block_endpoint()])
         tx.operator_account_id = operator_id
-        tx.node_account_id = node_account_id
+        tx.set_node_account_ids([node_account_id])
         body = tx.build_transaction_body()
         assert body.registeredNodeCreate.description == "x" * 101
 
@@ -186,7 +186,7 @@ class TestRegisteredNodeUpdateTransaction:
         tx = RegisteredNodeUpdateTransaction()
         tx.set_registered_node_id(42)
         tx.operator_account_id = operator_id
-        tx.node_account_id = node_account_id
+        tx.set_node_account_ids([node_account_id])
         body = tx.build_transaction_body()
         assert body.HasField("registeredNodeUpdate")
         assert body.registeredNodeUpdate.registered_node_id == 42
@@ -199,7 +199,7 @@ class TestRegisteredNodeUpdateTransaction:
         tx.set_registered_node_id(1)
         tx.set_admin_key(key)
         tx.operator_account_id = operator_id
-        tx.node_account_id = node_account_id
+        tx.set_node_account_ids([node_account_id])
         body = tx.build_transaction_body()
         assert body.registeredNodeUpdate.admin_key == key._to_proto()
 
@@ -210,7 +210,7 @@ class TestRegisteredNodeUpdateTransaction:
         tx.set_registered_node_id(1)
         tx.set_description("updated desc")
         tx.operator_account_id = operator_id
-        tx.node_account_id = node_account_id
+        tx.set_node_account_ids([node_account_id])
         body = tx.build_transaction_body()
         assert body.registeredNodeUpdate.description.value == "updated desc"
 
@@ -221,7 +221,7 @@ class TestRegisteredNodeUpdateTransaction:
         tx.set_registered_node_id(1)
         tx.set_service_endpoints([_make_block_endpoint(), _make_mirror_endpoint()])
         tx.operator_account_id = operator_id
-        tx.node_account_id = node_account_id
+        tx.set_node_account_ids([node_account_id])
         body = tx.build_transaction_body()
         assert len(body.registeredNodeUpdate.service_endpoint) == 2
 
@@ -231,7 +231,7 @@ class TestRegisteredNodeUpdateTransaction:
         tx = RegisteredNodeUpdateTransaction()
         tx.set_registered_node_id(1)
         tx.operator_account_id = operator_id
-        tx.node_account_id = node_account_id
+        tx.set_node_account_ids([node_account_id])
         body = tx.build_transaction_body()
         assert len(body.registeredNodeUpdate.service_endpoint) == 0
 
@@ -266,7 +266,7 @@ class TestRegisteredNodeUpdateTransaction:
         operator_id, _, node_account_id, _, _ = mock_account_ids
         tx = RegisteredNodeUpdateTransaction()
         tx.operator_account_id = operator_id
-        tx.node_account_id = node_account_id
+        tx.set_node_account_ids([node_account_id])
         body = tx.build_transaction_body()
         assert body.registeredNodeUpdate.registered_node_id == 0
 
@@ -277,7 +277,7 @@ class TestRegisteredNodeUpdateTransaction:
         tx.set_registered_node_id(1)
         tx.set_service_endpoints([])
         tx.operator_account_id = operator_id
-        tx.node_account_id = node_account_id
+        tx.set_node_account_ids([node_account_id])
         body = tx.build_transaction_body()
         assert len(body.registeredNodeUpdate.service_endpoint) == 0
 
@@ -288,7 +288,7 @@ class TestRegisteredNodeUpdateTransaction:
         tx.set_registered_node_id(1)
         tx.set_service_endpoints([_make_mirror_endpoint() for _ in range(51)])
         tx.operator_account_id = operator_id
-        tx.node_account_id = node_account_id
+        tx.set_node_account_ids([node_account_id])
         body = tx.build_transaction_body()
         assert len(body.registeredNodeUpdate.service_endpoint) == 51
 
@@ -307,7 +307,7 @@ class TestRegisteredNodeDeleteTransaction:
         tx = RegisteredNodeDeleteTransaction()
         tx.set_registered_node_id(7)
         tx.operator_account_id = operator_id
-        tx.node_account_id = node_account_id
+        tx.set_node_account_ids([node_account_id])
         body = tx.build_transaction_body()
         assert body.HasField("registeredNodeDelete")
         assert body.registeredNodeDelete.registered_node_id == 7
@@ -336,7 +336,7 @@ class TestRegisteredNodeDeleteTransaction:
         operator_id, _, node_account_id, _, _ = mock_account_ids
         tx = RegisteredNodeDeleteTransaction()
         tx.operator_account_id = operator_id
-        tx.node_account_id = node_account_id
+        tx.set_node_account_ids([node_account_id])
 
         with pytest.raises(ValueError, match="registered_node_id"):
             tx.build_transaction_body()

--- a/tests/unit/schedule_create_transaction_test.py
+++ b/tests/unit/schedule_create_transaction_test.py
@@ -77,7 +77,7 @@ def test_build_transaction_body_with_valid_parameters(mock_account_ids, schedule
 
     # Set operator and node account IDs needed for building transaction body
     schedule_tx.operator_account_id = operator_id
-    schedule_tx.node_account_id = node_account_id
+    schedule_tx.set_node_account_ids([node_account_id])
 
     transaction_body = schedule_tx.build_transaction_body()
 

--- a/tests/unit/schedule_delete_transaction_test.py
+++ b/tests/unit/schedule_delete_transaction_test.py
@@ -61,7 +61,7 @@ def test_build_transaction_body_with_valid_parameters(mock_account_ids, delete_p
 
     # Set operator and node account IDs needed for building transaction body
     delete_tx.operator_account_id = operator_id
-    delete_tx.node_account_id = node_account_id
+    delete_tx.set_node_account_ids([node_account_id])
 
     transaction_body = delete_tx.build_transaction_body()
 

--- a/tests/unit/schedule_sign_transaction_test.py
+++ b/tests/unit/schedule_sign_transaction_test.py
@@ -92,7 +92,7 @@ def test_build_transaction_body_with_valid_schedule_id(mock_account_ids, schedul
 
     # Set operator and node account IDs needed for building transaction body
     schedule_sign_tx.operator_account_id = operator_id
-    schedule_sign_tx.node_account_id = node_account_id
+    schedule_sign_tx.set_node_account_ids([node_account_id])
 
     transaction_body = schedule_sign_tx.build_transaction_body()
 

--- a/tests/unit/token_airdrop_claim_test.py
+++ b/tests/unit/token_airdrop_claim_test.py
@@ -142,7 +142,7 @@ def test_min_ids_enforced_on_build_hits_validation():
     """Tests that at least one airdrop is required to claim"""
     transaction_claim = TokenClaimAirdropTransaction()
     transaction_claim.transaction_id = TransactionId(AccountId(0, 0, 9999), timestamp_pb2.Timestamp(seconds=1))
-    transaction_claim.node_account_id = AccountId(0, 0, 3)
+    transaction_claim.set_node_account_ids([AccountId(0, 0, 3)])
 
     with pytest.raises(ValueError):
         transaction_claim.build_transaction_body()
@@ -193,7 +193,7 @@ def test_build_transaction_body_populates_proto():
 
     # Satisfy base preconditions: set transaction_id and node_account_id
     tx_claim.transaction_id = TransactionId(sender, timestamp_pb2.Timestamp(seconds=1, nanos=0))
-    tx_claim.node_account_id = AccountId(0, 0, 3)  # dummy node account
+    tx_claim.set_node_account_ids([AccountId(0, 0, 3)])  # dummy node account
 
     body: transaction_pb2.TransactionBody = tx_claim.build_transaction_body()
 

--- a/tests/unit/token_airdrop_transaction_cancel_test.py
+++ b/tests/unit/token_airdrop_transaction_cancel_test.py
@@ -60,7 +60,7 @@ def test_build_transaction_body(mock_account_ids):
     cancel_airdrop_tx.add_pending_airdrop(token_pending_airdrop)
     cancel_airdrop_tx.add_pending_airdrop(nft_pending_airdrop)
     cancel_airdrop_tx.transaction_id = generate_transaction_id(sender_id)
-    cancel_airdrop_tx.node_account_id = node_account_id
+    cancel_airdrop_tx.set_node_account_ids([node_account_id])
     transaction_body = cancel_airdrop_tx.build_transaction_body()
 
     assert len(transaction_body.tokenCancelAirdrop.pending_airdrops) == 2

--- a/tests/unit/token_airdrop_transaction_test.py
+++ b/tests/unit/token_airdrop_transaction_test.py
@@ -30,7 +30,7 @@ def test_build_transaction_body(mock_account_ids):
     airdrop_tx.add_token_transfer(token_id=token_id_1, account_id=receiver, amount=amount)
     airdrop_tx.add_nft_transfer(nft_id=nft_id, sender_id=sender, receiver_id=receiver)
     airdrop_tx.operator_account_id = sender
-    airdrop_tx.node_account_id = node_account_id
+    airdrop_tx.set_node_account_ids([node_account_id])
     transaction_body = airdrop_tx.build_transaction_body()
 
     assert len(transaction_body.tokenAirdrop.token_transfers) == 2
@@ -70,7 +70,7 @@ def test_build_transaction_body_with_approved_transfer(mock_account_ids):
     airdrop_tx.add_approved_token_transfer(token_id=token_id_1, account_id=receiver, amount=amount)
     airdrop_tx.add_approved_nft_transfer(nft_id=nft_id, sender_id=sender, receiver_id=receiver)
     airdrop_tx.operator_account_id = sender
-    airdrop_tx.node_account_id = node_account_id
+    airdrop_tx.set_node_account_ids([node_account_id])
     transaction_body = airdrop_tx.build_transaction_body()
 
     assert len(transaction_body.tokenAirdrop.token_transfers) == 2
@@ -116,7 +116,7 @@ def test_build_transaction_body_with_expected_decimal(mock_account_ids):
         token_id=token_id_2, account_id=receiver, amount=amount, decimals=decimal
     )
     airdrop_tx.operator_account_id = sender
-    airdrop_tx.node_account_id = node_account_id
+    airdrop_tx.set_node_account_ids([node_account_id])
     transaction_body = airdrop_tx.build_transaction_body()
 
     assert len(transaction_body.tokenAirdrop.token_transfers) == 2

--- a/tests/unit/token_associate_transaction_test.py
+++ b/tests/unit/token_associate_transaction_test.py
@@ -39,7 +39,7 @@ def test_build_transaction_body(mock_account_ids):
     associate_tx.add_token_id(token_id_1)
     associate_tx.add_token_id(token_id_2)
     associate_tx.transaction_id = generate_transaction_id(account_id)
-    associate_tx.node_account_id = node_account_id
+    associate_tx.set_node_account_ids([node_account_id])
 
     transaction_body = associate_tx.build_transaction_body()
 

--- a/tests/unit/token_burn_transaction_test.py
+++ b/tests/unit/token_burn_transaction_test.py
@@ -42,7 +42,7 @@ def test_build_transaction_body(mock_account_ids):
 
     # Set operator and node account IDs needed for building transaction body
     burn_tx.operator_account_id = operator_id
-    burn_tx.node_account_id = node_account_id
+    burn_tx.set_node_account_ids([node_account_id])
     transaction_body = burn_tx.build_transaction_body()
 
     assert transaction_body.tokenBurn.token == token_id._to_proto()

--- a/tests/unit/token_create_transaction_test.py
+++ b/tests/unit/token_create_transaction_test.py
@@ -90,7 +90,7 @@ def test_build_transaction_body_without_key(mock_account_ids):
     token_tx.set_treasury_account_id(treasury_account)
     token_tx.set_memo("Token Memo")
     token_tx.transaction_id = generate_transaction_id(treasury_account)
-    token_tx.node_account_id = node_account_id
+    token_tx.set_node_account_ids([node_account_id])
 
     transaction_body = token_tx.build_transaction_body()
 
@@ -143,7 +143,7 @@ def test_build_transaction_body(mock_account_ids):
     token_tx.set_metadata_key(private_key_metadata)
     token_tx.set_kyc_key(private_key_kyc)
     token_tx.set_fee_schedule_key(private_key_fee_schedule)
-    token_tx.node_account_id = node_account_id
+    token_tx.set_node_account_ids([node_account_id])
 
     transaction_body = token_tx.build_transaction_body()
 
@@ -177,7 +177,7 @@ def test_build_transaction_body_with_metadata(mock_account_ids):
     token_tx.set_metadata(metadata)
 
     token_tx.transaction_id = generate_transaction_id(treasury_account)
-    token_tx.node_account_id = node_account_id
+    token_tx.set_node_account_ids([node_account_id])
 
     transaction_body = token_tx.build_transaction_body()
 
@@ -396,7 +396,7 @@ def test_transaction_execution_failure(mock_account_ids):
             token_type=TokenType.FUNGIBLE_COMMON,
         )
     )
-    token_tx.node_account_id = node_account_id
+    token_tx.set_node_account_ids([node_account_id])
     token_tx.transaction_id = generate_transaction_id(treasury_account)
 
     # Set the transaction body bytes to avoid calling build_transaction_body
@@ -524,7 +524,7 @@ def test_transaction_freeze_prevents_modification(mock_account_ids, mock_client)
     transaction.set_decimals(2)
     transaction.set_treasury_account_id(treasury_account)
 
-    transaction.node_account_id = node_account_id
+    transaction.set_node_account_ids([node_account_id])
     transaction.transaction_id = generate_transaction_id(treasury_account)
 
     # Freeze the transaction
@@ -586,7 +586,7 @@ def test_build_transaction_body_non_fungible(mock_account_ids):
     token_tx.set_memo("NFT Memo")
 
     token_tx.transaction_id = generate_transaction_id(treasury_account)
-    token_tx.node_account_id = node_account_id
+    token_tx.set_node_account_ids([node_account_id])
 
     # Build the transaction body
     transaction_body = token_tx.build_transaction_body()
@@ -780,7 +780,7 @@ def test_token_create_with_expiration_time_overrides_auto_renew(mock_account_ids
 
     tx.set_expiration_time(expiration_time)
     tx.transaction_id = generate_transaction_id(treasury_account)
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
     body = tx.build_transaction_body()
 
     assert body.tokenCreation.expiry.seconds == expiration_time.seconds
@@ -892,7 +892,7 @@ def test_admin_key_token_operations_logic(mock_client):
     create_tx.set_supply_type(SupplyType.INFINITE)
     create_tx.set_admin_key(admin_key)
     create_tx.transaction_id = tx_id
-    create_tx.node_account_id = node_account_id
+    create_tx.set_node_account_ids([node_account_id])
 
     transaction_body = create_tx.build_transaction_body()
 

--- a/tests/unit/token_delete_transaction_test.py
+++ b/tests/unit/token_delete_transaction_test.py
@@ -36,7 +36,7 @@ def test_build_transaction_body(mock_account_ids):
     delete_tx = TokenDeleteTransaction()
     delete_tx.set_token_id(token_id)
     delete_tx.transaction_id = generate_transaction_id(account_id)
-    delete_tx.node_account_id = node_account_id
+    delete_tx.set_node_account_ids([node_account_id])
 
     transaction_body = delete_tx.build_transaction_body()
 

--- a/tests/unit/token_dissociate_transaction_test.py
+++ b/tests/unit/token_dissociate_transaction_test.py
@@ -37,7 +37,7 @@ def test_build_transaction_body(mock_account_ids):
     dissociate_tx.set_account_id(account_id)
     dissociate_tx.add_token_id(token_id_1)
     dissociate_tx.transaction_id = generate_transaction_id(account_id)
-    dissociate_tx.node_account_id = node_account_id
+    dissociate_tx.set_node_account_ids([node_account_id])
 
     transaction_body = dissociate_tx.build_transaction_body()
 
@@ -61,7 +61,7 @@ def test_transaction_body_with_multiple_tokens(mock_account_ids):
         dissociate_tx.add_token_id(token_id)
     dissociate_tx.operator_account_id = operator_id
     dissociate_tx.transaction_id = generate_transaction_id(account_id)
-    dissociate_tx.node_account_id = node_account_id
+    dissociate_tx.set_node_account_ids([node_account_id])
 
     transaction_body = dissociate_tx.build_transaction_body()
 

--- a/tests/unit/token_fee_schedule_update_transaction_test.py
+++ b/tests/unit/token_fee_schedule_update_transaction_test.py
@@ -64,7 +64,7 @@ def test_build_transaction_body_sets_token_id(mock_account_ids):
 
     update_tx = TokenFeeScheduleUpdateTransaction(token_id=token_id)
     update_tx.operator_account_id = operator_id
-    update_tx.node_account_id = node_account_id
+    update_tx.set_node_account_ids([node_account_id])
 
     transaction_body = update_tx.build_transaction_body()
 
@@ -79,7 +79,7 @@ def test_build_transaction_body_sets_custom_fees(mock_account_ids):
 
     update_tx = TokenFeeScheduleUpdateTransaction(token_id=token_id, custom_fees=test_fees_list)
     update_tx.operator_account_id = operator_id
-    update_tx.node_account_id = node_account_id
+    update_tx.set_node_account_ids([node_account_id])
 
     transaction_body = update_tx.build_transaction_body()
 
@@ -95,7 +95,7 @@ def test_build_transaction_body_with_empty_custom_fees(mock_account_ids):
 
     update_tx = TokenFeeScheduleUpdateTransaction(token_id=token_id, custom_fees=[])
     update_tx.operator_account_id = operator_id
-    update_tx.node_account_id = node_account_id
+    update_tx.set_node_account_ids([node_account_id])
 
     transaction_body = update_tx.build_transaction_body()
 

--- a/tests/unit/token_freeze_transaction_test.py
+++ b/tests/unit/token_freeze_transaction_test.py
@@ -37,7 +37,7 @@ def test_build_transaction_body(mock_account_ids):
     freeze_tx.set_token_id(token_id)
     freeze_tx.set_account_id(freeze_id)
     freeze_tx.transaction_id = generate_transaction_id(account_id)
-    freeze_tx.node_account_id = node_account_id
+    freeze_tx.set_node_account_ids([node_account_id])
 
     transaction_body = freeze_tx.build_transaction_body()
 

--- a/tests/unit/token_grant_kyc_transaction_test.py
+++ b/tests/unit/token_grant_kyc_transaction_test.py
@@ -27,7 +27,7 @@ def test_build_transaction_body(mock_account_ids):
 
     # Set operator and node account IDs needed for building transaction body
     grant_kyc_tx.operator_account_id = account_id
-    grant_kyc_tx.node_account_id = node_account_id
+    grant_kyc_tx.set_node_account_ids([node_account_id])
 
     transaction_body = grant_kyc_tx.build_transaction_body()
 

--- a/tests/unit/token_mint_transaction_test.py
+++ b/tests/unit/token_mint_transaction_test.py
@@ -41,7 +41,7 @@ def test_build_nft_transaction_body_single_bytes_metadata(mock_account_ids):
     mint_tx.set_token_id(token_id)
     mint_tx.set_metadata(single_metadata)
     mint_tx.transaction_id = generate_transaction_id(payer_account)
-    mint_tx.node_account_id = node_account_id
+    mint_tx.set_node_account_ids([node_account_id])
 
     transaction_body = mint_tx.build_transaction_body()
 
@@ -59,7 +59,7 @@ def test_build_transaction_body_fungible(mock_account_ids, amount):
     mint_tx.set_token_id(token_id)
     mint_tx.set_amount(amount)
     mint_tx.transaction_id = generate_transaction_id(payer_account)
-    mint_tx.node_account_id = node_account_id
+    mint_tx.set_node_account_ids([node_account_id])
 
     transaction_body = mint_tx.build_transaction_body()
 
@@ -79,7 +79,7 @@ def test_build_transaction_body_nft(mock_account_ids, metadata):
     mint_tx.set_token_id(token_id)
     mint_tx.set_metadata(metadata)
     mint_tx.transaction_id = generate_transaction_id(payer_account)
-    mint_tx.node_account_id = node_account_id
+    mint_tx.set_node_account_ids([node_account_id])
 
     transaction_body = mint_tx.build_transaction_body()
 
@@ -97,7 +97,7 @@ def test_build_proto_body_no_token_id(mock_account_ids):
     mint_tx = TokenMintTransaction()
     mint_tx.set_amount(100)
     mint_tx.transaction_id = generate_transaction_id(payer_account)
-    mint_tx.node_account_id = node_account_id
+    mint_tx.set_node_account_ids([node_account_id])
 
     transaction_body = mint_tx.build_transaction_body()
     assert transaction_body.tokenMint.amount == 100
@@ -111,7 +111,7 @@ def test_build_proto_body_no_amount_no_metadata(mock_account_ids):
     mint_tx = TokenMintTransaction()
     mint_tx.set_token_id(token_id)
     mint_tx.transaction_id = generate_transaction_id(payer_account)
-    mint_tx.node_account_id = node_account_id
+    mint_tx.set_node_account_ids([node_account_id])
 
     transaction_body = mint_tx.build_transaction_body()
     assert transaction_body.tokenMint.amount == 0
@@ -126,7 +126,7 @@ def test_build_proto_body_metadata_bytes_in_build(mock_account_ids):
     mint_tx.set_token_id(token_id)
     mint_tx.metadata = b"raw_bytes"  # bypass set_metadata to test the isinstance branch
     mint_tx.transaction_id = generate_transaction_id(payer_account)
-    mint_tx.node_account_id = node_account_id
+    mint_tx.set_node_account_ids([node_account_id])
 
     transaction_body = mint_tx.build_transaction_body()
     assert transaction_body.tokenMint.amount == 0

--- a/tests/unit/token_pause_transaction_test.py
+++ b/tests/unit/token_pause_transaction_test.py
@@ -31,13 +31,13 @@ def test_build_transaction_body(mock_account_ids, token_id):
 
     pause_tx = TokenPauseTransaction().set_token_id(token_id)
     pause_tx.operator_account_id = account_id
-    pause_tx.node_account_id = node_account_id
+    pause_tx.set_node_account_ids([node_account_id])
 
     transaction_body = pause_tx.build_transaction_body()  # Will generate a transaction_id
 
     assert transaction_body.token_pause.token == token_id._to_proto()
     assert transaction_body.transactionID == pause_tx.transaction_id._to_proto()
-    assert transaction_body.nodeAccountID == pause_tx.node_account_id._to_proto()
+    assert transaction_body.nodeAccountID == pause_tx._node_account_ids.current._to_proto()
 
 
 def test_build_transaction_body_nft(mock_account_ids, nft_id):
@@ -49,13 +49,13 @@ def test_build_transaction_body_nft(mock_account_ids, nft_id):
 
     pause_tx = TokenPauseTransaction().set_token_id(base_token_id)
     pause_tx.operator_account_id = account_id
-    pause_tx.node_account_id = node_account_id
+    pause_tx.set_node_account_ids([node_account_id])
 
     transaction_body = pause_tx.build_transaction_body()
 
     assert transaction_body.token_pause.token == base_token_id._to_proto()
     assert transaction_body.transactionID == pause_tx.transaction_id._to_proto()
-    assert transaction_body.nodeAccountID == pause_tx.node_account_id._to_proto()
+    assert transaction_body.nodeAccountID == pause_tx._node_account_ids.current._to_proto()
 
 
 # This test uses fixture (token_id, mock_client) as parameter

--- a/tests/unit/token_reject_transaction_test.py
+++ b/tests/unit/token_reject_transaction_test.py
@@ -41,7 +41,7 @@ def test_build_transaction_body_with_token_ids(mock_account_ids):
     reject_tx = TokenRejectTransaction().set_owner_id(owner_account_id).set_token_ids(token_ids)
 
     reject_tx.transaction_id = generate_transaction_id(account_id)
-    reject_tx.node_account_id = node_account_id
+    reject_tx.set_node_account_ids([node_account_id])
 
     transaction_body = reject_tx.build_transaction_body()
 
@@ -65,7 +65,7 @@ def test_build_transaction_body_with_nft_ids(mock_account_ids):
     reject_tx = TokenRejectTransaction().set_owner_id(owner_account_id).set_nft_ids(nft_ids)
 
     reject_tx.transaction_id = generate_transaction_id(account_id)
-    reject_tx.node_account_id = node_account_id
+    reject_tx.set_node_account_ids([node_account_id])
 
     transaction_body = reject_tx.build_transaction_body()
 

--- a/tests/unit/token_revoke_kyc_transaction_test.py
+++ b/tests/unit/token_revoke_kyc_transaction_test.py
@@ -27,7 +27,7 @@ def test_build_transaction_body(mock_account_ids):
 
     # Set operator and node account IDs needed for building transaction body
     revoke_kyc_tx.operator_account_id = account_id
-    revoke_kyc_tx.node_account_id = node_account_id
+    revoke_kyc_tx.set_node_account_ids([node_account_id])
 
     transaction_body = revoke_kyc_tx.build_transaction_body()
 

--- a/tests/unit/token_unfreeze_transaction_test.py
+++ b/tests/unit/token_unfreeze_transaction_test.py
@@ -35,7 +35,7 @@ def test_build_transaction_body(mock_account_ids):
     unfreeze_tx.set_token_id(token_id)
     unfreeze_tx.set_account_id(freeze_id)
     unfreeze_tx.transaction_id = generate_transaction_id(account_id)
-    unfreeze_tx.node_account_id = node_account_id
+    unfreeze_tx.set_node_account_ids([node_account_id])
     transaction_body = unfreeze_tx.build_transaction_body()
 
     assert transaction_body.tokenUnfreeze.token.shardNum == 1

--- a/tests/unit/token_unpause_transaction_test.py
+++ b/tests/unit/token_unpause_transaction_test.py
@@ -46,7 +46,7 @@ def test_build_transaction_body(mock_account_ids):
     account_id, _, node_account_id, token_id, _ = mock_account_ids
 
     unpause_tx = TokenUnpauseTransaction().set_token_id(token_id)
-    unpause_tx.node_account_id = node_account_id
+    unpause_tx.set_node_account_ids([node_account_id])
     unpause_tx.operator_account_id = account_id
 
     transaction_body = unpause_tx.build_transaction_body()
@@ -61,7 +61,7 @@ def test_build_transaction_body_when_token_id_not_set(mock_account_ids):
     account_id, _, node_account_id, _, _ = mock_account_ids
 
     unpause_tx = TokenUnpauseTransaction()
-    unpause_tx.node_account_id = node_account_id
+    unpause_tx.set_node_account_ids([node_account_id])
 
     with pytest.raises(ValueError, match="Missing token ID"):
         unpause_tx.build_transaction_body()

--- a/tests/unit/token_update_nfts_transaction_test.py
+++ b/tests/unit/token_update_nfts_transaction_test.py
@@ -31,7 +31,7 @@ def test_build_transaction_body(mock_account_ids):
 
     # Set operator and node account IDs needed for building transaction body
     update_tx.operator_account_id = operator_id
-    update_tx.node_account_id = node_account_id
+    update_tx.set_node_account_ids([node_account_id])
     transaction_body = update_tx.build_transaction_body()
 
     assert transaction_body.token_update_nfts.token.shardNum == token_id.shard

--- a/tests/unit/token_update_transaction_test.py
+++ b/tests/unit/token_update_transaction_test.py
@@ -103,7 +103,7 @@ def test_build_transaction_body(mock_account_ids, new_token_data):
 
     # Set operator and node account IDs needed for building transaction body
     update_tx.operator_account_id = operator_id
-    update_tx.node_account_id = node_account_id
+    update_tx.set_node_account_ids([node_account_id])
     transaction_body = update_tx.build_transaction_body()
 
     assert transaction_body.tokenUpdate.token == token_id._to_proto()
@@ -352,7 +352,7 @@ def test_single_key_fields(mock_account_ids, key_type, use_private, field_name, 
     assert getattr(tx, field_name).to_bytes() == key.to_bytes()
 
     tx.operator_account_id = operator_id
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
 
     # Build transaction body
     transaction_body = tx.build_transaction_body()
@@ -397,7 +397,7 @@ def test_constructor_with_public_key(mock_account_ids, key_type, use_private):
 
     # Verify keys are correctly stored
     update_tx.operator_account_id = operator_id
-    update_tx.node_account_id = operator_id  # Using operator_id as node_account_id for test
+    update_tx.set_node_account_ids([operator_id])  # Using operator_id as node_account_id for test
     transaction_body = update_tx.build_transaction_body()
 
     verify_key_in_proto(transaction_body.tokenUpdate.adminKey, expected_admin_public, key_type)
@@ -425,7 +425,7 @@ def test_mixed_key_types_in_constructor(mock_account_ids):
         token_keys=token_keys,
     )
     tx.operator_account_id = operator_id
-    tx.node_account_id = operator_id
+    tx.set_node_account_ids([operator_id])
 
     transaction_body = tx.build_transaction_body()
 
@@ -459,7 +459,7 @@ def test_build_transaction_body_with_keys(mock_account_ids, key_type, use_privat
     update_tx.set_freeze_key(freeze_key)
     update_tx.set_token_name(new_token_data["name"])
     update_tx.operator_account_id = operator_id
-    update_tx.node_account_id = node_account_id
+    update_tx.set_node_account_ids([node_account_id])
 
     transaction_body = update_tx.build_transaction_body()
 

--- a/tests/unit/token_wipe_transaction_test.py
+++ b/tests/unit/token_wipe_transaction_test.py
@@ -40,7 +40,7 @@ def test_build_transaction_body(mock_account_ids):
     wipe_tx = TokenWipeTransaction().set_token_id(token_id).set_account_id(wipe_account_id).set_amount(amount)
 
     wipe_tx.transaction_id = generate_transaction_id(account_id)
-    wipe_tx.node_account_id = node_account_id
+    wipe_tx.set_node_account_ids([node_account_id])
 
     transaction_body = wipe_tx.build_transaction_body()
 
@@ -64,7 +64,7 @@ def test_build_transaction_body_with_serial_numbers(mock_account_ids):
     wipe_tx = TokenWipeTransaction().set_token_id(token_id).set_account_id(wipe_account_id).set_serial(serial_numbers)
 
     wipe_tx.transaction_id = generate_transaction_id(account_id)
-    wipe_tx.node_account_id = node_account_id
+    wipe_tx.set_node_account_ids([node_account_id])
 
     transaction_body = wipe_tx.build_transaction_body()
 

--- a/tests/unit/topic_create_transaction_test.py
+++ b/tests/unit/topic_create_transaction_test.py
@@ -139,7 +139,7 @@ def test_build_topic_create_transaction_body(mock_account_ids, custom_fixed_fee,
     )
 
     tx.operator_account_id = AccountId(0, 0, 2)
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
 
     transaction_body = tx.build_transaction_body()
 
@@ -228,7 +228,7 @@ def test_missing_operator_in_topic_create(mock_account_ids):
     _, _, node_account_id, _, _ = mock_account_ids
 
     tx = TopicCreateTransaction(memo="No Operator")
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
 
     with pytest.raises(ValueError, match="Operator account ID is not set."):
         tx.build_transaction_body()
@@ -253,7 +253,7 @@ def test_sign_topic_create_transaction(mock_account_ids, private_key):
     _, _, node_account_id, _, _ = mock_account_ids
     tx = TopicCreateTransaction(memo="Signing test")
     tx.operator_account_id = AccountId(0, 0, 2)
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
 
     body_bytes = tx.build_transaction_body().SerializeToString()
     tx._transaction_body_bytes.setdefault(node_account_id, body_bytes)
@@ -452,7 +452,7 @@ def test_set_methods_require_not_frozen(mock_account_ids, custom_fixed_fee, mock
 
     tx = TopicCreateTransaction()
     tx.operator_account_id = AccountId(0, 0, 2)
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
     tx.freeze_with(mock_client)  # Freeze the transaction
 
     fee_schedule_key = create_key(key_type, use_private)
@@ -503,7 +503,7 @@ def test_single_key_fields(mock_account_ids, key_type, use_private, field_name, 
     assert getattr(tx, field_name).to_bytes() == key.to_bytes()
 
     tx.operator_account_id = AccountId(0, 0, 2)
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
 
     # Build transaction body
     transaction_body = tx.build_transaction_body()
@@ -538,7 +538,7 @@ def test_fee_exempt_keys(mock_account_ids, key_type, use_private):
     tx = TopicCreateTransaction()
     tx.set_fee_exempt_keys([key1, key2])
     tx.operator_account_id = AccountId(0, 0, 2)
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
 
     # Build transaction body
     transaction_body = tx.build_transaction_body()
@@ -566,7 +566,7 @@ def test_mixed_key_types_in_constructor(mock_account_ids):
         fee_exempt_keys=[ecdsa_public, ed25519_private],
     )
     tx.operator_account_id = AccountId(0, 0, 2)
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
 
     transaction_body = tx.build_transaction_body()
 

--- a/tests/unit/topic_delete_transaction_test.py
+++ b/tests/unit/topic_delete_transaction_test.py
@@ -30,7 +30,7 @@ def test_build_topic_delete_transaction_body(mock_account_ids, topic_id):
     tx = TopicDeleteTransaction(topic_id=topic_id)
 
     tx.operator_account_id = AccountId(0, 0, 2)
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
 
     transaction_body = tx.build_transaction_body()
     assert transaction_body.consensusDeleteTopic.topicID.topicNum == 1234
@@ -64,7 +64,7 @@ def test_missing_topic_id_in_delete(mock_account_ids):
     _, _, node_account_id, _, _ = mock_account_ids
     tx = TopicDeleteTransaction(topic_id=None)
     tx.operator_account_id = AccountId(0, 0, 2)
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
 
     with pytest.raises(ValueError, match="Missing required fields"):
         tx.build_transaction_body()
@@ -76,7 +76,7 @@ def test_sign_topic_delete_transaction(mock_account_ids, topic_id, private_key):
     _, _, node_account_id, _, _ = mock_account_ids
     tx = TopicDeleteTransaction(topic_id=topic_id)
     tx.operator_account_id = AccountId(0, 0, 2)
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
 
     body_bytes = tx.build_transaction_body().SerializeToString()
     tx._transaction_body_bytes.setdefault(node_account_id, body_bytes)

--- a/tests/unit/topic_message_submit_transaction_test.py
+++ b/tests/unit/topic_message_submit_transaction_test.py
@@ -549,7 +549,7 @@ def test_chunk_transaction_id_nanosecond_overflow(topic_id):
         .set_message("a" * 20)
         .set_chunk_size(10)
         .set_transaction_id(tx_id)
-        .set_node_account_id(AccountId(0, 0, 3))
+        .set_node_account_ids([AccountId(0, 0, 3)])
         .freeze()
     )
 

--- a/tests/unit/topic_update_transaction_test.py
+++ b/tests/unit/topic_update_transaction_test.py
@@ -130,7 +130,7 @@ def test_build_topic_update_transaction_body_with_all_key_types(mock_account_ids
     )
 
     tx.operator_account_id = AccountId(0, 0, 2)
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
 
     transaction_body = tx.build_transaction_body()
 
@@ -209,7 +209,7 @@ def test_build_topic_update_transaction_body(mock_account_ids, topic_id):
     tx = TopicUpdateTransaction(topic_id=topic_id, memo="Updated Memo")
 
     tx.operator_account_id = AccountId(0, 0, 2)
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
 
     transaction_body = tx.build_transaction_body()
     assert transaction_body.consensusUpdateTopic.topicID.topicNum == 1234
@@ -265,7 +265,7 @@ def test_missing_topic_id_in_update(mock_account_ids):
 
     tx = TopicUpdateTransaction(topic_id=None, memo="No ID")
     tx.operator_account_id = AccountId(0, 0, 2)
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
 
     transaction_body = tx.build_transaction_body()
 
@@ -278,7 +278,7 @@ def test_sign_topic_update_transaction(mock_account_ids, topic_id, private_key):
     _, _, node_account_id, _, _ = mock_account_ids
     tx = TopicUpdateTransaction(topic_id=topic_id, memo="Signature test")
     tx.operator_account_id = AccountId(0, 0, 2)
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
 
     body_bytes = tx.build_transaction_body().SerializeToString()
     tx._transaction_body_bytes.setdefault(node_account_id, body_bytes)
@@ -376,7 +376,7 @@ def test_topic_memo_and_transaction_memo_independent_in_protobuf(
     )
 
     tx.operator_account_id = AccountId(0, 0, 2)
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
 
     tx.set_transaction_memo("some unrelated audit note")
 
@@ -405,14 +405,14 @@ def test_topic_memo_serialization_distinguishes_unset_and_empty(
 
     tx = TopicUpdateTransaction(topic_id=topic_id)
     tx.operator_account_id = AccountId(0, 0, 2)
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
 
     body = tx.build_transaction_body().consensusUpdateTopic
     assert not body.HasField("memo")
 
     tx = TopicUpdateTransaction(topic_id=topic_id, memo="")
     tx.operator_account_id = AccountId(0, 0, 2)
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
 
     body = tx.build_transaction_body().consensusUpdateTopic
     assert body.HasField("memo")
@@ -420,7 +420,7 @@ def test_topic_memo_serialization_distinguishes_unset_and_empty(
 
     tx = TopicUpdateTransaction(topic_id=topic_id, memo="hello")
     tx.operator_account_id = AccountId(0, 0, 2)
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
 
     body = tx.build_transaction_body().consensusUpdateTopic
     assert body.HasField("memo")
@@ -436,7 +436,7 @@ def test_auto_renew_period_omitted_when_unset(
 
     tx = TopicUpdateTransaction(topic_id=topic_id)
     tx.operator_account_id = AccountId(0, 0, 2)
-    tx.node_account_id = node_account_id
+    tx.set_node_account_ids([node_account_id])
 
     body = tx.build_transaction_body().consensusUpdateTopic
 

--- a/tests/unit/transaction_freeze_and_bytes_test.py
+++ b/tests/unit/transaction_freeze_and_bytes_test.py
@@ -558,7 +558,7 @@ def test_changing_node_after_freeze_fails_for_to_bytes():
     assert isinstance(bytes_node_1, bytes)
 
     # Change to a different node that wasn't frozen
-    transaction.node_account_id = node_id_2
+    transaction._node_account_id = node_id_2
 
     # This should fail - no transaction body for node_id_2
     with pytest.raises(ValueError, match="No transaction body found for node"):
@@ -663,7 +663,9 @@ def test_transaction_freeze_without_node_ids(mock_client):
     tx = TransferTransaction()
     tx.freeze_with(mock_client)
 
-    assert tx.node_account_ids == []
+    assert len(tx.node_account_ids) == len(mock_client.network.nodes)
+    assert tx.node_account_ids == [node._account_id for node in mock_client.network.nodes]
+
     # Verify creates transaction_bytes for client network nodes
     assert len(tx._transaction_body_bytes) == len(mock_client.network.nodes)
     assert set(tx._transaction_body_bytes.keys()) == set(node._account_id for node in mock_client.network.nodes)

--- a/tests/unit/transaction_freeze_and_bytes_test.py
+++ b/tests/unit/transaction_freeze_and_bytes_test.py
@@ -25,7 +25,7 @@ pytestmark = pytest.mark.unit
 def test_freeze_without_transaction_id_raises_error():
     """Test that freeze() raises ValueError when transaction_id is not set."""
     transaction = TransferTransaction()
-    transaction.node_account_id = AccountId.from_string("0.0.3")
+    transaction.set_node_account_ids([AccountId.from_string("0.0.3")])
 
     with pytest.raises(ValueError, match="Transaction ID must be set before freezing"):
         transaction.freeze()
@@ -51,7 +51,7 @@ def test_freeze_with_valid_parameters():
     )
 
     transaction.transaction_id = TransactionId.generate(operator_id)
-    transaction.node_account_id = node_id
+    transaction.set_node_account_ids([node_id])
 
     # Should not raise any errors
     result = transaction.freeze()
@@ -75,7 +75,7 @@ def test_freeze_is_idempotent():
     )
 
     transaction.transaction_id = TransactionId.generate(operator_id)
-    transaction.node_account_id = node_id
+    transaction.set_node_account_ids([node_id])
 
     # Freeze multiple times
     transaction.freeze()
@@ -108,7 +108,7 @@ def test_to_bytes_returns_bytes():
     )
 
     transaction.transaction_id = TransactionId.generate(operator_id)
-    transaction.node_account_id = node_id
+    transaction.set_node_account_ids([node_id])
 
     # Freeze and sign the transaction
     transaction.freeze()
@@ -135,7 +135,7 @@ def test_to_bytes_produces_consistent_output():
     )
 
     transaction.transaction_id = TransactionId.generate(operator_id)
-    transaction.node_account_id = node_id
+    transaction.set_node_account_ids([node_id])
 
     transaction.freeze()
     transaction.sign(private_key)
@@ -161,7 +161,7 @@ def test_cannot_modify_transaction_after_freeze():
     )
 
     transaction.transaction_id = TransactionId.generate(operator_id)
-    transaction.node_account_id = node_id
+    transaction.set_node_account_ids([node_id])
     transaction.freeze()
 
     # Attempting to add more transfers should raise an error
@@ -202,7 +202,7 @@ def test_freeze_and_sign_workflow():
 
     # Set required IDs
     transaction.transaction_id = TransactionId.generate(operator_id)
-    transaction.node_account_id = node_id
+    transaction.set_node_account_ids([node_id])
 
     # Freeze
     transaction.freeze()
@@ -236,7 +236,7 @@ def test_from_bytes_round_trip_unsigned():
     )
 
     transaction.transaction_id = TransactionId.generate(operator_id)
-    transaction.node_account_id = node_id
+    transaction.set_node_account_ids([node_id])
     transaction.freeze()
 
     # Serialize to bytes
@@ -247,7 +247,7 @@ def test_from_bytes_round_trip_unsigned():
 
     # Verify common fields
     assert restored_transaction.transaction_id == transaction.transaction_id
-    assert restored_transaction.node_account_id == transaction.node_account_id
+    assert restored_transaction._node_account_ids.current == transaction._node_account_ids.current
     assert restored_transaction.memo == transaction.memo
     # When transaction_fee is None, it uses the default fee in the protobuf
     # So the restored transaction will have the default fee value
@@ -285,7 +285,7 @@ def test_from_bytes_round_trip_signed():
     )
 
     transaction.transaction_id = TransactionId.generate(operator_id)
-    transaction.node_account_id = node_id
+    transaction.set_node_account_ids([node_id])
     transaction.freeze()
     transaction.sign(private_key)
 
@@ -297,7 +297,7 @@ def test_from_bytes_round_trip_signed():
 
     # Verify fields
     assert restored_transaction.transaction_id == transaction.transaction_id
-    assert restored_transaction.node_account_id == transaction.node_account_id
+    assert restored_transaction._node_account_ids.current == transaction._node_account_ids.current
     assert restored_transaction.memo == "Signed transaction"
 
     # Verify transfers
@@ -327,7 +327,7 @@ def test_from_bytes_round_trip_multiple_signatures():
     )
 
     transaction.transaction_id = TransactionId.generate(operator_id)
-    transaction.node_account_id = node_id
+    transaction.set_node_account_ids([node_id])
     transaction.freeze()
 
     # Sign with multiple keys
@@ -366,7 +366,7 @@ def test_from_bytes_preserves_all_common_fields():
     )
 
     transaction.transaction_id = TransactionId.generate(operator_id)
-    transaction.node_account_id = node_id
+    transaction.set_node_account_ids([node_id])
     transaction.transaction_fee = 5_000_000  # Custom fee
     assert transaction.set_transaction_valid_duration(180) is transaction  # 3 minutes - using setter
     transaction.generate_record = True
@@ -379,7 +379,7 @@ def test_from_bytes_preserves_all_common_fields():
 
     # Verify all common fields
     assert restored_transaction.transaction_id == transaction.transaction_id
-    assert restored_transaction.node_account_id == transaction.node_account_id
+    assert restored_transaction._node_account_ids.current == transaction._node_account_ids.current
     assert restored_transaction.transaction_fee == 5_000_000
     assert restored_transaction.transaction_valid_duration == 180
     assert restored_transaction.generate_record == True
@@ -401,7 +401,7 @@ def test_from_bytes_external_signing_workflow():
     )
 
     transaction.transaction_id = TransactionId.generate(operator_id)
-    transaction.node_account_id = node_id
+    transaction.set_node_account_ids([node_id])
     transaction.freeze()
 
     unsigned_bytes = transaction.to_bytes()
@@ -427,7 +427,7 @@ def test_from_bytes_external_signing_workflow():
 
     # Verify all fields are still correct
     assert final_tx.transaction_id == transaction.transaction_id
-    assert final_tx.node_account_id == transaction.node_account_id
+    assert final_tx._node_account_ids.current == transaction._node_account_ids.current
     assert len(final_tx.hbar_transfers) == 2
 
 
@@ -442,7 +442,7 @@ def test_to_bytes_works_without_signatures():
     )
 
     transaction.transaction_id = TransactionId.generate(operator_id)
-    transaction.node_account_id = node_id
+    transaction.set_node_account_ids([node_id])
 
     # Freeze but DON'T sign
     transaction.freeze()
@@ -465,7 +465,7 @@ def test_freeze_only_builds_for_single_node():
     )
 
     transaction.transaction_id = TransactionId.generate(operator_id)
-    transaction.node_account_id = node_id
+    transaction.set_node_account_ids([node_id])
     transaction.freeze()
 
     # Should only have one node in the transaction body bytes map
@@ -486,7 +486,7 @@ def test_signed_and_unsigned_bytes_are_different():
     )
 
     transaction.transaction_id = TransactionId.generate(operator_id)
-    transaction.node_account_id = node_id
+    transaction.set_node_account_ids([node_id])
     transaction.freeze()
 
     # Get unsigned bytes
@@ -518,7 +518,7 @@ def test_multiple_signatures_increase_size():
     )
 
     transaction.transaction_id = TransactionId.generate(operator_id)
-    transaction.node_account_id = node_id
+    transaction.set_node_account_ids([node_id])
     transaction.freeze()
 
     # Get bytes with one signature
@@ -550,7 +550,7 @@ def test_changing_node_after_freeze_fails_for_to_bytes():
     )
 
     transaction.transaction_id = TransactionId.generate(operator_id)
-    transaction.node_account_id = node_id_1
+    transaction.set_node_account_ids([node_id_1])
     transaction.freeze()
 
     # This should work
@@ -558,7 +558,7 @@ def test_changing_node_after_freeze_fails_for_to_bytes():
     assert isinstance(bytes_node_1, bytes)
 
     # Change to a different node that wasn't frozen
-    transaction.node_account_id = node_id_2
+    transaction.set_node_account_ids([node_id_2])
 
     # This should fail - no transaction body for node_id_2
     with pytest.raises(ValueError, match="No transaction body found for node"):
@@ -578,7 +578,7 @@ def test_unsigned_transaction_can_be_signed_after_to_bytes():
     )
 
     transaction.transaction_id = TransactionId.generate(operator_id)
-    transaction.node_account_id = node_id
+    transaction.set_node_account_ids([node_id])
     transaction.freeze()
 
     # Get unsigned bytes
@@ -601,7 +601,7 @@ def test_transaction_freeze_with_node_ids(mock_client):
     # Case 1 Single node_account_id
     single_node_id = AccountId(0, 0, 3)
     tx = TransferTransaction()
-    tx.node_account_id = single_node_id
+    tx.set_node_account_ids([single_node_id])
 
     tx.freeze_with(mock_client)
 
@@ -633,7 +633,7 @@ def test_transaction_freeze_with_node_ids_without_client():
     single_node_id = AccountId(0, 0, 3)
     tx = TransferTransaction()
     tx.set_transaction_id(TransactionId.generate(operator_id))
-    tx.node_account_id = single_node_id
+    tx.set_node_account_ids([single_node_id])
 
     tx.freeze()
 

--- a/tests/unit/transaction_freeze_and_bytes_test.py
+++ b/tests/unit/transaction_freeze_and_bytes_test.py
@@ -558,7 +558,7 @@ def test_changing_node_after_freeze_fails_for_to_bytes():
     assert isinstance(bytes_node_1, bytes)
 
     # Change to a different node that wasn't frozen
-    transaction._node_account_id = node_id_2
+    transaction.node_account_id = node_id_2
 
     # This should fail - no transaction body for node_id_2
     with pytest.raises(ValueError, match="No transaction body found for node"):

--- a/tests/unit/transaction_nodes_test.py
+++ b/tests/unit/transaction_nodes_test.py
@@ -27,9 +27,30 @@ def test_set_single_node_account_id():
     txn = DummyTransaction()
     node = AccountId(0, 0, 3)
 
+    # Test deprecated for backward compatiblity
     txn.set_node_account_id(node)
 
     assert txn.node_account_ids == [node]
+
+
+def test_set_single_node_account_id_using_setter():
+    txn = DummyTransaction()
+    node = AccountId(0, 0, 3)
+
+    # Test deprecated for backward compatiblity
+    txn.node_account_id = node
+
+    assert txn.node_account_ids == [node]
+
+
+def test_get_single_node_account_id():
+    txn = DummyTransaction()
+    node = AccountId(0, 0, 3)
+
+    txn.set_node_account_ids([node])
+
+    # Test deprecated for backward compatiblity
+    assert txn.node_account_id == node
 
 
 def test_set_multiple_node_account_ids():
@@ -37,6 +58,15 @@ def test_set_multiple_node_account_ids():
     nodes = [AccountId(0, 0, 3), AccountId(0, 0, 4)]
 
     txn.set_node_account_ids(nodes)
+
+    assert txn.node_account_ids == nodes
+
+
+def test_set_multiple_node_account_ids_using_setters():
+    txn = DummyTransaction()
+    nodes = [AccountId(0, 0, 3), AccountId(0, 0, 4)]
+
+    txn.node_account_ids = nodes
 
     assert txn.node_account_ids == nodes
 

--- a/tests/unit/transaction_nodes_test.py
+++ b/tests/unit/transaction_nodes_test.py
@@ -43,12 +43,15 @@ def test_set_multiple_node_account_ids():
     assert txn._used_node_account_id is None
 
 
-def test_select_node_account_id():
+def test_node_account_ids_advance_method():
     txn = DummyTransaction()
     nodes = [AccountId(0, 0, 3), AccountId(0, 0, 4)]
     txn.set_node_account_ids(nodes)
 
-    selected = txn._select_node_account_id()
+    assert txn._node_account_ids._index == 0
+    assert txn._node_account_ids.current == nodes[0]
 
-    assert selected == nodes[0]
-    assert txn._used_node_account_id == nodes[0]
+    index = txn._node_account_ids.advance()
+    assert index == 0  # returns current index
+    assert txn._node_account_ids._index == 1
+    assert txn._node_account_ids.current == nodes[1]

--- a/tests/unit/transaction_nodes_test.py
+++ b/tests/unit/transaction_nodes_test.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import re
+
+import pytest
+
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.transaction.transaction import Transaction
 
@@ -28,7 +32,11 @@ def test_set_single_node_account_id():
     node = AccountId(0, 0, 3)
 
     # Test deprecated for backward compatiblity
-    txn.set_node_account_id(node)
+    with pytest.warns(
+        DeprecationWarning,
+        match=re.escape("Method 'set_node_account_id()' is deprecated; use 'set_node_account_ids()' instead."),
+    ):
+        txn.set_node_account_id(node)
 
     assert txn.node_account_ids == [node]
 
@@ -38,7 +46,8 @@ def test_set_single_node_account_id_using_setter():
     node = AccountId(0, 0, 3)
 
     # Test deprecated for backward compatiblity
-    txn.node_account_id = node
+    with pytest.warns(DeprecationWarning, match="'node_account_id' is deprecated"):
+        txn.node_account_id = node
 
     assert txn.node_account_ids == [node]
 
@@ -50,7 +59,8 @@ def test_get_single_node_account_id():
     txn.set_node_account_ids([node])
 
     # Test deprecated for backward compatiblity
-    assert txn.node_account_id == node
+    with pytest.warns(DeprecationWarning, match="'node_account_id' is deprecated"):
+        assert txn.node_account_id == node
 
 
 def test_set_multiple_node_account_ids():

--- a/tests/unit/transaction_nodes_test.py
+++ b/tests/unit/transaction_nodes_test.py
@@ -46,10 +46,10 @@ def test_node_account_ids_advance_method():
     nodes = [AccountId(0, 0, 3), AccountId(0, 0, 4)]
     txn.set_node_account_ids(nodes)
 
-    assert txn._node_account_ids._index == 0
+    assert txn._node_account_ids.index == 0
     assert txn._node_account_ids.current == nodes[0]
 
     index = txn._node_account_ids.advance()
     assert index == 0  # returns current index
-    assert txn._node_account_ids._index == 1
+    assert txn._node_account_ids.index == 1
     assert txn._node_account_ids.current == nodes[1]

--- a/tests/unit/transaction_nodes_test.py
+++ b/tests/unit/transaction_nodes_test.py
@@ -30,7 +30,6 @@ def test_set_single_node_account_id():
     txn.set_node_account_id(node)
 
     assert txn.node_account_ids == [node]
-    assert txn._used_node_account_id is None
 
 
 def test_set_multiple_node_account_ids():
@@ -40,7 +39,6 @@ def test_set_multiple_node_account_ids():
     txn.set_node_account_ids(nodes)
 
     assert txn.node_account_ids == nodes
-    assert txn._used_node_account_id is None
 
 
 def test_node_account_ids_advance_method():

--- a/tests/unit/transaction_test.py
+++ b/tests/unit/transaction_test.py
@@ -553,3 +553,37 @@ def test_transaction_default_max_fee(account_id):
 
     assert tx_body is not None
     assert tx_body.transactionFee == Hbar(2).to_tinybars()
+
+
+def test_transaction_body_bytes_for_each_node_id_on_freeze(mock_client):
+    """Test create transaction body bytes for each network node when frozen."""
+    tx = AccountCreateTransaction().set_key_without_alias(PrivateKey.generate_ecdsa())
+    tx.freeze_with(mock_client)
+
+    body_bytes = tx._transaction_body_bytes
+
+    assert body_bytes
+    assert body_bytes.keys() == {node._account_id for node in mock_client.network.nodes}
+
+    for node_id, body_bytes_value in body_bytes.items():
+        body = transaction_pb2.TransactionBody()
+        body.ParseFromString(body_bytes_value)
+        assert body.nodeAccountID == AccountId._to_proto(node_id)
+
+
+def test_transaction_body_bytes_for_each_node_id_on_freeze_manual(mock_client):
+    """Test create transaction body bytes for manually configured node account IDs."""
+    node_ids = [AccountId(0, 0, 3), AccountId(0, 0, 4)]
+
+    tx = AccountCreateTransaction().set_key_without_alias(PrivateKey.generate_ecdsa()).set_node_account_ids(node_ids)
+    tx.freeze_with(mock_client)
+
+    body_bytes = tx._transaction_body_bytes
+
+    assert body_bytes
+    assert set(body_bytes) == set(node_ids)
+
+    for node_id, body_bytes_value in body_bytes.items():
+        body = transaction_pb2.TransactionBody()
+        body.ParseFromString(body_bytes_value)
+        assert body.nodeAccountID == AccountId._to_proto(node_id)

--- a/tests/unit/transaction_test.py
+++ b/tests/unit/transaction_test.py
@@ -101,7 +101,7 @@ def test_execute_without_wait_returns_transaction_response():
 
         assert isinstance(response, TransactionResponse)
         assert response.transaction is tx
-        assert response.node_id == tx.node_account_id
+        assert response.node_id == tx._node_account_ids.current
         assert response.validate_status is True
 
 
@@ -151,7 +151,7 @@ def test_execute_returns_receipt_without_error_when_validation_disabled():
 def test_duplicate_signature_not_added():
     tx = TokenMintTransaction()
     tx.set_transaction_id(TransactionId.generate(AccountId(0, 0, 1234)))
-    tx.set_node_account_id(AccountId(0, 0, 3))
+    tx.set_node_account_ids([AccountId(0, 0, 3)])
     tx.set_token_id(TokenId(0, 0, 1))
     tx.set_amount(100)
     key = PrivateKey.generate_ed25519()
@@ -167,7 +167,7 @@ def test_duplicate_signature_not_added():
 def test_multiple_keys_still_work():
     tx = TokenMintTransaction()
     tx.set_transaction_id(TransactionId.generate(AccountId(0, 0, 1234)))
-    tx.set_node_account_id(AccountId(0, 0, 3))
+    tx.set_node_account_ids([AccountId(0, 0, 3)])
     tx.set_token_id(TokenId(0, 0, 1))
     tx.set_amount(100)
     key1 = PrivateKey.generate_ed25519()
@@ -196,7 +196,7 @@ def test_same_size_for_identical_transactions(transaction_id, account_id):
         .set_key_without_alias(key)
         .set_initial_balance(Hbar(2))
         .set_transaction_id(transaction_id)
-        .set_node_account_id(account_id)
+        .set_node_account_ids([account_id])
         .freeze()
     )
 
@@ -205,7 +205,7 @@ def test_same_size_for_identical_transactions(transaction_id, account_id):
         .set_key_without_alias(key)
         .set_initial_balance(Hbar(2))
         .set_transaction_id(transaction_id)
-        .set_node_account_id(account_id)
+        .set_node_account_ids([account_id])
         .freeze()
     )
 
@@ -221,7 +221,7 @@ def test_signed_tx_have_larger_size(transaction_id, account_id):
         .set_key_without_alias(key)
         .set_initial_balance(Hbar(2))
         .set_transaction_id(transaction_id)
-        .set_node_account_id(account_id)
+        .set_node_account_ids([account_id])
         .freeze()
         .sign(PrivateKey.generate())
     )
@@ -231,7 +231,7 @@ def test_signed_tx_have_larger_size(transaction_id, account_id):
         .set_key_without_alias(key)
         .set_initial_balance(Hbar(2))
         .set_transaction_id(transaction_id)
-        .set_node_account_id(account_id)
+        .set_node_account_ids([account_id])
         .freeze()
     )
 
@@ -244,7 +244,7 @@ def test_tx_with_larger_content_should_have_larger_tx_body(transaction_id, accou
         FileCreateTransaction()
         .set_contents("smallBody")
         .set_transaction_id(transaction_id)
-        .set_node_account_id(account_id)
+        .set_node_account_ids([account_id])
         .freeze()
     )
 
@@ -252,7 +252,7 @@ def test_tx_with_larger_content_should_have_larger_tx_body(transaction_id, accou
         FileCreateTransaction()
         .set_contents("veryLargeBody")
         .set_transaction_id(transaction_id)
-        .set_node_account_id(account_id)
+        .set_node_account_ids([account_id])
         .freeze()
     )
 
@@ -267,7 +267,7 @@ def test_tx_without_optional_fields_should_have_smaller_tx_body(transaction_id, 
         .set_key_without_alias(key)
         .set_initial_balance(Hbar(2))
         .set_transaction_id(transaction_id)
-        .set_node_account_id(account_id)
+        .set_node_account_ids([account_id])
         .freeze()
     )
 
@@ -276,7 +276,7 @@ def test_tx_without_optional_fields_should_have_smaller_tx_body(transaction_id, 
         .set_key_without_alias(key)
         .set_initial_balance(Hbar(2))
         .set_transaction_id(transaction_id)
-        .set_node_account_id(account_id)
+        .set_node_account_ids([account_id])
         .set_alias(PrivateKey.generate_ecdsa().public_key().to_evm_address())
         .set_transaction_valid_duration(10)
         .freeze()
@@ -296,7 +296,7 @@ def test_file_append_chunk_tx_should_return_list_of_body_sizes(file_id, account_
         .set_chunk_size(chunk_size)
         .set_contents(content)
         .set_transaction_id(transaction_id)
-        .set_node_account_id(account_id)
+        .set_node_account_ids([account_id])
         .freeze()
     )
 
@@ -313,7 +313,7 @@ def test_file_append_single_chunk_tx_return_list_of_len_one(file_id, account_id,
         .set_file_id(file_id)
         .set_contents(content)
         .set_transaction_id(transaction_id)
-        .set_node_account_id(account_id)
+        .set_node_account_ids([account_id])
         .freeze()
     )
 
@@ -333,7 +333,7 @@ def test_message_submit_chunk_tx_should_return_list_of_body_sizes(topic_id, acco
         .set_chunk_size(chunk_size)
         .set_message(message)
         .set_transaction_id(transaction_id)
-        .set_node_account_id(account_id)
+        .set_node_account_ids([account_id])
         .freeze()
     )
 
@@ -351,7 +351,7 @@ def test_message_submit_single_chunk_tx_return_list_of_len_one(topic_id, account
         .set_topic_id(topic_id)
         .set_message(message)
         .set_transaction_id(transaction_id)
-        .set_node_account_id(account_id)
+        .set_node_account_ids([account_id])
         .freeze()
     )
 
@@ -367,7 +367,7 @@ def test_tx_with_no_content_should_return_single_body_chunk(file_id, account_id,
         .set_file_id(file_id)
         .set_contents(" ")
         .set_transaction_id(transaction_id)
-        .set_node_account_id(account_id)
+        .set_node_account_ids([account_id])
         .freeze()
     )
 
@@ -385,7 +385,7 @@ def test_chunked_tx_return_proper_sizes(file_id, account_id, transaction_id):
         .set_file_id(file_id)
         .set_contents(large_content)
         .set_transaction_id(transaction_id)
-        .set_node_account_id(account_id)
+        .set_node_account_ids([account_id])
         .freeze()
     )
 
@@ -398,7 +398,7 @@ def test_chunked_tx_return_proper_sizes(file_id, account_id, transaction_id):
         .set_file_id(file_id)
         .set_contents(small_content)
         .set_transaction_id(transaction_id)
-        .set_node_account_id(account_id)
+        .set_node_account_ids([account_id])
         .freeze()
     )
 
@@ -422,7 +422,7 @@ def test_chunked_tx_differ_size_if_chunk_are_not_equal(topic_id, account_id, tra
         .set_chunk_size(chunk_size)
         .set_message(message)
         .set_transaction_id(transaction_id)
-        .set_node_account_id(account_id)
+        .set_node_account_ids([account_id])
         .freeze()
     )
 
@@ -459,7 +459,7 @@ def test_high_volume_cannot_change_after_freeze(transaction_id, account_id):
         AccountCreateTransaction()
         .set_key_without_alias(PrivateKey.generate_ed25519())
         .set_transaction_id(transaction_id)
-        .set_node_account_id(account_id)
+        .set_node_account_ids([account_id])
         .freeze()
     )
 
@@ -478,7 +478,7 @@ def test_high_volume_is_included_in_protobuf_output(
         AccountCreateTransaction()
         .set_key_without_alias(PrivateKey.generate_ed25519())
         .set_transaction_id(transaction_id)
-        .set_node_account_id(account_id)
+        .set_node_account_ids([account_id])
         .set_high_volume(True)
         .freeze()
     )
@@ -497,7 +497,7 @@ def test_high_volume_is_included_in_protobuf_output(
         AccountCreateTransaction()
         .set_key_without_alias(PrivateKey.generate_ed25519())
         .set_transaction_id(transaction_id)
-        .set_node_account_id(account_id)
+        .set_node_account_ids([account_id])
         .set_high_volume(False)
         .freeze()
     )
@@ -546,7 +546,7 @@ def test_transaction_fee_rejects_negative_int():
 def test_transaction_default_max_fee(account_id):
     """Test default transaction fee is set if no transaction fee is set."""
     tx = TopicMessageSubmitTransaction()
-    tx.set_node_account_id(AccountId(0, 0, 3))
+    tx.set_node_account_ids([AccountId(0, 0, 3)])
     tx.operator_account_id = account_id
 
     tx_body = tx.build_base_transaction_body()

--- a/tests/unit/transfer_transaction_test.py
+++ b/tests/unit/transfer_transaction_test.py
@@ -334,7 +334,7 @@ def test_build_transaction_body(mock_account_ids):
     transfer_tx.add_nft_transfer(NftId(token_id_1, 1), account_id_sender, account_id_recipient)
 
     # Set required fields for building transaction
-    transfer_tx.node_account_id = node_account_id
+    transfer_tx.set_node_account_ids([node_account_id])
     transfer_tx.operator_account_id = account_id_sender
 
     # Build the transaction body
@@ -604,7 +604,7 @@ def test_token_transfer_with_expected_decimals_building(mock_account_ids):
 
     transfer_tx.add_token_transfer_with_decimals(token_id_1, account_id_1, -100, 8)
     transfer_tx.add_token_transfer_with_decimals(token_id_1, account_id_2, 100, 8)
-    transfer_tx.node_account_id = node_account_id
+    transfer_tx.set_node_account_ids([node_account_id])
     transfer_tx.operator_account_id = account_id_1
 
     result = transfer_tx.build_transaction_body()
@@ -630,7 +630,7 @@ def test_nft_transfer_with_approval_building(mock_account_ids):
 
     transfer_tx.add_nft_transfer(NftId(token_id_1, 1), account_id_sender, account_id_recipient, False)
     transfer_tx.add_nft_transfer(NftId(token_id_1, 2), account_id_sender, account_id_recipient, True)
-    transfer_tx.node_account_id = node_account_id
+    transfer_tx.set_node_account_ids([node_account_id])
     transfer_tx.operator_account_id = account_id_sender
 
     result = transfer_tx.build_transaction_body()
@@ -654,7 +654,7 @@ def test_nft_transfer_reconstruction_from_protobuf(mock_account_ids):
     transfer_tx = TransferTransaction()
 
     transfer_tx.add_nft_transfer(NftId(token_id_1, 5), account_id_sender, account_id_recipient, True)
-    transfer_tx.node_account_id = node_account_id
+    transfer_tx.set_node_account_ids([node_account_id])
     transfer_tx.operator_account_id = account_id_sender
 
     body = transfer_tx.build_transaction_body()
@@ -677,7 +677,7 @@ def test_nft_transfers_unapproved_reconstruction(mock_account_ids):
     transfer_tx = TransferTransaction()
 
     transfer_tx.add_nft_transfer(NftId(token_id_1, 10), account_id_sender, account_id_recipient, False)
-    transfer_tx.node_account_id = node_account_id
+    transfer_tx.set_node_account_ids([node_account_id])
     transfer_tx.operator_account_id = account_id_sender
 
     body = transfer_tx.build_transaction_body()
@@ -697,7 +697,7 @@ def test_token_transfer_with_expected_decimals_reconstruction(mock_account_ids):
 
     transfer_tx.add_token_transfer_with_decimals(token_id_1, account_id_sender, -100, 6)
     transfer_tx.add_token_transfer_with_decimals(token_id_1, account_id_recipient, 100, 6)
-    transfer_tx.node_account_id = node_account_id
+    transfer_tx.set_node_account_ids([node_account_id])
     transfer_tx.operator_account_id = account_id_sender
 
     body = transfer_tx.build_transaction_body()
@@ -724,7 +724,7 @@ def test_combined_transfers_reconstruction(mock_account_ids):
     transfer_tx.add_token_transfer_with_decimals(token_id_1, account_id_sender, -50, 8)
     transfer_tx.add_token_transfer_with_decimals(token_id_1, account_id_recipient, 50, 8)
     transfer_tx.add_nft_transfer(NftId(token_id_1, 1), account_id_sender, account_id_recipient, True)
-    transfer_tx.node_account_id = node_account_id
+    transfer_tx.set_node_account_ids([node_account_id])
     transfer_tx.operator_account_id = account_id_sender
 
     body = transfer_tx.build_transaction_body()
@@ -750,7 +750,7 @@ def test_expected_decimals_field_preservation(mock_account_ids):
 
     transfer_tx.add_token_transfer_with_decimals(token_id_1, account_id_sender, -200, 8)
     transfer_tx.add_token_transfer_with_decimals(token_id_1, account_id_recipient, 200, 8)
-    transfer_tx.node_account_id = node_account_id
+    transfer_tx.set_node_account_ids([node_account_id])
     transfer_tx.operator_account_id = account_id_sender
 
     body = transfer_tx.build_transaction_body()
@@ -770,7 +770,7 @@ def test_nft_transfer_fields_preservation(mock_account_ids):
     transfer_tx = TransferTransaction()
 
     transfer_tx.add_nft_transfer(NftId(token_id_1, 42), account_id_sender, account_id_recipient, True)
-    transfer_tx.node_account_id = node_account_id
+    transfer_tx.set_node_account_ids([node_account_id])
     transfer_tx.operator_account_id = account_id_sender
 
     body = transfer_tx.build_transaction_body()
@@ -797,7 +797,7 @@ def test_multiple_nft_transfers_all_fields(mock_account_ids):
     transfer_tx.add_nft_transfer(NftId(token_id_1, 100), account_id_sender, account_id_recipient, True)
     transfer_tx.add_nft_transfer(NftId(token_id_1, 101), account_id_sender, account_id_recipient, False)
     transfer_tx.add_nft_transfer(NftId(token_id_1, 102), account_id_sender, account_id_recipient, True)
-    transfer_tx.node_account_id = node_account_id
+    transfer_tx.set_node_account_ids([node_account_id])
     transfer_tx.operator_account_id = account_id_sender
 
     body = transfer_tx.build_transaction_body()
@@ -826,7 +826,7 @@ def test_token_transfer_without_expected_decimals(mock_account_ids):
 
     transfer_tx.add_token_transfer(token_id_1, account_id_sender, -300)
     transfer_tx.add_token_transfer(token_id_1, account_id_recipient, 300)
-    transfer_tx.node_account_id = node_account_id
+    transfer_tx.set_node_account_ids([node_account_id])
     transfer_tx.operator_account_id = account_id_sender
 
     body = transfer_tx.build_transaction_body()


### PR DESCRIPTION
**Description**:
This PR deprecate the `set_node_account_id` and `node_account_id` to use `set_node_account_ids` and aling with other sdk's

**Changes Made**
- Added `_LockableList` class
- Deprecated the `node_account_id` and `set_node_account_id()` method
- Remove unused `var` that are only being used in test
- Added unit test for changes

**Related issue(s)**:

Fixes #2475

**Notes for reviewer**:
- The set_lock() for node_account_ids is currently not used, to keep this PR focus on the node_account_ids stuff only. and will be address in follow up PR.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
