### PR TITLE
chore: Fix failing tck methods

### DIFF
--- a/src/hiero_sdk_python/tokens/abstract_token_transfer_transaction.py
+++ b/src/hiero_sdk_python/tokens/abstract_token_transfer_transaction.py
@@ -144,9 +144,11 @@ class AbstractTokenTransferTransaction(Transaction, ABC, Generic[T]):
             raise TypeError("token_id must be a TokenId instance.")
         if not isinstance(account_id, AccountId):
             raise TypeError("account_id must be an AccountId instance.")
-        if not isinstance(amount, int) or amount == 0:
-            raise ValueError("Amount must be a non-zero integer.")
-        if expected_decimals is not None and not isinstance(expected_decimals, int):
+        if isinstance(amount, bool) or not isinstance(amount, int):
+            raise ValueError("Amount must be an integer.")
+        if expected_decimals is not None and (
+            isinstance(expected_decimals, bool) or not isinstance(expected_decimals, int)
+        ):
             raise TypeError("expected_decimals must be an integer.")
         if not isinstance(is_approved, bool):
             raise TypeError("is_approved must be a boolean.")

--- a/src/hiero_sdk_python/tokens/abstract_token_transfer_transaction.py
+++ b/src/hiero_sdk_python/tokens/abstract_token_transfer_transaction.py
@@ -130,7 +130,7 @@ class AbstractTokenTransferTransaction(Transaction, ABC, Generic[T]):
             account_id (AccountId): The account ID of the sender (negative amount)
                 or receiver (positive amount).
             amount (int): The amount of the token to transfer (in smallest denomination).
-                Must be a non-zero integer.
+                Must be an integer.
             expected_decimals (int, optional): The number of decimals
                 expected for the token. Defaults to None.
             is_approved (bool, optional): Whether the transfer is approved.

--- a/tck/handlers/registry.py
+++ b/tck/handlers/registry.py
@@ -119,11 +119,14 @@ def parse_result(result: Any) -> dict:
             for f in dc_fields(obj):
                 if f.metadata.get("nullable"):
                     nullable_fields.add(f.name)
+                collect_nullable(getattr(obj, f.name))
+        elif isinstance(obj, list):
+            for item in obj:
+                collect_nullable(item)
+        elif isinstance(obj, dict):
+            for val in obj.values():
+                collect_nullable(val)
 
     collect_nullable(result)
-    for f in dc_fields(result):
-        val = getattr(result, f.name)
-        collect_nullable(val)
-
     raw = asdict(result)
     return _strip_none(raw, nullable_keys=nullable_fields)

--- a/tck/handlers/registry.py
+++ b/tck/handlers/registry.py
@@ -126,5 +126,4 @@ def parse_result(result: Any) -> dict:
         collect_nullable(val)
 
     raw = asdict(result)
-    print(raw)
     return _strip_none(raw, nullable_keys=nullable_fields)

--- a/tck/handlers/registry.py
+++ b/tck/handlers/registry.py
@@ -97,12 +97,12 @@ def _strip_none(obj: Any, nullable_keys: set[str] | None = None) -> Any:
     """Recursively strip None values from nested dicts and lists."""
     if isinstance(obj, dict):
         return {
-            k: _strip_none(v)
+            k: _strip_none(v, nullable_keys=nullable_keys)
             for k, v in obj.items()
             if v is not None or (nullable_keys is not None and k in nullable_keys)
         }
     if isinstance(obj, list):
-        return [_strip_none(item) for item in obj]
+        return [_strip_none(item, nullable_keys=nullable_keys) for item in obj]
     return obj
 
 
@@ -113,9 +113,18 @@ def parse_result(result: Any) -> dict:
     Recursively strips None from nested structures.
     """
     nullable_fields: set[str] = set()
+
+    def collect_nullable(obj: Any) -> None:
+        if hasattr(obj, "__dataclass_fields__"):
+            for f in dc_fields(obj):
+                if f.metadata.get("nullable"):
+                    nullable_fields.add(f.name)
+
+    collect_nullable(result)
     for f in dc_fields(result):
-        if f.metadata.get("nullable"):
-            nullable_fields.add(f.name)
+        val = getattr(result, f.name)
+        collect_nullable(val)
 
     raw = asdict(result)
+    print(raw)
     return _strip_none(raw, nullable_keys=nullable_fields)

--- a/tck/response/account.py
+++ b/tck/response/account.py
@@ -32,11 +32,11 @@ class StakingInfoResponse:
     """Nested staking fields in the getAccountInfo response."""
 
     declineStakingReward: bool | None = None
-    stakePeriodStart: str | None = None
+    stakePeriodStart: str | None = field(metadata={"nullable": True}, default=None)
     pendingReward: str | None = None
     stakedToMe: str | None = None
-    stakedAccountId: str | None = None
-    stakedNodeId: str | None = None
+    stakedAccountId: str | None = field(metadata={"nullable": True}, default=None)
+    stakedNodeId: str | None = field(metadata={"nullable": True}, default=None)
 
 
 @dataclass

--- a/tests/tck/handlers_test.py
+++ b/tests/tck/handlers_test.py
@@ -66,12 +66,20 @@ class NestedChild:
 
 
 @dataclass
+class NestedChildWithNullable:
+    """Nested dataclass for testing recursive Nullable."""
+
+    nullable_field: str | None = field(metadata={"nullable": True}, default=None)
+    label: str | None = None
+
+
+@dataclass
 class DummyResultWithNested:
     """Dataclass with nested fields for testing recursive parse_result."""
 
     name: str | None = None
-    child: NestedChild | None = None
-    children: list[NestedChild] | None = None
+    child: NestedChild | NestedChildWithNullable | None = None
+    children: list[NestedChild | NestedChildWithNullable] | None = None
     nullable_field: str | None = field(metadata={"nullable": True}, default=None)
 
 
@@ -326,3 +334,33 @@ class TestParseResult:
         parsed = parse_result(result)
 
         assert parsed == {"name": "test", "nullable_field": None}
+
+    def test_nested_dataclass_preserve_nullable_true(self):
+        """Verify nested dataclass preserves nullable None while dropping regular None."""
+        data = DummyResultWithNested(
+            name="test", child=NestedChildWithNullable(nullable_field=None, label=None), nullable_field=None
+        )
+        result = parse_result(data)
+
+        assert result == {
+            "name": "test",
+            "child": {
+                "nullable_field": None,
+            },
+            "nullable_field": None,
+        }
+
+    def test_deep_nested_dataclass_preserve_nullable_true(self):
+        """Verify nested dataclass preserves nullable None while dropping regular None."""
+        data = DummyResultWithNested(
+            name="test",
+            child=DummyResultWithNested(name="test", child=NestedChildWithNullable(nullable_field=None, label="test")),
+            nullable_field=None,
+        )
+        result = parse_result(data)
+
+        assert result == {
+            "name": "test",
+            "child": {"name": "test", "child": {"nullable_field": None, "label": "test"}, "nullable_field": None},
+            "nullable_field": None,
+        }

--- a/tests/unit/token_airdrop_transaction_test.py
+++ b/tests/unit/token_airdrop_transaction_test.py
@@ -144,21 +144,22 @@ def test_build_transaction_body_with_expected_decimal(mock_account_ids):
     assert token_transfer_2.transfers[1].is_approval == True
 
 
-def test_add_zero_transfer_amount(mock_account_ids):
+@pytest.mark.parametrize("amount", [True, "0", "string", {}, [], None, 3.14])
+def test_add_non_int_transfer_amount(amount, mock_account_ids):
     account_id, _, _, token_id, _ = mock_account_ids
     airdrop_tx = TokenAirdropTransaction()
 
-    with pytest.raises(ValueError):
-        airdrop_tx.add_token_transfer(token_id, account_id, 0)
+    with pytest.raises(ValueError, match="Amount must be an integer"):
+        airdrop_tx.add_token_transfer(token_id, account_id, amount)
 
-    with pytest.raises(ValueError):
-        airdrop_tx.add_token_transfer_with_decimals(token_id, account_id, 0, 1)
+    with pytest.raises(ValueError, match="Amount must be an integer"):
+        airdrop_tx.add_token_transfer_with_decimals(token_id, account_id, amount, 1)
 
-    with pytest.raises(ValueError):
-        airdrop_tx.add_approved_token_transfer(token_id, account_id, 0)
+    with pytest.raises(ValueError, match="Amount must be an integer"):
+        airdrop_tx.add_approved_token_transfer(token_id, account_id, amount)
 
-    with pytest.raises(ValueError):
-        airdrop_tx.add_approved_token_transfer_with_decimals(token_id, account_id, 0, 1)
+    with pytest.raises(ValueError, match="Amount must be an integer"):
+        airdrop_tx.add_approved_token_transfer_with_decimals(token_id, account_id, amount, 1)
 
 
 def test_add_unbalanced_transfer_amount(mock_account_ids):

--- a/tests/unit/transfer_transaction_test.py
+++ b/tests/unit/transfer_transaction_test.py
@@ -280,9 +280,11 @@ def test_zero_amount_handling(mock_account_ids):
     assert transfer_tx.hbar_transfers[0].account_id == account_id_1
     assert transfer_tx.hbar_transfers[0].amount == 0
 
-    # Token transfers still reject zero amounts (if unchanged)
-    with pytest.raises(ValueError, match="Amount must be a non-zero integer"):
-        transfer_tx.add_token_transfer(token_id_1, account_id_1, 0)
+    # Token transfers set zero amounts (cause PrecheckError when execute)
+    transfer_tx.add_token_transfer(token_id_1, account_id_1, 0)
+    assert len(transfer_tx.token_transfers[token_id_1]) == 1
+    assert transfer_tx.token_transfers[token_id_1][0].account_id == account_id_1
+    assert transfer_tx.token_transfers[token_id_1][0].amount == 0
 
 
 def test_multiple_nft_transfers(mock_account_ids):
@@ -485,18 +487,28 @@ def test_approved_token_transfer_accumulation(mock_account_ids):
     assert transfer_2.expected_decimals is None  # unchanged
 
 
-def test_approved_token_transfer_validation(mock_account_ids):
-    """Test validation for approved token transfers with decimals."""
+@pytest.mark.parametrize(
+    "decimals",
+    [True, "0", "string", {}, [], 3.4],  # exepected_decimal can be none if not set
+)
+def test_approved_token_transfer_invalid_expected_decimal_type(mock_account_ids, decimals):
+    """Test approved token transfers with invalid decimal types decimals."""
     account_id_1, _, _, token_id_1, _ = mock_account_ids
     transfer_tx = TransferTransaction()
 
     # Test invalid expected_decimals type
     with pytest.raises(TypeError, match="expected_decimals must be an integer"):
-        transfer_tx.add_approved_token_transfer_with_decimals(token_id_1, account_id_1, 1000, "invalid")
+        transfer_tx.add_approved_token_transfer_with_decimals(token_id_1, account_id_1, 1000, decimals)
 
-    # Test zero amount
-    with pytest.raises(ValueError, match="Amount must be a non-zero integer"):
-        transfer_tx.add_approved_token_transfer_with_decimals(token_id_1, account_id_1, 0, 6)
+
+@pytest.mark.parametrize("amount", [True, "0", "string", {}, [], None, 3.4])
+def test_approved_token_transfer_invalid_amount_type(mock_account_ids, amount):
+    """Test approved token transfers with invalid type for amount."""
+    account_id_1, _, _, token_id_1, _ = mock_account_ids
+    transfer_tx = TransferTransaction()
+    # Test amount non int
+    with pytest.raises(ValueError, match="Amount must be an integer"):
+        transfer_tx.add_approved_token_transfer_with_decimals(token_id_1, account_id_1, amount, 6)
 
 
 def test_add_hbar_transfer_with_hbar_object(mock_account_ids):


### PR DESCRIPTION
**Description**:
This PR fix the failing tck methods

**Changes Made:**
- Updated the `_add_token_transfer()` to accept the amount as `0`. 
- Updated the tck/handler/registery.py  `parse_result()` to recursively check for `nullable` fields.

**Related issue(s)**:

Fixes #2512

**Notes for reviewer**:
- `0` amount transfer is valid for token tested using js/java sdk 
- Verified changes running tck against solo
<img width="1159" height="299" alt="Screenshot From 2026-08-06 00-32-12" src="https://github.com/user-attachments/assets/eb4ada21-9382-4fc4-b43d-6c914c414a18" />


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
