### PR TITLE
chore: Refactor FileCreateTransaction to use `Key` instead of `PublicKey`

### DIFF
--- a/src/hiero_sdk_python/file/file_create_transaction.py
+++ b/src/hiero_sdk_python/file/file_create_transaction.py
@@ -32,9 +32,9 @@ class FileCreateTransaction(Transaction):
     def __init__(
         self,
         keys: list[Key] | None = None,
-        contents: str | bytes = "",
+        contents: str | bytes | None = None,
         expiration_time: Timestamp | None = None,
-        file_memo: str = "",
+        file_memo: str | None = None,
     ):
         """
         Initializes a new FileCreateTransaction instance with the specified parameters.

--- a/src/hiero_sdk_python/file/file_create_transaction.py
+++ b/src/hiero_sdk_python/file/file_create_transaction.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import time
 
 from hiero_sdk_python.channels import _Channel
-from hiero_sdk_python.crypto.public_key import PublicKey
+from hiero_sdk_python.crypto.key import Key
+from hiero_sdk_python.crypto.key_list import KeyList
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services import file_create_pb2
-from hiero_sdk_python.hapi.services.basic_types_pb2 import KeyList as KeyListProto
 from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
     SchedulableTransactionBody,
 )
@@ -31,22 +31,22 @@ class FileCreateTransaction(Transaction):
 
     def __init__(
         self,
-        keys: list[PublicKey] | None = None,
-        contents: str | bytes | None = None,
+        keys: list[Key] | None = None,
+        contents: str | bytes = "",
         expiration_time: Timestamp | None = None,
-        file_memo: str | None = None,
+        file_memo: str = "",
     ):
         """
         Initializes a new FileCreateTransaction instance with the specified parameters.
 
         Args:
-            keys (Optional[list[PublicKey]], optional): The keys that are allowed to update/delete the file.
+            keys (Optional[list[Key]], optional): The keys that are allowed to update/delete the file.
             contents (Optional[str | bytes], optional): The contents of the file to create. Strings will be automatically encoded as UTF-8 bytes.
             expiration_time (Optional[Timestamp], optional): The time at which the file should expire.
             file_memo (Optional[str], optional): A memo to include with the file.
         """
         super().__init__()
-        self.keys: list[PublicKey] | None = keys or []
+        self.keys: list[Key] | None = keys or []
         self.contents: bytes | None = self._encode_contents(contents)
         self.expiration_time: Timestamp | None = (
             expiration_time if expiration_time else Timestamp(int(time.time()) + self.DEFAULT_EXPIRY_SECONDS, 0)
@@ -70,18 +70,18 @@ class FileCreateTransaction(Transaction):
             return contents.encode("utf-8")
         return contents
 
-    def set_keys(self, keys: list[PublicKey] | None | PublicKey) -> FileCreateTransaction:
+    def set_keys(self, keys: list[Key] | None | Key) -> FileCreateTransaction:
         """
         Sets the keys for this file create transaction.
 
         Args:
-            keys (Optional[list[PublicKey]] | PublicKey): The keys to set for the file. Can be a list of PublicKey objects or None.
+            keys (Optional[list[Key]] | Key): The keys to set for the file. Can be a list of PublicKey objects or None.
 
         Returns:
             FileCreateTransaction: This transaction instance.
         """
         self._require_not_frozen()
-        if isinstance(keys, PublicKey):
+        if isinstance(keys, Key):
             self.keys = [keys]
         else:
             self.keys = keys or []
@@ -137,7 +137,7 @@ class FileCreateTransaction(Transaction):
             FileCreateTransactionBody: The protobuf body for this transaction.
         """
         return file_create_pb2.FileCreateTransactionBody(
-            keys=KeyListProto(keys=[key._to_proto() for key in self.keys or []]),
+            keys=KeyList().set_keys(self.keys).to_proto(),
             contents=self.contents if self.contents is not None else b"",
             expirationTime=self.expiration_time._to_protobuf() if self.expiration_time else None,
             memo=self.file_memo if self.file_memo is not None else "",
@@ -192,7 +192,7 @@ class FileCreateTransaction(Transaction):
         Returns:
             FileCreateTransaction: This transaction instance.
         """
-        self.keys = [PublicKey._from_proto(key) for key in proto.keys.keys] if proto.keys.keys else []
+        self.keys = KeyList.from_proto(proto.keys).keys
         self.contents = proto.contents
         self.expiration_time = Timestamp._from_protobuf(proto.expirationTime) if proto.expirationTime else None
         self.file_memo = proto.memo

--- a/src/hiero_sdk_python/file/file_info.py
+++ b/src/hiero_sdk_python/file/file_info.py
@@ -4,7 +4,7 @@ import datetime
 from dataclasses import dataclass, field
 
 from hiero_sdk_python.crypto.key_list import KeyList
-from hiero_sdk_python.crypto.public_key import PublicKey
+from hiero_sdk_python.crypto.public_key import Key
 from hiero_sdk_python.file.file_id import FileId
 from hiero_sdk_python.hapi.services.file_get_info_pb2 import FileGetInfoResponse
 from hiero_sdk_python.timestamp import Timestamp
@@ -20,7 +20,7 @@ class FileInfo:
         size (int, optional): The size of the file in bytes
         expiration_time (Timestamp, optional): When the file will expire
         is_deleted (bool, optional): Whether the file has been deleted
-        keys (list[PublicKey]): The keys that can modify this file
+        keys (list[Key]): The keys that can modify this file
         file_memo (str, optional): The memo associated with the file
         ledger_id (bytes, optional): The ID of the ledger this file exists in
     """
@@ -29,7 +29,7 @@ class FileInfo:
     size: int | None = None
     expiration_time: Timestamp | None = None
     is_deleted: bool | None = None
-    keys: list[PublicKey] = field(default_factory=list)
+    keys: list[Key] = field(default_factory=list)
     file_memo: str | None = None
     ledger_id: bytes | None = None
 

--- a/src/hiero_sdk_python/file/file_info.py
+++ b/src/hiero_sdk_python/file/file_info.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import datetime
 from dataclasses import dataclass, field
 
+from hiero_sdk_python.crypto.key_list import KeyList
 from hiero_sdk_python.crypto.public_key import PublicKey
 from hiero_sdk_python.file.file_id import FileId
-from hiero_sdk_python.hapi.services.basic_types_pb2 import KeyList as KeyListProto
 from hiero_sdk_python.hapi.services.file_get_info_pb2 import FileGetInfoResponse
 from hiero_sdk_python.timestamp import Timestamp
 
@@ -52,7 +52,7 @@ class FileInfo:
             size=proto.size,
             expiration_time=Timestamp._from_protobuf(proto.expirationTime),
             is_deleted=proto.deleted,
-            keys=[PublicKey._from_proto(key) for key in proto.keys.keys],
+            keys=KeyList.from_proto(proto.keys).keys,
             file_memo=proto.memo,
             ledger_id=proto.ledger_id,
         )
@@ -64,12 +64,13 @@ class FileInfo:
         Returns:
             FileGetInfoResponse.FileInfo: The protobuf representation of this FileInfo.
         """
+
         return FileGetInfoResponse.FileInfo(
             fileID=self.file_id._to_proto() if self.file_id else None,
             size=self.size,
             expirationTime=self.expiration_time._to_protobuf() if self.expiration_time else None,
             deleted=self.is_deleted,
-            keys=KeyListProto(keys=[key._to_proto() for key in self.keys or []]),
+            keys=KeyList().set_keys(self.keys).to_proto(),
             memo=self.file_memo,
             ledger_id=self.ledger_id,
         )

--- a/tests/integration/file_create_transaction_e2e_test.py
+++ b/tests/integration/file_create_transaction_e2e_test.py
@@ -4,7 +4,11 @@ import time
 
 from pytest import mark
 
+from hiero_sdk_python.crypto.key_list import KeyList
+from hiero_sdk_python.crypto.private_key import PrivateKey
 from hiero_sdk_python.file.file_create_transaction import FileCreateTransaction
+from hiero_sdk_python.file.file_delete_transaction import FileDeleteTransaction
+from hiero_sdk_python.file.file_info_query import FileInfoQuery
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.timestamp import Timestamp
 
@@ -51,3 +55,62 @@ def test_integration_file_create_transaction_too_large_expiration_fails(env):
     assert receipt.status == ResponseCode.AUTORENEW_DURATION_NOT_IN_RANGE, (
         f"FileCreateTransaction should have failed with AUTORENEW_DURATION_NOT_IN_RANGE but got: {ResponseCode(receipt.status).name}"
     )
+
+
+@mark.integration
+def test_integration_file_create_transaction_with_supported_key_types(env):
+    """Test FileCreateTransaction with all supported key types."""
+    file_private_key = PrivateKey.generate()
+
+    file_public_key_private = PrivateKey.generate()
+    file_public_key = file_public_key_private.public_key()
+
+    key_list_private_key = PrivateKey.generate()
+    key_list = KeyList([key_list_private_key])
+
+    threshold_private_key_1 = PrivateKey.generate()
+    threshold_private_key_2 = PrivateKey.generate()
+    threshold_key = KeyList(
+        [threshold_private_key_1, threshold_private_key_2],
+        threshold=1,
+    )
+
+    receipt = (
+        FileCreateTransaction()
+        .set_keys(
+            [
+                file_private_key,
+                file_public_key,
+                key_list,
+                threshold_key,
+            ]
+        )
+        .set_contents("Hello, Hedera!")
+        .freeze_with(env.client)
+        .sign(file_private_key)
+        .sign(file_public_key_private)
+        .sign(key_list_private_key)
+        .sign(threshold_private_key_1)
+        .sign(threshold_private_key_2)
+        .execute(env.client)
+    )
+
+    assert receipt.status == ResponseCode.SUCCESS
+    assert receipt.file_id is not None
+
+    info = FileInfoQuery(receipt.file_id).execute(env.client)
+    assert len(info.keys) == 4
+
+    # Verify the stored keys authorize file deletion.
+    receipt = (
+        FileDeleteTransaction()
+        .set_file_id(receipt.file_id)
+        .freeze_with(env.client)
+        .sign(file_private_key)
+        .sign(file_public_key_private)
+        .sign(key_list_private_key)
+        .sign(threshold_private_key_1)  # sign with one since threshold is set to one
+        .execute(env.client)
+    )
+
+    assert receipt.status == ResponseCode.SUCCESS

--- a/tests/unit/file_create_transaction_test.py
+++ b/tests/unit/file_create_transaction_test.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
+from hiero_sdk_python.crypto.key_list import KeyList
 from hiero_sdk_python.crypto.private_key import PrivateKey
 from hiero_sdk_python.crypto.public_key import PublicKey
 from hiero_sdk_python.file.file_create_transaction import FileCreateTransaction
@@ -149,26 +150,43 @@ def test_set_methods():
 def test_set_keys_variations():
     """Test setting keys with different input types."""
     file_tx = FileCreateTransaction()
-    private_key1 = PrivateKey.generate()
-    private_key2 = PrivateKey.generate()
-    public_key1 = private_key1.public_key()
-    public_key2 = private_key2.public_key()
 
-    # Test with single PublicKey
-    file_tx.set_keys(public_key1)
+    private_key = PrivateKey.generate()
+    public_key = PrivateKey.generate().public_key()
+
+    key_list = KeyList([PrivateKey.generate()])
+    threshold_key = KeyList([PrivateKey.generate()], 1)
+
+    # Single PublicKey
+    file_tx.set_keys(public_key)
     assert isinstance(file_tx.keys, list)
     assert len(file_tx.keys) == 1
-    assert file_tx.keys[0] == public_key1
+    assert file_tx.keys == [public_key]
 
-    # Test with list of PublicKeys
-    file_tx.set_keys([public_key1, public_key2])
+    # Single PrivateKey
+    file_tx.set_keys(private_key)
     assert isinstance(file_tx.keys, list)
-    assert len(file_tx.keys) == 2
+    assert len(file_tx.keys) == 1
+    assert file_tx.keys == [private_key]
 
-    # Test with KeyList
-    key_list = [public_key1]
+    # Single KeyList
     file_tx.set_keys(key_list)
-    assert file_tx.keys is key_list
+    assert isinstance(file_tx.keys, list)
+    assert len(file_tx.keys) == 1
+    assert file_tx.keys == [key_list]
+
+    # Single ThresholdKey
+    file_tx.set_keys(threshold_key)
+    assert isinstance(file_tx.keys, list)
+    assert len(file_tx.keys) == 1
+    assert file_tx.keys == [threshold_key]
+
+    # Sequence of keys
+    keys = [private_key, public_key, key_list, threshold_key]
+    file_tx.set_keys(keys)
+    assert isinstance(file_tx.keys, list)
+    assert len(file_tx.keys) == 4
+    assert file_tx.keys == keys
 
 
 def test_set_methods_require_not_frozen(mock_client):
@@ -235,11 +253,11 @@ def test_file_create_transaction_from_proto():
     """Test that a file create transaction can be created from a protobuf object."""
     private_key = PrivateKey.generate()
     public_key = private_key.public_key()
-    key_list = [public_key]
+    key_list = [private_key]
 
     # Create protobuf object with file create details
     proto = file_create_pb2.FileCreateTransactionBody(
-        keys=basic_types_pb2.KeyList(keys=[key._to_proto() for key in key_list]),
+        keys=basic_types_pb2.KeyList(keys=[key.to_proto_key() for key in key_list]),
         contents=b"Proto test content",
         memo="Proto test memo",
     )
@@ -252,11 +270,50 @@ def test_file_create_transaction_from_proto():
     assert from_proto.file_memo == "Proto test memo"
     assert len(from_proto.keys) == 1
     assert isinstance(from_proto.keys[0], PublicKey)
+    assert from_proto.keys[0].to_bytes_raw() == public_key.to_bytes_raw()
 
     # Deserialize empty protobuf
     from_proto = FileCreateTransaction()._from_proto(file_create_pb2.FileCreateTransactionBody())
 
     # Verify empty protobuf deserializes to empty/default values
+    assert from_proto.contents == b""
+    assert from_proto.file_memo == ""
+    assert from_proto.keys == []
+
+
+def test_file_create_transaction_from_proto_keys():
+    """Test deserializing a file create transaction from protobuf with all supported key types."""
+
+    private_key = PrivateKey.generate()
+    public_key = PrivateKey.generate().public_key()
+    key_list = KeyList([PrivateKey.generate()])
+    threshold_key = KeyList([PrivateKey.generate(), PrivateKey.generate()], 1)
+
+    keys = [private_key, public_key, key_list, threshold_key]
+
+    proto = file_create_pb2.FileCreateTransactionBody(
+        keys=basic_types_pb2.KeyList(keys=[key.to_proto_key() for key in keys]),
+        contents=b"Proto test content",
+        memo="Proto test memo",
+    )
+
+    from_proto = FileCreateTransaction()._from_proto(proto)
+
+    assert from_proto.contents == b"Proto test content"
+    assert from_proto.file_memo == "Proto test memo"
+
+    assert len(from_proto.keys) == 4
+    assert isinstance(from_proto.keys[0], PublicKey)  # protobuf conversion convert the private to public key
+    assert isinstance(from_proto.keys[1], PublicKey)
+    assert isinstance(from_proto.keys[2], KeyList)
+    assert isinstance(from_proto.keys[3], KeyList)
+
+    # Threshold should be preserved
+    assert from_proto.keys[3].threshold == 1
+
+    # Empty protobuf
+    from_proto = FileCreateTransaction()._from_proto(file_create_pb2.FileCreateTransactionBody())
+
     assert from_proto.contents == b""
     assert from_proto.file_memo == ""
     assert from_proto.keys == []


### PR DESCRIPTION
**Description**:
This PR refactors `FileCreateTransaction` to accept `Key` instead of `PublicKey`, allowing any `Key` subtype (e.g. PublicKey, KeyList, ThresholdKey) to be used.

**Related issue(s)**:

Fixes #2497

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
