### PR TITLE
fix: migrate set_amount_in_tinybars to set_hbar_amount

### DIFF
--- a/examples/consensus/topic_create_transaction_revenue_generating.py
+++ b/examples/consensus/topic_create_transaction_revenue_generating.py
@@ -257,7 +257,7 @@ def setup_token_and_update_topic(client, topic_id, alice_id, alice_key, operator
     print("Updating the topic to have a custom fee of the token")
     custom_token_fee = (
         CustomFixedFee()
-        .set_amount_in_tinybars(1)
+        .set_hbar_amount(Hbar.from_tinybars(1))
         .set_denominating_token_id(token_id)
         .set_fee_collector_account_id(operator_id)
     )

--- a/tck/handlers/topic.py
+++ b/tck/handlers/topic.py
@@ -127,7 +127,7 @@ def _build_custom_fee_limit(params: CustomFeeLimitParams) -> CustomFeeLimit:
         for fee in params.fixedFees:
             fixed_fee = CustomFixedFee()
             if fee.amount is not None:
-                fixed_fee.set_amount_in_tinybars(int(fee.amount))
+                fixed_fee.set_hbar_amount(Hbar.from_tinybars(int(fee.amount)))
 
             if fee.denominatingTokenId is not None:
                 fixed_fee.set_denominating_token_id(TokenId.from_string(fee.denominatingTokenId))

--- a/tests/integration/revenue_generating_topics_e2e_test.py
+++ b/tests/integration/revenue_generating_topics_e2e_test.py
@@ -34,7 +34,7 @@ def _create_custom_fee(env, token_id, amount):
     """Create a custom fee for a token."""
     return (
         CustomFixedFee()
-        .set_amount_in_tinybars(amount)
+        .set_hbar_amount(Hbar.from_tinybars(amount))
         .set_denominating_token_id(token_id)
         .set_fee_collector_account_id(env.operator_id)
     )
@@ -412,7 +412,7 @@ def test_integration_revenue_generating_topic_can_charge_tokens_with_limit(env):
     custom_fee_limit = (
         CustomFeeLimit()
         .set_payer_id(payer_account.id)
-        .add_custom_fee(CustomFixedFee().set_amount_in_tinybars(2).set_denominating_token_id(token_id))
+        .add_custom_fee(CustomFixedFee().set_hbar_amount(Hbar.from_tinybars(2)).set_denominating_token_id(token_id))
     )
 
     # Set operator to payer
@@ -698,7 +698,7 @@ def test_integration_revenue_generating_topic_cannot_charge_tokens_with_lower_li
     custom_fee_limit = (
         CustomFeeLimit()
         .set_payer_id(payer_account.id)
-        .add_custom_fee(CustomFixedFee().set_amount_in_tinybars(1).set_denominating_token_id(token_id))
+        .add_custom_fee(CustomFixedFee().set_hbar_amount(Hbar.from_tinybars(1)).set_denominating_token_id(token_id))
     )
 
     # Submit a message to the revenue generating topic with custom fee limit
@@ -816,7 +816,9 @@ def test_integration_revenue_generating_topic_cannot_execute_with_invalid_token_
     custom_fee_limit = (
         CustomFeeLimit()
         .set_payer_id(payer_account.id)
-        .add_custom_fee(CustomFixedFee().set_amount_in_tinybars(2).set_denominating_token_id(invalid_token_id))
+        .add_custom_fee(
+            CustomFixedFee().set_hbar_amount(Hbar.from_tinybars(2)).set_denominating_token_id(invalid_token_id)
+        )
     )
 
     # Set operator to payer
@@ -871,8 +873,8 @@ def test_integration_revenue_generating_topic_cannot_execute_with_duplicate_deno
     custom_fee_limit = (
         CustomFeeLimit()
         .set_payer_id(payer_account.id)
-        .add_custom_fee(CustomFixedFee().set_amount_in_tinybars(1).set_denominating_token_id(token_id))
-        .add_custom_fee(CustomFixedFee().set_amount_in_tinybars(2).set_denominating_token_id(token_id))
+        .add_custom_fee(CustomFixedFee().set_hbar_amount(Hbar.from_tinybars(1)).set_denominating_token_id(token_id))
+        .add_custom_fee(CustomFixedFee().set_hbar_amount(Hbar.from_tinybars(2)).set_denominating_token_id(token_id))
     )
 
     # Set operator to payer

--- a/tests/integration/topic_update_transaction_e2e_test.py
+++ b/tests/integration/topic_update_transaction_e2e_test.py
@@ -7,6 +7,7 @@ from hiero_sdk_python.consensus.topic_delete_transaction import TopicDeleteTrans
 from hiero_sdk_python.consensus.topic_update_transaction import TopicUpdateTransaction
 from hiero_sdk_python.crypto.private_key import PrivateKey
 from hiero_sdk_python.crypto.public_key import PublicKey
+from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.query.topic_info_query import TopicInfoQuery
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.custom_fixed_fee import CustomFixedFee
@@ -67,7 +68,9 @@ def test_integration_topic_update_transaction_clear_custom_fees():
 
     try:
         custom_fee = (
-            CustomFixedFee().set_amount_in_tinybars(1).set_fee_collector_account_id(env.client.operator_account_id)
+            CustomFixedFee()
+            .set_hbar_amount(Hbar.from_tinybars(1))
+            .set_fee_collector_account_id(env.client.operator_account_id)
         )
 
         create_transaction = (


### PR DESCRIPTION
Replace deprecated CustomFixedFee.set_amount_in_tinybars() calls with set_hbar_amount(Hbar.from_tinybars(amount)) in the TCK handler and the revenue-generating topics example. Both methods are behaviorally identical (set amount, clear denominating_token_id). Test call sites that intentionally exercise the deprecated path are left unchanged.

## Problem
`CustomFixedFee.set_amount_in_tinybars()` is deprecated and emits a `DeprecationWarning`.
Two non-test call sites still used it, causing the TCK server to emit warnings during
test runs and teaching users the deprecated API via the example.

## Solution
Replaced `set_amount_in_tinybars(amount)` with `set_hbar_amount(Hbar.from_tinybars(amount))`
at the two non-test call sites:

- `tck/handlers/topic.py`
- `examples/consensus/topic_create_transaction_revenue_generating.py`

Both methods are behaviorally identical (set `amount`, clear `denominating_token_id`).
`Hbar` was already imported in both files, so no import changes were needed.

Test call sites that intentionally exercise the deprecated path (including the dedicated
deprecation-warning unit test) were left unchanged, as scoped in the issue.

## Verification
- `git grep -n "set_amount_in_tinybars" -- examples/ tck/ src/` → only the definition in
  `src/hiero_sdk_python/tokens/custom_fixed_fee.py` remains.
- `uv run ruff check .` → clean
- `uv run ruff format --check .` → clean
- `uv run pytest tests/unit tests/tck -q` → all passing

Fixes #2495