### PR TITLE
feat: add clear_custom_fee_limits() to TopicMessageSubmitTransaction

### DIFF
--- a/src/hiero_sdk_python/consensus/topic_message_submit_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_message_submit_transaction.py
@@ -162,6 +162,17 @@ class TopicMessageSubmitTransaction(ChunkedTransaction):
         self.custom_fee_limits.append(custom_fee_limit)
         return self
 
+    def clear_custom_fee_limits(self) -> TopicMessageSubmitTransaction:
+        """
+        Clears all previously configured custom fee limits for the message submission.
+
+        Returns:
+            TopicMessageSubmitTransaction: This transaction instance (for chaining).
+        """
+        self._require_not_frozen()
+        self.custom_fee_limits = []
+        return self
+
     def _build_proto_body(self) -> consensus_submit_message_pb2.ConsensusSubmitMessageTransactionBody:
         """
         Returns the protobuf body for the topic message submit transaction.

--- a/tests/unit/topic_message_submit_transaction_test.py
+++ b/tests/unit/topic_message_submit_transaction_test.py
@@ -99,6 +99,11 @@ def test_constructor_and_setters(topic_id, message, custom_fee_limit):
     assert tx_default.custom_fee_limits[0] == custom_fee_limit
     assert result is tx_default
 
+    # Test clear_custom_fee_limits
+    result = tx_default.clear_custom_fee_limits()
+    assert tx_default.custom_fee_limits == []
+    assert result is tx_default
+
 
 def test_set_methods_require_not_frozen(mock_client, topic_id, message, custom_fee_limit):
     """Test that setter methods raise exception when transaction is frozen."""
@@ -122,6 +127,16 @@ def test_set_methods_require_not_frozen(mock_client, topic_id, message, custom_f
             getattr(tx, method_name)(value)
 
 
+def test_clear_custom_fee_limits_requires_not_frozen(mock_client, topic_id, message, custom_fee_limit):
+    """Test that clear_custom_fee_limits() raises when the transaction is frozen."""
+    tx = TopicMessageSubmitTransaction(topic_id=topic_id, message=message)
+    tx.add_custom_fee_limit(custom_fee_limit)
+    tx.freeze_with(mock_client)
+
+    with pytest.raises(Exception, match="Transaction is immutable; it has been frozen"):
+        tx.clear_custom_fee_limits()
+
+
 def test_method_chaining(topic_id, message, custom_fee_limit):
     """Test method chaining functionality."""
     tx = TopicMessageSubmitTransaction()
@@ -143,6 +158,10 @@ def test_method_chaining(topic_id, message, custom_fee_limit):
     assert len(tx.custom_fee_limits) == 2
     assert tx.chunk_size == chunk_size
     assert tx.max_chunks == max_chunks
+
+    result = tx.clear_custom_fee_limits()
+    assert result is tx
+    assert tx.custom_fee_limits == []
 
 
 def test_get_method():


### PR DESCRIPTION
**Description**:

Add `clear_custom_fee_limits()` to `TopicMessageSubmitTransaction`.

* Add `clear_custom_fee_limits()` to remove all configured custom fee limits
* Prevent modification after the transaction has been frozen
* Return `self` to preserve method chaining
* Add unit tests covering clearing custom fee limits, freeze behavior, and method chaining

**Related issue(s)**:

Fixes #2449

**Notes for reviewer**:

This change adds `clear_custom_fee_limits()` to `TopicMessageSubmitTransaction`, matching the behavior provided by the other Hiero SDKs. The method clears all configured custom fee limits, enforces immutability after freezing, returns `self` for fluent chaining, and is covered by unit tests.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
