### PR TITLE
feat: Update TopicUpdate Transaction

### DIFF
--- a/src/hiero_sdk_python/consensus/topic_update_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_update_transaction.py
@@ -57,10 +57,10 @@ class TopicUpdateTransaction(Transaction):
         """
         super().__init__()
         self.topic_id: TopicId | None = topic_id
-        self.topic_memo = memo
+        self.topic_memo: str | None = memo
         self.admin_key: Key | None = admin_key
         self.submit_key: Key | None = submit_key
-        self.auto_renew_period = auto_renew_period
+        self.auto_renew_period: Duration | None = auto_renew_period
         self.auto_renew_account: AccountId | None = auto_renew_account
         self.expiration_time: Timestamp | None = expiration_time
         self.transaction_fee: int = 10_000_000

--- a/src/hiero_sdk_python/consensus/topic_update_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_update_transaction.py
@@ -13,7 +13,7 @@ from hiero_sdk_python.consensus.topic_id import TopicId
 from hiero_sdk_python.crypto.key import Key
 from hiero_sdk_python.Duration import Duration
 from hiero_sdk_python.executable import _Method
-from hiero_sdk_python.hapi.services import consensus_update_topic_pb2, duration_pb2, timestamp_pb2, transaction_pb2
+from hiero_sdk_python.hapi.services import consensus_update_topic_pb2, duration_pb2, transaction_pb2
 from hiero_sdk_python.hapi.services.custom_fees_pb2 import FeeExemptKeyList, FixedCustomFeeList
 from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
     SchedulableTransactionBody,
@@ -33,7 +33,7 @@ class TopicUpdateTransaction(Transaction):
         memo: str | None = None,
         admin_key: Key | None = None,
         submit_key: Key | None = None,
-        auto_renew_period: Duration | None = Duration(7890000),
+        auto_renew_period: Duration | None = None,
         auto_renew_account: AccountId | None = None,
         expiration_time: Timestamp | None = None,
         custom_fees: list[CustomFixedFee] | None = None,
@@ -57,10 +57,10 @@ class TopicUpdateTransaction(Transaction):
         """
         super().__init__()
         self.topic_id: TopicId | None = topic_id
-        self.topic_memo: str | None = memo
+        self.topic_memo = memo
         self.admin_key: Key | None = admin_key
         self.submit_key: Key | None = submit_key
-        self.auto_renew_period: Duration | None = auto_renew_period
+        self.auto_renew_period = auto_renew_period
         self.auto_renew_account: AccountId | None = auto_renew_account
         self.expiration_time: Timestamp | None = expiration_time
         self.transaction_fee: int = 10_000_000
@@ -157,7 +157,7 @@ class TopicUpdateTransaction(Transaction):
         self.auto_renew_account = account_id
         return self
 
-    def set_expiration_time(self, expiration_time: timestamp_pb2.Timestamp) -> TopicUpdateTransaction:
+    def set_expiration_time(self, expiration_time: Timestamp) -> TopicUpdateTransaction:
         """
         Sets the expiration time for the topic.
 
@@ -243,12 +243,7 @@ class TopicUpdateTransaction(Transaction):
 
         Returns:
             ConsensusUpdateTopicTransactionBody: The protobuf body for this transaction.
-
-        Raises:
-            ValueError: If required fields are missing.
         """
-        if self.topic_id is None:
-            raise ValueError("Missing required fields: topic_id")
 
         custom_fees = (
             FixedCustomFeeList(fees=[custom_fee._to_topic_fee_proto() for custom_fee in self.custom_fees])
@@ -263,7 +258,7 @@ class TopicUpdateTransaction(Transaction):
         )
 
         return consensus_update_topic_pb2.ConsensusUpdateTopicTransactionBody(
-            topicID=self.topic_id._to_proto(),
+            topicID=self.topic_id._to_proto() if self.topic_id else None,
             adminKey=key_to_proto(self.admin_key) if self.admin_key else None,
             submitKey=key_to_proto(self.submit_key) if self.submit_key else None,
             autoRenewPeriod=(

--- a/tests/unit/topic_update_transaction_test.py
+++ b/tests/unit/topic_update_transaction_test.py
@@ -260,15 +260,16 @@ def test_build_scheduled_body(topic_id):
 
 # This test uses fixture mock_account_ids as parameter
 def test_missing_topic_id_in_update(mock_account_ids):
-    """Test that building fails if no topic ID is provided."""
+    """Test that a missing topic ID is deferred to network validation."""
     _, _, node_account_id, _, _ = mock_account_ids
 
     tx = TopicUpdateTransaction(topic_id=None, memo="No ID")
     tx.operator_account_id = AccountId(0, 0, 2)
     tx.node_account_id = node_account_id
 
-    with pytest.raises(ValueError, match="Missing required fields"):
-        tx.build_transaction_body()
+    transaction_body = tx.build_transaction_body()
+
+    assert not transaction_body.consensusUpdateTopic.HasField("topicID")
 
 
 # This test uses fixtures (mock_account_ids, topic_id, private_key) as parameters
@@ -424,3 +425,19 @@ def test_topic_memo_serialization_distinguishes_unset_and_empty(
     body = tx.build_transaction_body().consensusUpdateTopic
     assert body.HasField("memo")
     assert body.memo.value == "hello"
+
+
+def test_auto_renew_period_omitted_when_unset(
+    mock_account_ids,
+    topic_id,
+):
+    """Unset auto-renew period should not be serialized."""
+    _, _, node_account_id, _, _ = mock_account_ids
+
+    tx = TopicUpdateTransaction(topic_id=topic_id)
+    tx.operator_account_id = AccountId(0, 0, 2)
+    tx.node_account_id = node_account_id
+
+    body = tx.build_transaction_body().consensusUpdateTopic
+
+    assert not body.HasField("autoRenewPeriod")


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->
Align `TopicUpdateTransaction` behavior with the JS SDK and sibling update transactions by treating omitted optional fields as true no-ops, deferring `topic_id` validation to the Hedera network, and correcting the expiration time type hint.

## Changes

* Default `auto_renew_period` to `None` so it is only serialized when explicitly set via `set_auto_renew_period()`.
* Default the topic memo to `None` so an omitted memo is not included in the transaction protobuf.
* Remove client-side validation requiring `topic_id` during transaction body construction and instead omit the field when unset, allowing the network to return `INVALID_TOPIC_ID`.
* Update `set_expiration_time()` to use the SDK `Timestamp` type hint for consistency with the constructor and protobuf serialization.
* Add unit tests covering:

  * Omission of `autoRenewPeriod` when no auto-renew period is specified.
  * Omission of `topicID` when no topic ID is provided, verifying transaction body construction succeeds and validation is deferred to the network.
  * Existing memo serialization behavior, ensuring unset memos are omitted while explicitly provided memos are serialized.

## Result

These changes bring `TopicUpdateTransaction` in line with the behavior of the JavaScript SDK and other update transactions, preventing unintended state updates caused by default values while allowing server-side validation of missing topic IDs.


**Related issue(s)**:

Fixes #2471 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)