### PR TITLE
docs: update GitHub signup link

### DIFF
--- a/docs/sdk_developers/setup.md
+++ b/docs/sdk_developers/setup.md
@@ -23,7 +23,7 @@ This guide walks you through setting up your development environment for contrib
 Before you begin, make sure you have:
 - **Git** installed ([Download Git](https://git-scm.com/downloads))
 - **Python 3.10+** installed ([Download Python](https://www.python.org/downloads/))
-- A **GitHub account** ([Sign up](https://github.com/join))
+- A **GitHub account** ([Sign up](https://docs.github.com/en/account-and-profile/how-tos/account-management/creating-an-account-on-github))
 
 ### Step 1: Fork the Repository
 


### PR DESCRIPTION
## Summary

Fix the broken GitHub account signup link reported by the scheduled Markdown link checker.

The old https://github.com/join URL redirects to GitHub's signup flow and is rejected by the repository's Lychee check. This updates the documentation to GitHub's current account-creation documentation.

## Validation

- lychee --verbose --no-progress './**/*.md' â€” pass
- Exactly one documentation file changed
- Exactly one signed + DCO-signoff commit

Fixes #2502