### PR TITLE
chore: update solo version to 0.79.1

### DIFF
--- a/.github/workflows/pr-check-secondary-examples.yml
+++ b/.github/workflows/pr-check-secondary-examples.yml
@@ -75,7 +75,7 @@ jobs:
         uses: hiero-ledger/hiero-solo-action@531a2b283ca4912df537d64bf89da0f6be4c2574 # v0.22.0
         with:
           installMirrorNode: true
-          soloVersion: v0.74.0
+          soloVersion: v0.79.1
           mirrorNodeVersion: v0.153.0
           hieroVersion: v0.73.0
 

--- a/.github/workflows/pr-check-secondary-unit-integration-test.yml
+++ b/.github/workflows/pr-check-secondary-unit-integration-test.yml
@@ -132,7 +132,7 @@ jobs:
         uses: hiero-ledger/hiero-solo-action@531a2b283ca4912df537d64bf89da0f6be4c2574 # v0.22.0
         with:
           installMirrorNode: true
-          soloVersion: v0.74.0
+          soloVersion: v0.79.1
           mirrorNodeVersion: v0.153.0
           hieroVersion: v0.73.0
 


### PR DESCRIPTION
## Summary
- Bumps the pinned Solo CLI version used in CI (`hiero-solo-action` `soloVersion` input) from `v0.74.0` to `v0.79.1` in `pr-check-secondary-examples.yml` and `pr-check-secondary-unit-integration-test.yml`.