### PR TITLE
feat: Added opt-in receipt/record query failover to other nodes

### DIFF
--- a/src/hiero_sdk_python/client/client.py
+++ b/src/hiero_sdk_python/client/client.py
@@ -66,6 +66,8 @@ class Client:
         self._grpc_deadline: float = DEFAULT_GRPC_DEADLINE
         self._request_timeout: float = DEFAULT_REQUEST_TIMEOUT
 
+        self._allow_receipt_node_failover: bool = False
+
         self.logger: Logger = Logger(LogLevel.from_env(), "hiero_sdk_python")
 
     @property
@@ -422,6 +424,33 @@ class Client:
     def update_network(self) -> Client:
         """Refresh the network node list from the mirror node."""
         self.network._set_network_nodes()
+        return self
+
+    @property
+    def allow_receipt_node_failover(self) -> bool:
+        """
+        Return whether receipt and record queries can fail over to other nodes.
+        """
+        return self._allow_receipt_node_failover
+
+    def set_allow_receipt_node_failover(self, allow: bool) -> Client:
+        """
+        Enable or disable receipt and record query node failover.
+
+        Args:
+            allow (bool): Whether to allow receipt/record queries to fail over to
+                other nodes when the submitting node is unavailable.
+
+        Returns:
+            Client: This client instance for fluent chaining.
+
+        Raises:
+            TypeError: If allow is not a bool.
+        """
+        if not isinstance(allow, bool):
+            raise TypeError("allow must be an instance of bool")
+
+        self._allow_receipt_node_failover = allow
         return self
 
     def __enter__(self) -> Client:

--- a/src/hiero_sdk_python/executable.py
+++ b/src/hiero_sdk_python/executable.py
@@ -382,7 +382,7 @@ class _Executable(ABC):
     def _handle_unhealthy_node(self, proto_request, attempt, logger, err) -> bool:
         """Handle node switching and backoff for unhealthy node."""
         # Check if the request is a transaction receipt or record because they are single node requests
-        if _is_transaction_receipt_or_record_request(proto_request):
+        if _is_transaction_receipt_or_record_request(proto_request) and len(self._node_account_ids) <= 1:
             _delay_for_attempt(
                 self._get_request_id(),
                 self._min_backoff,

--- a/src/hiero_sdk_python/transaction/transaction.py
+++ b/src/hiero_sdk_python/transaction/transaction.py
@@ -109,6 +109,7 @@ class Transaction(_Executable):
         transaction_response.transaction_id = self.transaction_id
         transaction_response.node_id = node_id
         transaction_response.hash = tx_hash
+        transaction_response._transaction_node_ids = self._node_account_ids.get_list()
 
         return transaction_response
 
@@ -364,6 +365,12 @@ class Transaction(_Executable):
         if self.batch_key and not isinstance(self, (BatchTransaction)):
             raise ValueError("Cannot execute batchified transaction outside of BatchTransaction.")
 
+        if not isinstance(validate_status, bool):
+            raise TypeError("validate_status must be a boolean")
+
+        if client is not None and not isinstance(client, Client):
+            raise TypeError("client must be an instance of Client")
+
         if not self._transaction_body_bytes:
             self.freeze_with(client)
 
@@ -379,7 +386,6 @@ class Transaction(_Executable):
         response.validate_status = True
         response.transaction = self
         response.transaction_id = self.transaction_id
-        response._transaction_node_ids = self._node_account_ids.get_list()
 
         if wait_for_receipt:
             return response.get_receipt(client, timeout=timeout, validate_status=validate_status)

--- a/src/hiero_sdk_python/transaction/transaction.py
+++ b/src/hiero_sdk_python/transaction/transaction.py
@@ -374,11 +374,12 @@ class Transaction(_Executable):
             self.sign(client.operator_private_key)
 
         # Call the _execute function from executable.py to handle the actual execution
-        response = self._execute(client, timeout)
+        response: TransactionResponse = self._execute(client, timeout)
 
         response.validate_status = True
         response.transaction = self
         response.transaction_id = self.transaction_id
+        response._transaction_node_ids = self._node_account_ids.get_list()
 
         if wait_for_receipt:
             return response.get_receipt(client, timeout=timeout, validate_status=validate_status)

--- a/src/hiero_sdk_python/transaction/transaction.py
+++ b/src/hiero_sdk_python/transaction/transaction.py
@@ -365,10 +365,16 @@ class Transaction(_Executable):
         if self.batch_key and not isinstance(self, (BatchTransaction)):
             raise ValueError("Cannot execute batchified transaction outside of BatchTransaction.")
 
+        if timeout is not None and (isinstance(timeout, bool) or not isinstance(timeout, (int, float))):
+            raise TypeError("timeout must be a int or float")
+
         if not isinstance(validate_status, bool):
             raise TypeError("validate_status must be a boolean")
 
-        if client is not None and not isinstance(client, Client):
+        if not isinstance(wait_for_receipt, bool):
+            raise TypeError("wait_for_receipt must be a boolean")
+
+        if not isinstance(client, Client):
             raise TypeError("client must be an instance of Client")
 
         if not self._transaction_body_bytes:

--- a/src/hiero_sdk_python/transaction/transaction_response.py
+++ b/src/hiero_sdk_python/transaction/transaction_response.py
@@ -33,23 +33,34 @@ class TransactionResponse:
         self.hash: bytes = b""
         self.validate_status: bool = False
         self.transaction: Transaction | None = None
+        self._transaction_node_ids: list[AccountId] | None = None
 
-    def get_receipt_query(self, validate_status: bool = False):
+    def get_receipt_query(self, client: Client | None = None, validate_status: bool = False):
         """
         Create a receipt query for this transaction.
 
         Args:
             validate_status (bool, optional): The query should automatically validate the transaction status. (default False)
+            client (Client, optional): The client to enable failover behavior.
 
         Returns:
             TransactionGetReceiptQuery: A configured receipt query.
         """
         from hiero_sdk_python.query.transaction_get_receipt_query import TransactionGetReceiptQuery
 
+        if client is None or not client.allow_receipt_node_failover:
+            return (
+                TransactionGetReceiptQuery()
+                .set_transaction_id(self.transaction_id)
+                .set_node_account_ids([self.node_id])
+                .set_validate_status(validate_status)
+            )
+
+        node_account_ids = self._resolve_node_account_ids(client)
         return (
             TransactionGetReceiptQuery()
             .set_transaction_id(self.transaction_id)
-            .set_node_account_ids([self.node_id])
+            .set_node_account_ids(node_account_ids)
             .set_validate_status(validate_status)
         )
 
@@ -68,18 +79,25 @@ class TransactionResponse:
             TransactionReceipt: The receipt from the network, containing the status
                                and any entities created by the transaction
         """
-        return self.get_receipt_query(validate_status=validate_status).execute(client, timeout)
+        return self.get_receipt_query(validate_status=validate_status, client=client).execute(client, timeout)
 
-    def get_record_query(self):
+    def get_record_query(self, client: Client | None = None):
         """
         Create a record query for this transaction.
+
+        Args:
+            client (Client, optional): The client to enable failover behavior.
 
         Returns:
             TransactionRecordQuery: A configured record query.
         """
         from hiero_sdk_python.query.transaction_record_query import TransactionRecordQuery
 
-        return TransactionRecordQuery().set_transaction_id(self.transaction_id).set_node_account_ids([self.node_id])
+        if client is None or not client.allow_receipt_node_failover:
+            return TransactionRecordQuery().set_transaction_id(self.transaction_id).set_node_account_ids([self.node_id])
+
+        node_account_ids = self._resolve_node_account_ids(client)
+        return TransactionRecordQuery().set_transaction_id(self.transaction_id).set_node_account_ids(node_account_ids)
 
     def get_record(self, client: Client, timeout: int | float | None = None) -> TransactionRecord:
         """
@@ -92,4 +110,12 @@ class TransactionResponse:
         Returns:
             TransactionRecord: The full transaction record.
         """
-        return self.get_record_query().execute(client, timeout)
+        return self.get_record_query(client).execute(client, timeout)
+
+    def _resolve_node_account_ids(self, client: Client) -> list[AccountId]:
+        """Resolve node account IDs for receipt or record query failover."""
+        available_node_ids = self._transaction_node_ids if self._transaction_node_ids else client.get_node_account_ids()
+
+        node_account_ids = [self.node_id]
+        node_account_ids.extend(node_id for node_id in available_node_ids if node_id != self.node_id)
+        return node_account_ids

--- a/src/hiero_sdk_python/transaction/transaction_response.py
+++ b/src/hiero_sdk_python/transaction/transaction_response.py
@@ -45,16 +45,17 @@ class TransactionResponse:
 
         Returns:
             TransactionGetReceiptQuery: A configured receipt query.
+
+        Raises:
+            TypeError: If `validate_status` is not a bool or `client` is not a Client.
         """
         from hiero_sdk_python.query.transaction_get_receipt_query import TransactionGetReceiptQuery
 
-        if client is None or not client.allow_receipt_node_failover:
-            return (
-                TransactionGetReceiptQuery()
-                .set_transaction_id(self.transaction_id)
-                .set_node_account_ids([self.node_id])
-                .set_validate_status(validate_status)
-            )
+        if not isinstance(validate_status, bool):
+            raise TypeError("validate_status must be a boolean")
+
+        if client is not None and not isinstance(client, Client):
+            raise TypeError("client must be an instance of Client")
 
         node_account_ids = self._resolve_node_account_ids(client)
         return (
@@ -90,11 +91,14 @@ class TransactionResponse:
 
         Returns:
             TransactionRecordQuery: A configured record query.
+
+        Raises:
+            TypeError: If `client` is not a Client.
         """
         from hiero_sdk_python.query.transaction_record_query import TransactionRecordQuery
 
-        if client is None or not client.allow_receipt_node_failover:
-            return TransactionRecordQuery().set_transaction_id(self.transaction_id).set_node_account_ids([self.node_id])
+        if client is not None and not isinstance(client, Client):
+            raise TypeError("client must be an instance of Client")
 
         node_account_ids = self._resolve_node_account_ids(client)
         return TransactionRecordQuery().set_transaction_id(self.transaction_id).set_node_account_ids(node_account_ids)
@@ -114,8 +118,11 @@ class TransactionResponse:
 
     def _resolve_node_account_ids(self, client: Client) -> list[AccountId]:
         """Resolve node account IDs for receipt or record query failover."""
-        available_node_ids = self._transaction_node_ids if self._transaction_node_ids else client.get_node_account_ids()
-
         node_account_ids = [self.node_id]
+
+        if client is None or not client.allow_receipt_node_failover:
+            return node_account_ids
+
+        available_node_ids = self._transaction_node_ids if self._transaction_node_ids else client.get_node_account_ids()
         node_account_ids.extend(node_id for node_id in available_node_ids if node_id != self.node_id)
         return node_account_ids

--- a/src/hiero_sdk_python/transaction/transaction_response.py
+++ b/src/hiero_sdk_python/transaction/transaction_response.py
@@ -35,7 +35,7 @@ class TransactionResponse:
         self.transaction: Transaction | None = None
         self._transaction_node_ids: list[AccountId] | None = None
 
-    def get_receipt_query(self, client: Client | None = None, validate_status: bool = False):
+    def get_receipt_query(self, validate_status: bool = False, client: Client | None = None):
         """
         Create a receipt query for this transaction.
 

--- a/tests/integration/transaction_e2e_test.py
+++ b/tests/integration/transaction_e2e_test.py
@@ -258,3 +258,41 @@ def test_get_receipt_raises_exception_on_failure_with_validation(env):
         response.get_receipt(env.client, validate_status=True)
 
     assert e.value.status == ResponseCode.INVALID_ACCOUNT_ID
+
+
+@pytest.mark.integration
+def test_get_receipt_with_allow_failover(env):
+    """Test that a transaction receipt can be retrieved with node failover enabled."""
+    env.client.set_allow_receipt_node_failover(True)
+
+    tx = AccountCreateTransaction().set_key_without_alias(PrivateKey.generate_ecdsa())
+    response = tx.execute(env.client, wait_for_receipt=False)
+
+    assert response is not None
+
+    receipt = response.get_receipt(env.client)
+    assert receipt is not None
+    assert receipt.account_id is not None
+
+    AccountDeleteTransaction().set_transfer_account_id(env.operator_id).set_account_id(receipt.account_id).execute(
+        env.client
+    )
+
+
+@pytest.mark.integration
+def test_get_record_with_allow_failover(env):
+    """Test that a transaction record can be retrieved with node failover enabled."""
+    env.client.set_allow_receipt_node_failover(True)
+
+    tx = AccountCreateTransaction().set_key_without_alias(PrivateKey.generate_ecdsa())
+    response = tx.execute(env.client, wait_for_receipt=False)
+
+    assert response is not None
+
+    record = response.get_record(env.client)
+    assert record is not None
+    assert record.receipt.account_id is not None
+
+    AccountDeleteTransaction().set_transfer_account_id(env.operator_id).set_account_id(
+        record.receipt.account_id
+    ).execute(env.client)

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -604,3 +604,22 @@ def test_for_network_invalid_shard_realm_raises_error(invalid_map, error_msg):
     """Test that for_network catches mismatched shards or realms."""
     with pytest.raises(ValueError, match=error_msg):
         Client.for_network(invalid_map)
+
+
+def test_set_receipt_failover_set_values():
+    """Test that receipt failover is set to the provided value."""
+    client = Client.from_env()
+    # default
+    assert client.allow_receipt_node_failover is False
+
+    return_value = client.set_allow_receipt_node_failover(True)
+    assert client.allow_receipt_node_failover is True
+    assert return_value is client
+
+
+@pytest.mark.parametrize("allow", ["true", 1, 0.1, [], {}, None])
+def test_set_receipt_failover_rejects_non_bool(allow):
+    """Test that non-boolean values are rejected."""
+    client = Client.from_env()
+    with pytest.raises(TypeError, match="allow must be an instance of bool"):
+        client.set_allow_receipt_node_failover(allow)

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -608,7 +608,7 @@ def test_for_network_invalid_shard_realm_raises_error(invalid_map, error_msg):
 
 def test_set_receipt_failover_set_values():
     """Test that receipt failover is set to the provided value."""
-    client = Client.from_env()
+    client = Client.for_testnet()
     # default
     assert client.allow_receipt_node_failover is False
 
@@ -620,6 +620,6 @@ def test_set_receipt_failover_set_values():
 @pytest.mark.parametrize("allow", ["true", 1, 0.1, [], {}, None])
 def test_set_receipt_failover_rejects_non_bool(allow):
     """Test that non-boolean values are rejected."""
-    client = Client.from_env()
+    client = Client.for_testnet()
     with pytest.raises(TypeError, match="allow must be an instance of bool"):
         client.set_allow_receipt_node_failover(allow)

--- a/tests/unit/executable_test.py
+++ b/tests/unit/executable_test.py
@@ -1175,8 +1175,9 @@ def test_transaction_receipt_query_with_single_node_does_not_advance():
         patch("hiero_sdk_python.node._Node.is_healthy", side_effect=[False, True]),
         patch("hiero_sdk_python.executable._delay_for_attempt") as mock_delay,
     ):
-        query.execute(client)
+        receipt = query.execute(client)
 
+        assert receipt.status == receipt_response.transactionGetReceipt.receipt.status
         assert mock_delay.call_count > 0
         assert query._node_account_ids.index == initial_index
         assert query._node_account_ids.current == node_id
@@ -1209,8 +1210,9 @@ def test_transaction_receipt_query_with_mutiple_node_advance_to_next():
         mock_hedera_servers(response_sequences) as client,
         patch("hiero_sdk_python.node._Node.is_healthy", side_effect=[False, True]),
     ):
-        query.execute(client)
+        receipt = query.execute(client)
 
+        assert receipt.status == receipt_response.transactionGetReceipt.receipt.status
         assert query._node_account_ids.index == initial_index + 1
         assert query._node_account_ids.current == node_ids[1]
 
@@ -1257,7 +1259,11 @@ def test_transaction_record_query_with_single_node_does_not_advance():
         patch("hiero_sdk_python.node._Node.is_healthy", side_effect=[False, True, True]),
         patch("hiero_sdk_python.executable._delay_for_attempt") as mock_delay,
     ):
-        query.execute(client)
+        record_response = query.execute(client)
+
+        assert record_response.receipt.status == record.receipt.status
+        assert record_response.transaction_fee == record.transactionFee
+        assert record_response.transaction_memo == record.memo
 
         assert mock_delay.call_count > 0
         assert query._node_account_ids.index == initial_index
@@ -1307,7 +1313,10 @@ def test_transaction_record_query_with_mutiple_node_advance_to_next():
         mock_hedera_servers(response_sequences) as client,
         patch("hiero_sdk_python.node._Node.is_healthy", side_effect=[False, True, True]),
     ):
-        query.execute(client)
+        record_response = query.execute(client)
 
+        assert record_response.receipt.status == record.receipt.status
+        assert record_response.transaction_fee == record.transactionFee
+        assert record_response.transaction_memo == record.memo
         assert query._node_account_ids.index == initial_index + 1
         assert query._node_account_ids.current == node_ids[1]

--- a/tests/unit/executable_test.py
+++ b/tests/unit/executable_test.py
@@ -22,7 +22,10 @@ from hiero_sdk_python.hapi.services import (
     response_pb2,
     transaction_get_receipt_pb2,
     transaction_receipt_pb2,
+    transaction_record_pb2,
 )
+from hiero_sdk_python.hapi.services.query_header_pb2 import ResponseType
+from hiero_sdk_python.hapi.services.transaction_get_record_pb2 import TransactionGetRecordResponse
 from hiero_sdk_python.hapi.services.transaction_response_pb2 import (
     TransactionResponse as TransactionResponseProto,
 )
@@ -1146,3 +1149,165 @@ def test_retry_invalid_node_account_updates_network():
         mock_increase_backoff.assert_called_once()
         mock_update_network.assert_called_once()
         mock_delay.assert_called_once()
+
+
+def test_transaction_receipt_query_with_single_node_does_not_advance():
+    """Test that a single-node receipt query remains on the same node after retry."""
+    receipt_response = response_pb2.Response(
+        transactionGetReceipt=transaction_get_receipt_pb2.TransactionGetReceiptResponse(
+            header=response_header_pb2.ResponseHeader(nodeTransactionPrecheckCode=ResponseCode.OK),
+            receipt=transaction_receipt_pb2.TransactionReceipt(status=ResponseCode.SUCCESS),
+        )
+    )
+
+    response = [[receipt_response]]
+
+    node_id = AccountId.from_string("0.0.3")
+    query = (
+        TransactionGetReceiptQuery()
+        .set_transaction_id(TransactionId.from_string("0.0.3@1769674705.770340600"))
+        .set_node_account_ids([node_id])
+    )
+    initial_index = query._node_account_ids.index
+
+    with (
+        mock_hedera_servers(response) as client,
+        patch("hiero_sdk_python.node._Node.is_healthy", side_effect=[False, True]),
+        patch("hiero_sdk_python.executable._delay_for_attempt") as mock_delay,
+    ):
+        query.execute(client)
+
+        assert mock_delay.call_count > 0
+        assert query._node_account_ids.index == initial_index
+        assert query._node_account_ids.current == node_id
+
+
+def test_transaction_receipt_query_with_mutiple_node_advance_to_next():
+    """Test that a receipt query advances to the next node when the current node is unhealthy."""
+    receipt_response = response_pb2.Response(
+        transactionGetReceipt=transaction_get_receipt_pb2.TransactionGetReceiptResponse(
+            header=response_header_pb2.ResponseHeader(nodeTransactionPrecheckCode=ResponseCode.OK),
+            receipt=transaction_receipt_pb2.TransactionReceipt(status=ResponseCode.SUCCESS),
+        )
+    )
+
+    response_sequences = [
+        [],  # first node (unhealthy)
+        [receipt_response],  # second node (healthy)
+    ]
+
+    node_ids = [AccountId.from_string("0.0.3"), AccountId.from_string("0.0.4")]
+    query = (
+        TransactionGetReceiptQuery()
+        .set_transaction_id(TransactionId.from_string("0.0.3@1769674705.770340600"))
+        .set_node_account_ids(node_ids)
+    )
+
+    initial_index = query._node_account_ids.index
+
+    with (
+        mock_hedera_servers(response_sequences) as client,
+        patch("hiero_sdk_python.node._Node.is_healthy", side_effect=[False, True]),
+    ):
+        query.execute(client)
+
+        assert query._node_account_ids.index == initial_index + 1
+        assert query._node_account_ids.current == node_ids[1]
+
+
+def test_transaction_record_query_with_single_node_does_not_advance():
+    """Test that a single-node record query remains on the same node after retry."""
+    record = transaction_record_pb2.TransactionRecord(
+        receipt=transaction_receipt_pb2.TransactionReceipt(status=ResponseCode.SUCCESS),
+        memo="test_Record",
+        transactionFee=100000,
+    )
+
+    response = [
+        [
+            response_pb2.Response(
+                transactionGetRecord=TransactionGetRecordResponse(
+                    header=response_header_pb2.ResponseHeader(
+                        nodeTransactionPrecheckCode=ResponseCode.OK, responseType=ResponseType.COST_ANSWER, cost=2
+                    )
+                )
+            ),
+            response_pb2.Response(
+                transactionGetRecord=TransactionGetRecordResponse(
+                    header=response_header_pb2.ResponseHeader(
+                        nodeTransactionPrecheckCode=ResponseCode.OK,
+                        responseType=ResponseType.ANSWER_ONLY,
+                    ),
+                    transactionRecord=record,
+                )
+            ),
+        ]
+    ]
+
+    node_id = AccountId.from_string("0.0.3")
+    query = (
+        TransactionRecordQuery()
+        .set_transaction_id(TransactionId.from_string("0.0.3@1769674705.770340600"))
+        .set_node_account_ids([node_id])
+    )
+    initial_index = query._node_account_ids.index
+
+    with (
+        mock_hedera_servers(response) as client,
+        patch("hiero_sdk_python.node._Node.is_healthy", side_effect=[False, True, True]),
+        patch("hiero_sdk_python.executable._delay_for_attempt") as mock_delay,
+    ):
+        query.execute(client)
+
+        assert mock_delay.call_count > 0
+        assert query._node_account_ids.index == initial_index
+        assert query._node_account_ids.current == node_id
+
+
+def test_transaction_record_query_with_mutiple_node_advance_to_next():
+    """Test that a record query advances to the next node when the current node is unhealthy."""
+    record = transaction_record_pb2.TransactionRecord(
+        receipt=transaction_receipt_pb2.TransactionReceipt(status=ResponseCode.SUCCESS),
+        memo="test_Record",
+        transactionFee=100000,
+    )
+
+    response_sequences = [
+        [],
+        [
+            response_pb2.Response(
+                transactionGetRecord=TransactionGetRecordResponse(
+                    header=response_header_pb2.ResponseHeader(
+                        nodeTransactionPrecheckCode=ResponseCode.OK, responseType=ResponseType.COST_ANSWER, cost=2
+                    )
+                )
+            ),
+            response_pb2.Response(
+                transactionGetRecord=TransactionGetRecordResponse(
+                    header=response_header_pb2.ResponseHeader(
+                        nodeTransactionPrecheckCode=ResponseCode.OK,
+                        responseType=ResponseType.ANSWER_ONLY,
+                    ),
+                    transactionRecord=record,
+                )
+            ),
+        ],
+    ]
+
+    node_ids = [AccountId.from_string("0.0.3"), AccountId.from_string("0.0.4")]
+    query = (
+        TransactionRecordQuery()
+        .set_transaction_id(TransactionId.from_string("0.0.3@1769674705.770340600"))
+        .set_node_account_ids(node_ids)
+    )
+
+    initial_index = query._node_account_ids.index
+
+    with (
+        mock_hedera_servers(response_sequences) as client,
+        patch("hiero_sdk_python.node._Node.is_healthy", side_effect=[False, True, True]),
+    ):
+        query.execute(client)
+
+        assert query._node_account_ids.index == initial_index + 1
+        assert query._node_account_ids.current == node_ids[1]

--- a/tests/unit/token_create_transaction_test.py
+++ b/tests/unit/token_create_transaction_test.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.client.client import Client
 from hiero_sdk_python.crypto.private_key import PrivateKey
 from hiero_sdk_python.Duration import Duration
 from hiero_sdk_python.exceptions import PrecheckError
@@ -403,7 +404,8 @@ def test_transaction_execution_failure(mock_account_ids):
     token_tx._transaction_body_bytes = b"mock_body_bytes"
 
     # Mock the client and its operator_private_key
-    token_tx.client = MagicMock()
+    token_tx.client = MagicMock(spec=Client)
+    token_tx.client.operator_account_id = MagicMock()
     mock_public_key = MagicMock()
     mock_public_key.to_bytes_raw.return_value = b"mock_public_key"
 

--- a/tests/unit/transaction_response_test.py
+++ b/tests/unit/transaction_response_test.py
@@ -251,3 +251,123 @@ def test_transaction_response_get_receipt_is_pinned_to_submitting_node(
         receipt = resp.get_receipt(client)
 
         assert receipt.status == ResponseCode.SUCCESS
+
+
+def test_default_receipt_query_is_pinned_to_submitting_node(mock_client):
+    """Test that receipt queries use only the submitting node by default."""
+    node_id = AccountId.from_string("0.0.4")
+    transaction_node_ids = [
+        node_id,
+        AccountId.from_string("0.0.5"),
+    ]
+
+    response = TransactionResponse()
+    response.node_id = node_id
+    response._transaction_node_ids = transaction_node_ids
+
+    # Without a client, always pinned to the submitting node.
+    query = response.get_receipt_query()
+    assert isinstance(query, TransactionGetReceiptQuery)
+    assert query.node_account_ids == [node_id]
+
+    # With failover disabled
+    query = response.get_receipt_query(mock_client)
+    assert isinstance(query, TransactionGetReceiptQuery)
+    assert query.node_account_ids == [node_id]
+
+
+def test_default_record_query_is_pinned_to_submitting_node(mock_client):
+    """Test that record queries use only the submitting node by default."""
+    node_id = AccountId.from_string("0.0.4")
+    transaction_node_ids = [
+        node_id,
+        AccountId.from_string("0.0.5"),
+    ]
+
+    response = TransactionResponse()
+    response.node_id = node_id
+    response._transaction_node_ids = transaction_node_ids
+
+    # Without a client, always pinned to the submitting node.
+    query = response.get_record_query()
+    assert isinstance(query, TransactionRecordQuery)
+    assert query.node_account_ids == [node_id]
+
+    # With failover disabled
+    query = response.get_record_query(mock_client)
+    assert isinstance(query, TransactionRecordQuery)
+    assert query.node_account_ids == [node_id]
+
+
+def test_receipt_query_uses_transaction_nodes_when_failover_enabled(mock_client):
+    """Test that receipt queries use transaction nodes when failover is enabled."""
+    node_id = AccountId.from_string("0.0.4")
+    transaction_node_ids = [
+        node_id,
+        AccountId.from_string("0.0.5"),
+    ]
+
+    response = TransactionResponse()
+    response.node_id = node_id
+    response._transaction_node_ids = transaction_node_ids
+
+    mock_client.set_allow_receipt_node_failover(True)
+
+    query = response.get_receipt_query(client=mock_client)
+
+    assert isinstance(query, TransactionGetReceiptQuery)
+    assert query.node_account_ids == transaction_node_ids
+
+
+def test_record_query_uses_transaction_nodes_when_failover_enabled(mock_client):
+    """Test that record queries use transaction nodes when failover is enabled."""
+    node_id = AccountId.from_string("0.0.4")
+    transaction_node_ids = [
+        node_id,
+        AccountId.from_string("0.0.5"),
+    ]
+
+    response = TransactionResponse()
+    response.node_id = node_id
+    response._transaction_node_ids = transaction_node_ids
+
+    mock_client.set_allow_receipt_node_failover(True)
+
+    query = response.get_record_query(client=mock_client)
+
+    assert isinstance(query, TransactionRecordQuery)
+    assert query.node_account_ids == transaction_node_ids
+
+
+def test_receipt_query_uses_client_nodes_when_transaction_nodes_not_set(mock_client):
+    """Test that receipt queries use client nodes when transaction nodes are not set."""
+    node_id = AccountId.from_string("0.0.4")
+
+    response = TransactionResponse()
+    response.node_id = node_id
+
+    mock_client.set_allow_receipt_node_failover(True)
+    query = response.get_receipt_query(client=mock_client)
+
+    except_node_ids = [node_id]
+    except_node_ids.extend(id for id in mock_client.get_node_account_ids() if id != node_id)
+
+    assert isinstance(query, TransactionGetReceiptQuery)
+    assert query.node_account_ids == except_node_ids
+
+
+def test_record_query_uses_client_nodes_when_transaction_nodes_not_set(mock_client):
+    """Test that record queries use client nodes when transaction nodes are not set."""
+    node_id = AccountId.from_string("0.0.4")
+
+    response = TransactionResponse()
+    response.node_id = node_id
+
+    mock_client.set_allow_receipt_node_failover(True)
+    query = response.get_record_query(client=mock_client)
+
+    except_node_ids = [node_id]
+    except_node_ids.extend(id for id in mock_client.get_node_account_ids() if id != node_id)
+
+    assert isinstance(query, TransactionRecordQuery)
+    assert query.node_account_ids == except_node_ids

--- a/tests/unit/transaction_response_test.py
+++ b/tests/unit/transaction_response_test.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import pytest
 
 from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.client.client import Client
 from hiero_sdk_python.exceptions import ReceiptStatusError
 from hiero_sdk_python.hapi.services import (
     basic_types_pb2,
@@ -253,6 +254,73 @@ def test_transaction_response_get_receipt_is_pinned_to_submitting_node(
         assert receipt.status == ResponseCode.SUCCESS
 
 
+@pytest.mark.parametrize("status", [1, 1.2, None, Client(), "True", [], {}])
+def test_get_receipt_query_invalid_status_type(status):
+    """Test that get_receipt_query raises TypeError for an invalid status type."""
+    response = TransactionResponse()
+    with pytest.raises(TypeError, match="validate_status must be a boolean"):
+        response.get_receipt_query(validate_status=status)
+
+
+@pytest.mark.parametrize(
+    "client",
+    [1, 1.2, True, "True", [], {}],  # None is allow for client
+)
+def test_get_receipt_query_invalid_client_type(client):
+    """Test that get_receipt_query raises TypeError for an invalid client type."""
+    response = TransactionResponse()
+    with pytest.raises(TypeError, match="client must be an instance of Client"):
+        response.get_receipt_query(client=client)
+
+
+@pytest.mark.parametrize(
+    "client",
+    [1, 1.2, True, "True", [], {}],  # None is allow for client
+)
+def test_get_record_query_invalid_client_type(client):
+    """Test that get_record_query raises TypeError for an invalid client type."""
+    response = TransactionResponse()
+    with pytest.raises(TypeError, match="client must be an instance of Client"):
+        response.get_record_query(client=client)
+
+
+def test_resolve_node_account_ids_with_failover_diabled(mock_client):
+    """Test that only the transaction node is returned when no client or failover is disabled."""
+    response = TransactionResponse()
+    response.node_id = AccountId.from_string("0.0.3")
+
+    # When client is None
+    node_ids = response._resolve_node_account_ids(None)
+    assert node_ids == [AccountId.from_string("0.0.3")]
+
+    # With failover disabled
+    node_ids = response._resolve_node_account_ids(mock_client)
+    assert node_ids == [AccountId.from_string("0.0.3")]
+
+
+def test_resolve_node_account_ids_with_transaction_nodes(mock_client):
+    """Test that transaction nodes are used when receipt failover is enabled."""
+    response = TransactionResponse()
+    response.node_id = AccountId.from_string("0.0.3")
+    response._transaction_node_ids = [AccountId.from_string("0.0.3"), AccountId.from_string("0.0.4")]
+
+    mock_client.set_allow_receipt_node_failover(True)
+    node_ids = response._resolve_node_account_ids(mock_client)
+    assert node_ids == [AccountId.from_string("0.0.3"), AccountId.from_string("0.0.4")]
+
+
+def test_resolve_node_account_ids_uses_client_nodes_when_transaction_nodes_unavailable(mock_client):
+    """Test that client nodes are used when transaction nodes are unavailable."""
+    response = TransactionResponse()
+    response.node_id = AccountId.from_string("0.0.3")
+    response._transaction_node_ids = []
+
+    mock_client.set_allow_receipt_node_failover(True)
+    node_ids = response._resolve_node_account_ids(mock_client)
+
+    assert node_ids == mock_client.get_node_account_ids()
+
+
 def test_default_receipt_query_is_pinned_to_submitting_node(mock_client):
     """Test that receipt queries use only the submitting node by default."""
     node_id = AccountId.from_string("0.0.4")
@@ -271,7 +339,7 @@ def test_default_receipt_query_is_pinned_to_submitting_node(mock_client):
     assert query.node_account_ids == [node_id]
 
     # With failover disabled
-    query = response.get_receipt_query(mock_client)
+    query = response.get_receipt_query(client=mock_client)
     assert isinstance(query, TransactionGetReceiptQuery)
     assert query.node_account_ids == [node_id]
 

--- a/tests/unit/transaction_test.py
+++ b/tests/unit/transaction_test.py
@@ -587,3 +587,47 @@ def test_transaction_body_bytes_for_each_node_id_on_freeze_manual(mock_client):
         body = transaction_pb2.TransactionBody()
         body.ParseFromString(body_bytes_value)
         assert body.nodeAccountID == AccountId._to_proto(node_id)
+
+
+@pytest.mark.parametrize("client", ["Client", True, 1, 0.1, {}, []])
+def test_transaction_execute_with_invalid_client_param(client):
+    """Test execute() raises TypeError when client is invalid."""
+    tx = AccountCreateTransaction()
+
+    with pytest.raises(TypeError, match="client must be an instance of Client"):
+        tx.execute(client)
+
+
+def test_transaction_execute_with_none_client_param(mock_client):
+    """Test execute() raises TypeError when client is None."""
+    tx = AccountCreateTransaction().freeze_with(mock_client)
+
+    with pytest.raises(TypeError, match="client must be an instance of Client"):
+        tx.execute(None)
+
+
+@pytest.mark.parametrize("validate_status", ["True", 1, None, 0.1, {}, []])
+def test_transaction_execute_with_invalid_validate_status_param(mock_client, validate_status):
+    """Test execute() raises TypeError when validate_status is invalid."""
+    tx = AccountCreateTransaction()
+
+    with pytest.raises(TypeError, match="validate_status must be a boolean"):
+        tx.execute(mock_client, validate_status=validate_status)
+
+
+@pytest.mark.parametrize("wait_for_receipt", ["True", 1, None, 0.1, {}, []])
+def test_transaction_execute_with_invalid_wait_for_receipt_param(mock_client, wait_for_receipt):
+    """Test execute() raises TypeError when wait_for_receipt is invalid."""
+    tx = AccountCreateTransaction()
+
+    with pytest.raises(TypeError, match="wait_for_receipt must be a boolean"):
+        tx.execute(mock_client, wait_for_receipt=wait_for_receipt)
+
+
+@pytest.mark.parametrize("timeout", ["1.0", True, {}, []])
+def test_transaction_execute_with_invalid_timeout_param(mock_client, timeout):
+    """Test execute() raises TypeError when timeout is invalid."""
+    tx = AccountCreateTransaction()
+
+    with pytest.raises(TypeError, match="timeout must be a int or float"):
+        tx.execute(mock_client, timeout=timeout)


### PR DESCRIPTION
**Description**:
This PR implement opt-in receipt/record node failover.

**Changes Made**
- Add `allow_receipt_node_failover`  to Client (default=`False`)
- Add `set_allow_receipt_node_failover()` 
- Update `TransactionResponse.get_receipt_query()` and `get_record_query()` to support node failover.


**Related issue(s)**:

Fixes #2526

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
