### PR TITLE
Replace deprecated set_key() in account creation examples

### DIFF
--- a/examples/transaction/transfer_transaction_gigabar.py
+++ b/examples/transaction/transfer_transaction_gigabar.py
@@ -50,7 +50,11 @@ def create_account(client, operator_key):
     print("\nSTEP 1: Creating a new recipient account...")
     recipient_key = PrivateKey.generate()
     try:
-        tx = AccountCreateTransaction().set_key(recipient_key.public_key()).set_initial_balance(Hbar.from_tinybars(0))
+        tx = (
+            AccountCreateTransaction()
+            .set_key_without_alias(recipient_key.public_key())
+            .set_initial_balance(Hbar.from_tinybars(0))
+        )
 
         receipt = tx.freeze_with(client).sign(operator_key).execute(client)
 

--- a/examples/transaction/transfer_transaction_tinybar.py
+++ b/examples/transaction/transfer_transaction_tinybar.py
@@ -50,7 +50,7 @@ def create_account(client, operator_key):
     try:
         tx = (
             AccountCreateTransaction()
-            .set_key(recipient_key.public_key())
+            .set_key_without_alias(recipient_key.public_key())
             .set_initial_balance(Hbar.from_tinybars(100_000_000))
         )
         receipt = tx.freeze_with(client).sign(operator_key).execute(client)


### PR DESCRIPTION
**Description**:

Update the `AccountCreateTransaction` examples to use the non-deprecated `set_key_without_alias()` method instead of `set_key()`, preventing `DeprecationWarning`s when users follow the examples.

- Replace `set_key()` with `set_key_without_alias()` in `examples/transaction/transfer_transaction_gigabar.py`
- Replace `set_key()` with `set_key_without_alias()` in `examples/transaction/transfer_transaction_tinybar.py`
- Leave `AccountUpdateTransaction.set_key()` call sites unchanged

**Related issue(s)**:

Fixes #2494

**Notes for reviewer**:

Verified the change by:
- Running the deprecation verification command from the issue (`no deprecation warning`).
- Confirming only the expected `AccountUpdateTransaction.set_key()` call sites remain with `git grep`.
- Running `uv run pytest tests/unit -q` successfully (`2866 passed`).

**Checklist**

- [x] Documented (examples updated)
- [x] Tested (verified no `DeprecationWarning` and `uv run pytest tests/unit -q` passes)