### PR TITLE
refactor: replace PublicKey with Key in contract and schedule modules

### DIFF
--- a/src/hiero_sdk_python/contract/contract_create_transaction.py
+++ b/src/hiero_sdk_python/contract/contract_create_transaction.py
@@ -10,7 +10,7 @@ from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.contract.contract_function_parameters import (
     ContractFunctionParameters,
 )
-from hiero_sdk_python.crypto.public_key import PublicKey
+from hiero_sdk_python.crypto.key import Key
 from hiero_sdk_python.Duration import Duration
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.file.file_id import FileId
@@ -36,7 +36,7 @@ class ContractCreateParams:
         bytecode_file_id (FileId, optional): The FileId of the file containing
             the contract bytecode.
         proxy_account_id (AccountId, optional): The AccountId of the proxy account.
-        admin_key (PublicKey, optional): The admin key for the contract.
+        admin_key (Key, optional): The admin key for the contract.
         gas (int, optional): The gas limit for contract creation.
         initial_balance (int, optional): The initial balance for the contract
             in tinybars.
@@ -56,7 +56,7 @@ class ContractCreateParams:
 
     bytecode_file_id: FileId | None = None
     proxy_account_id: AccountId | None = None
-    admin_key: PublicKey | None = None
+    admin_key: Key | None = None
     gas: int | None = None
     initial_balance: int | None = None
     auto_renew_period: Duration = Duration(DEFAULT_AUTO_RENEW_PERIOD)
@@ -96,7 +96,7 @@ class ContractCreateTransaction(Transaction):
         params = contract_params or ContractCreateParams()
         self.bytecode_file_id: FileId | None = params.bytecode_file_id
         self.proxy_account_id: AccountId | None = params.proxy_account_id
-        self.admin_key: PublicKey | None = params.admin_key
+        self.admin_key: Key | None = params.admin_key
         self.gas: int | None = params.gas
         self.initial_balance: int | None = params.initial_balance
         self.auto_renew_period: Duration = params.auto_renew_period
@@ -158,12 +158,12 @@ class ContractCreateTransaction(Transaction):
         self.proxy_account_id = proxy_account_id
         return self
 
-    def set_admin_key(self, admin_key: PublicKey | None) -> ContractCreateTransaction:
+    def set_admin_key(self, admin_key: Key | None) -> ContractCreateTransaction:
         """
         Sets the admin key for the contract.
 
         Args:
-            admin_key (PublicKey | None): The admin key.
+            admin_key (Key | None): The admin key.
 
         Returns:
             ContractCreateTransaction: This transaction instance.
@@ -355,7 +355,7 @@ class ContractCreateTransaction(Transaction):
             staked_node_id=self.staked_node_id,
             autoRenewPeriod=self.auto_renew_period._to_proto(),
             proxyAccountID=(self.proxy_account_id._to_proto() if self.proxy_account_id else None),
-            adminKey=(self.admin_key._to_proto() if self.admin_key else None),
+            adminKey=(self.admin_key.to_proto_key() if self.admin_key else None),
             fileID=self.bytecode_file_id._to_proto() if self.bytecode_file_id else None,
             initcode=self.bytecode,
         )

--- a/src/hiero_sdk_python/contract/contract_info.py
+++ b/src/hiero_sdk_python/contract/contract_info.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.contract.contract_id import ContractId
-from hiero_sdk_python.crypto.public_key import PublicKey
+from hiero_sdk_python.crypto.key import Key
 from hiero_sdk_python.Duration import Duration
 from hiero_sdk_python.hapi.services.contract_get_info_pb2 import ContractGetInfoResponse
 from hiero_sdk_python.staking_info import StakingInfo
@@ -26,7 +26,7 @@ class ContractInfo:
         contract_id (ContractId, optional): The ID of the contract
         account_id (AccountId, optional): The ID of the account owned by the contract
         contract_account_id (str, optional): The contract's EVM address (hex).
-        admin_key (PublicKey, optional): The key that can modify this contract
+        admin_key (Key, optional): The key that can modify this contract
         expiration_time (Timestamp, optional): When the contract will expire
         auto_renew_period (Duration, optional): The period for which the contract will auto-renew
         auto_renew_account_id (AccountId, optional):
@@ -45,7 +45,7 @@ class ContractInfo:
     contract_id: ContractId | None = None
     account_id: AccountId | None = None
     contract_account_id: str | None = None
-    admin_key: PublicKey | None = None
+    admin_key: Key | None = None
     expiration_time: Timestamp | None = None
     auto_renew_period: Duration | None = None
     auto_renew_account_id: AccountId | None = None
@@ -76,7 +76,7 @@ class ContractInfo:
             contract_id=(cls._from_proto_field(proto, "contractID", ContractId._from_proto)),
             account_id=(cls._from_proto_field(proto, "accountID", AccountId._from_proto)),
             contract_account_id=proto.contractAccountID,
-            admin_key=(cls._from_proto_field(proto, "adminKey", PublicKey._from_proto)),
+            admin_key=(cls._from_proto_field(proto, "adminKey", Key.from_proto_key)),
             expiration_time=(cls._from_proto_field(proto, "expirationTime", Timestamp._from_protobuf)),
             auto_renew_period=(cls._from_proto_field(proto, "autoRenewPeriod", Duration._from_proto)),
             auto_renew_account_id=(cls._from_proto_field(proto, "auto_renew_account_id", AccountId._from_proto)),
@@ -103,7 +103,7 @@ class ContractInfo:
             accountID=self.account_id._to_proto() if self.account_id else None,
             contractID=self.contract_id._to_proto() if self.contract_id else None,
             contractAccountID=self.contract_account_id,
-            adminKey=self.admin_key._to_proto() if self.admin_key else None,
+            adminKey=self.admin_key.to_proto_key() if self.admin_key else None,
             expirationTime=(self.expiration_time._to_protobuf() if self.expiration_time else None),
             autoRenewPeriod=(self.auto_renew_period._to_proto() if self.auto_renew_period else None),
             storage=self.storage,

--- a/src/hiero_sdk_python/contract/contract_info.py
+++ b/src/hiero_sdk_python/contract/contract_info.py
@@ -15,6 +15,7 @@ from hiero_sdk_python.hapi.services.contract_get_info_pb2 import ContractGetInfo
 from hiero_sdk_python.staking_info import StakingInfo
 from hiero_sdk_python.timestamp import Timestamp
 from hiero_sdk_python.tokens.token_relationship import TokenRelationship
+from hiero_sdk_python.utils.key_format import format_key
 
 
 @dataclass
@@ -150,7 +151,7 @@ class ContractInfo:
             f"  contract_id={self.contract_id},\n"
             f"  account_id={self.account_id},\n"
             f"  contract_account_id={self.contract_account_id},\n"
-            f"  admin_key={self.admin_key},\n"
+            f"  admin_key={format_key(self.admin_key)},\n"
             f"  auto_renew_account_id={self.auto_renew_account_id},\n"
             f"  auto_renew_period={self.auto_renew_period},\n"
             f"  storage={self.storage},\n"

--- a/src/hiero_sdk_python/contract/contract_update_transaction.py
+++ b/src/hiero_sdk_python/contract/contract_update_transaction.py
@@ -11,7 +11,7 @@ from google.protobuf.wrappers_pb2 import BoolValue, Int32Value, StringValue
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.channels import _Channel
 from hiero_sdk_python.contract.contract_id import ContractId
-from hiero_sdk_python.crypto.public_key import PublicKey
+from hiero_sdk_python.crypto.key import Key
 from hiero_sdk_python.Duration import Duration
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services import contract_update_pb2, transaction_pb2
@@ -31,7 +31,7 @@ class ContractUpdateParams:
     Attributes:
         contract_id (ContractId, optional): The contract ID to update.
         expiration_time (Timestamp, optional): The new expiration time for the contract.
-        admin_key (PublicKey, optional): The new admin key for the contract.
+        admin_key (Key, optional): The new admin key for the contract.
         auto_renew_period (Duration, optional): The new auto-renew period for the contract.
         contract_memo (str, optional): The new memo for the contract.
         max_automatic_token_associations (int, optional): The new maximum number of
@@ -45,7 +45,7 @@ class ContractUpdateParams:
 
     contract_id: ContractId | None = None
     expiration_time: Timestamp | None = None
-    admin_key: PublicKey | None = None
+    admin_key: Key | None = None
     auto_renew_period: Duration | None = None
     contract_memo: str | None = None
     max_automatic_token_associations: int | None = None
@@ -86,7 +86,7 @@ class ContractUpdateTransaction(Transaction):
         params = contract_params or ContractUpdateParams()
         self.contract_id: ContractId | None = params.contract_id
         self.expiration_time: Timestamp | None = params.expiration_time
-        self.admin_key: PublicKey | None = params.admin_key
+        self.admin_key: Key | None = params.admin_key
         self.auto_renew_period: Duration | None = params.auto_renew_period
         self.contract_memo: str | None = params.contract_memo
         self.max_automatic_token_associations: int | None = params.max_automatic_token_associations
@@ -124,12 +124,12 @@ class ContractUpdateTransaction(Transaction):
         self.expiration_time = expiration_time
         return self
 
-    def set_admin_key(self, admin_key: PublicKey | None) -> ContractUpdateTransaction:
+    def set_admin_key(self, admin_key: Key | None) -> ContractUpdateTransaction:
         """
         Sets the new admin key for the contract.
 
         Args:
-            admin_key (PublicKey | None): The new admin key for the contract.
+            admin_key (Key | None): The new admin key for the contract.
                 This key can update or delete the contract.
 
         Returns:
@@ -264,7 +264,7 @@ class ContractUpdateTransaction(Transaction):
         return contract_update_pb2.ContractUpdateTransactionBody(
             contractID=self.contract_id._to_proto(),
             expirationTime=(self.expiration_time._to_protobuf() if self.expiration_time else None),
-            adminKey=self._convert_to_proto(self.admin_key),
+            adminKey=self.admin_key.to_proto_key() if self.admin_key else None,
             autoRenewPeriod=self._convert_to_proto(self.auto_renew_period),
             staked_node_id=self.staked_node_id,
             memoWrapper=(StringValue(value=self.contract_memo) if self.contract_memo is not None else None),

--- a/src/hiero_sdk_python/schedule/schedule_create_transaction.py
+++ b/src/hiero_sdk_python/schedule/schedule_create_transaction.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.channels import _Channel
-from hiero_sdk_python.crypto.public_key import PublicKey
+from hiero_sdk_python.crypto.key import Key
 from hiero_sdk_python.executable import _Method
 from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
     SchedulableTransactionBody,
@@ -27,7 +27,7 @@ class ScheduleCreateParams:
     Attributes:
         payer_account_id (AccountId, optional): The account ID of the payer
             for the scheduled transaction.
-        admin_key (PublicKey, optional): The key that can delete or sign the schedule.
+        admin_key (Key, optional): The key that can delete or sign the schedule.
         schedulable_body (SchedulableTransactionBody, optional): The body of the transaction
             to be scheduled.
         schedule_memo (str, optional): A memo to include with the schedule.
@@ -38,7 +38,7 @@ class ScheduleCreateParams:
     """
 
     payer_account_id: AccountId | None = None
-    admin_key: PublicKey | None = None
+    admin_key: Key | None = None
     schedulable_body: SchedulableTransactionBody | None = None
     schedule_memo: str | None = None
     expiration_time: Timestamp | None = None
@@ -70,7 +70,7 @@ class ScheduleCreateTransaction(Transaction):
         super().__init__()
         schedule_params = schedule_params or ScheduleCreateParams()
         self.payer_account_id: AccountId | None = schedule_params.payer_account_id
-        self.admin_key: PublicKey | None = schedule_params.admin_key
+        self.admin_key: Key | None = schedule_params.admin_key
         self.schedulable_body: SchedulableTransactionBody | None = schedule_params.schedulable_body
         self.schedule_memo: str | None = schedule_params.schedule_memo
         self.expiration_time: Timestamp | None = schedule_params.expiration_time
@@ -164,12 +164,12 @@ class ScheduleCreateTransaction(Transaction):
         self.wait_for_expiry = wait_for_expiry
         return self
 
-    def set_admin_key(self, admin_key: PublicKey | None) -> ScheduleCreateTransaction:
+    def set_admin_key(self, admin_key: Key | None) -> ScheduleCreateTransaction:
         """
         Sets the admin key for this schedule create transaction.
 
         Args:
-            admin_key (PublicKey | None): The admin key for the schedule.
+            admin_key (Key | None): The admin key for the schedule.
 
         Returns:
             ScheduleCreateTransaction: This transaction instance.
@@ -188,7 +188,7 @@ class ScheduleCreateTransaction(Transaction):
         return ScheduleCreateTransactionBody(
             wait_for_expiry=self.wait_for_expiry,
             memo=self.schedule_memo,
-            adminKey=self.admin_key._to_proto() if self.admin_key else None,
+            adminKey=self.admin_key.to_proto_key() if self.admin_key else None,
             scheduledTransactionBody=self.schedulable_body,
             expiration_time=(self.expiration_time._to_protobuf() if self.expiration_time else None),
             payerAccountID=(self.payer_account_id._to_proto() if self.payer_account_id else None),

--- a/src/hiero_sdk_python/schedule/schedule_create_transaction.py
+++ b/src/hiero_sdk_python/schedule/schedule_create_transaction.py
@@ -27,7 +27,7 @@ class ScheduleCreateParams:
     Attributes:
         payer_account_id (AccountId, optional): The account ID of the payer
             for the scheduled transaction.
-        admin_key (Key, optional): The key that can delete or sign the schedule.
+        admin_key (Key, optional): The key that can delete the schedule.
         schedulable_body (SchedulableTransactionBody, optional): The body of the transaction
             to be scheduled.
         schedule_memo (str, optional): A memo to include with the schedule.

--- a/src/hiero_sdk_python/schedule/schedule_info.py
+++ b/src/hiero_sdk_python/schedule/schedule_info.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.crypto.key import Key
 from hiero_sdk_python.crypto.public_key import PublicKey
 from hiero_sdk_python.hapi.services.basic_types_pb2 import KeyList as KeyListProto
 from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
@@ -39,7 +40,7 @@ class ScheduleInfo:
         scheduled_transaction_body (SchedulableTransactionBody, optional):
             The body of the scheduled transaction.
         schedule_memo (str, optional): The memo associated with the schedule.
-        admin_key (PublicKey, optional): The key that can delete or update the schedule.
+        admin_key (Key, optional): The key that can delete or update the schedule.
         signers (list[PublicKey]): The list of public keys that have signed the schedule.
         ledger_id (bytes, optional): The ID of the ledger this schedule exists in.
         wait_for_expiry (bool, optional): Whether the schedule is set to wait for expiry.
@@ -54,7 +55,7 @@ class ScheduleInfo:
     scheduled_transaction_id: TransactionId | None = None
     scheduled_transaction_body: SchedulableTransactionBody | None = None
     schedule_memo: str | None = None
-    admin_key: PublicKey | None = None
+    admin_key: Key | None = None
     signers: list[PublicKey] = field(default_factory=list)
     ledger_id: bytes | None = None
     wait_for_expiry: bool | None = None
@@ -86,7 +87,7 @@ class ScheduleInfo:
             ),
             scheduled_transaction_body=proto.scheduledTransactionBody,
             schedule_memo=proto.memo,
-            admin_key=(cls._from_proto_field(proto, "adminKey", PublicKey._from_proto)),
+            admin_key=(cls._from_proto_field(proto, "adminKey", Key.from_proto_key)),
             signers=[PublicKey._from_proto(key) for key in proto.signers.keys],
             ledger_id=proto.ledger_id,
             wait_for_expiry=proto.wait_for_expiry,
@@ -109,7 +110,7 @@ class ScheduleInfo:
             scheduledTransactionID=(self._convert_to_proto(self.scheduled_transaction_id, TransactionId._to_proto)),
             scheduledTransactionBody=self.scheduled_transaction_body,
             memo=self.schedule_memo,
-            adminKey=self._convert_to_proto(self.admin_key, PublicKey._to_proto),
+            adminKey=self.admin_key.to_proto_key() if self.admin_key else None,
             signers=KeyListProto(keys=[self._convert_to_proto(key, PublicKey._to_proto) for key in self.signers or []]),
             ledger_id=self.ledger_id,
             wait_for_expiry=self.wait_for_expiry,

--- a/src/hiero_sdk_python/schedule/schedule_info.py
+++ b/src/hiero_sdk_python/schedule/schedule_info.py
@@ -20,6 +20,7 @@ from hiero_sdk_python.hapi.services.schedule_get_info_pb2 import (
 from hiero_sdk_python.schedule.schedule_id import ScheduleId
 from hiero_sdk_python.timestamp import Timestamp
 from hiero_sdk_python.transaction.transaction_id import TransactionId
+from hiero_sdk_python.utils.key_format import format_key
 
 
 @dataclass()
@@ -40,7 +41,7 @@ class ScheduleInfo:
         scheduled_transaction_body (SchedulableTransactionBody, optional):
             The body of the scheduled transaction.
         schedule_memo (str, optional): The memo associated with the schedule.
-        admin_key (Key, optional): The key that can delete or update the schedule.
+        admin_key (Key, optional): The key that can delete the schedule.
         signers (list[PublicKey]): The list of public keys that have signed the schedule.
         ledger_id (bytes, optional): The ID of the ledger this schedule exists in.
         wait_for_expiry (bool, optional): Whether the schedule is set to wait for expiry.
@@ -152,7 +153,7 @@ class ScheduleInfo:
             f"  scheduled_transaction_id={self.scheduled_transaction_id},\n"
             f"  scheduled_transaction_body={self.scheduled_transaction_body},\n"
             f"  schedule_memo='{self.schedule_memo}',\n"
-            f"  admin_key={self.admin_key.to_string() if self.admin_key else None},\n"
+            f"  admin_key={format_key(self.admin_key)},\n"
             f"  signers={signers_str},\n"
             f"  ledger_id={ledger_id_display},\n"
             f"  wait_for_expiry={self.wait_for_expiry}\n"

--- a/src/hiero_sdk_python/utils/key_format.py
+++ b/src/hiero_sdk_python/utils/key_format.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from hiero_sdk_python.hapi.services.basic_types_pb2 import Key
+from hiero_sdk_python.crypto.key import Key
+from hiero_sdk_python.hapi.services.basic_types_pb2 import Key as KeyProto
 
 
-def format_key(key: Key) -> str:
+def format_key(key: Key | KeyProto | None) -> str:
     """
-    Converts a protobuf Key into a nicely formatted string:
+    Converts an SDK or protobuf Key into a nicely formatted string:
       - If key is None, return "None"
       - If ed25519, show "ed25519(hex-encoded)"
       - If thresholdKey, keyList, or something else, show a short label.
@@ -13,10 +14,8 @@ def format_key(key: Key) -> str:
     if key is None:
         return "None"
 
-    # If PublicKey objects don't have certain method e.g., HasField() (protobuf-only)
-    # check for _to_proto() method and convert before calling it
-    if hasattr(key, "_to_proto"):
-        key = key._to_proto()  # Handle PublicKey objects (convert to proto first)
+    if isinstance(key, Key):
+        key = key.to_proto_key()
     if key.HasField("ed25519"):
         return f"ed25519({key.ed25519.hex()})"
     if key.HasField("thresholdKey"):

--- a/tests/unit/contract_create_transaction_test.py
+++ b/tests/unit/contract_create_transaction_test.py
@@ -15,6 +15,7 @@ from hiero_sdk_python.contract.contract_create_transaction import (
 from hiero_sdk_python.contract.contract_function_parameters import (
     ContractFunctionParameters,
 )
+from hiero_sdk_python.crypto.key_list import KeyList
 from hiero_sdk_python.crypto.private_key import PrivateKey
 from hiero_sdk_python.Duration import Duration
 from hiero_sdk_python.file.file_id import FileId
@@ -144,7 +145,7 @@ def test_build_transaction_body_with_bytecode_file_id(mock_account_ids, contract
     assert transaction_body.contractCreateInstance.fileID == contract_params["bytecode_file_id"]._to_proto()
     assert transaction_body.contractCreateInstance.gas == contract_params["gas"]
     assert transaction_body.contractCreateInstance.initialBalance == contract_params["initial_balance"]
-    assert transaction_body.contractCreateInstance.adminKey == contract_params["admin_key"]._to_proto()
+    assert transaction_body.contractCreateInstance.adminKey == contract_params["admin_key"].to_proto_key()
     assert transaction_body.contractCreateInstance.memo == contract_params["contract_memo"]
     assert transaction_body.contractCreateInstance.constructorParameters == contract_params["parameters"]
     assert transaction_body.contractCreateInstance.initcode == b""
@@ -203,7 +204,7 @@ def test_build_scheduled_body(mock_account_ids, contract_params):
     assert schedulable_body.contractCreateInstance.fileID == contract_params["bytecode_file_id"]._to_proto()
     assert schedulable_body.contractCreateInstance.gas == contract_params["gas"]
     assert schedulable_body.contractCreateInstance.initialBalance == contract_params["initial_balance"]
-    assert schedulable_body.contractCreateInstance.adminKey == contract_params["admin_key"]._to_proto()
+    assert schedulable_body.contractCreateInstance.adminKey == contract_params["admin_key"].to_proto_key()
     assert schedulable_body.contractCreateInstance.memo == contract_params["contract_memo"]
     assert schedulable_body.contractCreateInstance.constructorParameters == contract_params["parameters"]
     assert schedulable_body.contractCreateInstance.initcode == b""
@@ -222,6 +223,27 @@ def test_build_transaction_body_validation_errors():
 
     with pytest.raises(ValueError, match="Gas limit must be provided"):
         contract_tx.build_transaction_body()
+
+
+@pytest.mark.parametrize(
+    "admin_key",
+    [
+        PrivateKey.generate(),
+        KeyList([PrivateKey.generate().public_key(), PrivateKey.generate().public_key()]),
+    ],
+    ids=["private-key", "key-list"],
+)
+def test_build_transaction_body_with_generic_admin_key(mock_account_ids, admin_key):
+    """Test building a contract create transaction with generic admin key types."""
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+    contract_tx = ContractCreateTransaction().set_bytecode(b"test bytecode").set_gas(100000).set_admin_key(admin_key)
+    contract_tx.operator_account_id = operator_id
+    contract_tx.set_node_account_ids([node_account_id])
+
+    transaction_body = contract_tx.build_transaction_body()
+
+    assert contract_tx.admin_key is admin_key
+    assert transaction_body.contractCreateInstance.adminKey == admin_key.to_proto_key()
 
 
 def test_set_methods(contract_params):

--- a/tests/unit/contract_info_test.py
+++ b/tests/unit/contract_info_test.py
@@ -9,6 +9,7 @@ import pytest
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.contract.contract_id import ContractId
 from hiero_sdk_python.contract.contract_info import ContractInfo
+from hiero_sdk_python.crypto.key_list import KeyList
 from hiero_sdk_python.crypto.private_key import PrivateKey
 from hiero_sdk_python.Duration import Duration
 from hiero_sdk_python.hapi.services.basic_types_pb2 import StakingInfo as StakingInfoProto
@@ -213,6 +214,19 @@ def test_from_proto_none_raises_error():
     """Test the from_proto method of the ContractInfo class with a None proto"""
     with pytest.raises(ValueError, match="Contract info proto is None"):
         ContractInfo._from_proto(None)
+
+
+def test_admin_key_key_list_round_trip():
+    """Test serializing and deserializing a key-list contract admin key."""
+    admin_key = KeyList(
+        [PrivateKey.generate().public_key(), PrivateKey.generate().public_key()],
+        threshold=1,
+    )
+
+    restored_info = ContractInfo._from_proto(ContractInfo(admin_key=admin_key)._to_proto())
+
+    assert isinstance(restored_info.admin_key, KeyList)
+    assert restored_info.admin_key.to_proto_key() == admin_key.to_proto_key()
 
 
 def test_to_proto(contract_info):

--- a/tests/unit/contract_info_test.py
+++ b/tests/unit/contract_info_test.py
@@ -229,6 +229,14 @@ def test_admin_key_key_list_round_trip():
     assert restored_info.admin_key.to_proto_key() == admin_key.to_proto_key()
 
 
+def test_str_safely_formats_generic_admin_keys():
+    """Test string formatting supports key lists without exposing private keys."""
+    private_key = PrivateKey.generate_ed25519()
+
+    assert private_key.to_string_raw() not in str(ContractInfo(admin_key=private_key))
+    assert "admin_key=keyList(...)" in str(ContractInfo(admin_key=KeyList([private_key.public_key()])))
+
+
 def test_to_proto(contract_info):
     """Test the to_proto method of the ContractInfo class"""
     proto = contract_info._to_proto()

--- a/tests/unit/contract_update_transaction_test.py
+++ b/tests/unit/contract_update_transaction_test.py
@@ -12,6 +12,7 @@ from hiero_sdk_python.contract.contract_update_transaction import (
     ContractUpdateParams,
     ContractUpdateTransaction,
 )
+from hiero_sdk_python.crypto.key_list import KeyList
 from hiero_sdk_python.crypto.private_key import PrivateKey
 from hiero_sdk_python.Duration import Duration
 from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
@@ -213,6 +214,24 @@ def test_build_transaction_body_success(contract_id, mock_account_ids, transacti
     assert transaction_body.contractUpdateInstance.contractID.contractNum == contract_id.contract
     assert transaction_body.contractUpdateInstance.contractID.shardNum == contract_id.shard
     assert transaction_body.contractUpdateInstance.contractID.realmNum == contract_id.realm
+
+
+@pytest.mark.parametrize(
+    "admin_key",
+    [
+        PrivateKey.generate(),
+        KeyList([PrivateKey.generate().public_key(), PrivateKey.generate().public_key()]),
+    ],
+    ids=["private-key", "key-list"],
+)
+def test_build_proto_body_with_generic_admin_key(contract_id, admin_key):
+    """Test building a contract update body with generic admin key types."""
+    tx = ContractUpdateTransaction().set_contract_id(contract_id).set_admin_key(admin_key)
+
+    proto_body = tx._build_proto_body()
+
+    assert tx.admin_key is admin_key
+    assert proto_body.adminKey == admin_key.to_proto_key()
 
 
 def test_build_transaction_body_missing_contract_id():

--- a/tests/unit/schedule_create_transaction_test.py
+++ b/tests/unit/schedule_create_transaction_test.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.crypto.key_list import KeyList
 from hiero_sdk_python.crypto.private_key import PrivateKey
 from hiero_sdk_python.schedule.schedule_create_transaction import (
     ScheduleCreateParams,
@@ -87,11 +88,29 @@ def test_build_transaction_body_with_valid_parameters(mock_account_ids, schedule
     # Verify all fields are correctly set
     schedule_create = transaction_body.scheduleCreate
     assert schedule_create.payerAccountID == schedule_params["payer_account_id"]._to_proto()
-    assert schedule_create.adminKey == schedule_params["admin_key"]._to_proto()
+    assert schedule_create.adminKey == schedule_params["admin_key"].to_proto_key()
     assert schedule_create.scheduledTransactionBody == schedule_params["schedulable_body"]
     assert schedule_create.memo == schedule_params["schedule_memo"]
     assert schedule_create.expiration_time == schedule_params["expiration_time"]._to_protobuf()
     assert schedule_create.wait_for_expiry == schedule_params["wait_for_expiry"]
+
+
+@pytest.mark.parametrize(
+    "admin_key",
+    [
+        PrivateKey.generate(),
+        KeyList([PrivateKey.generate().public_key(), PrivateKey.generate().public_key()]),
+    ],
+    ids=["private-key", "key-list"],
+)
+def test_build_proto_body_with_generic_admin_key(admin_key):
+    """Test building a schedule create body with generic admin key types."""
+    schedule_tx = ScheduleCreateTransaction().set_admin_key(admin_key)
+
+    proto_body = schedule_tx._build_proto_body()
+
+    assert schedule_tx.admin_key is admin_key
+    assert proto_body.adminKey == admin_key.to_proto_key()
 
 
 def test_set_schedulable_body(schedule_params):

--- a/tests/unit/schedule_info_test.py
+++ b/tests/unit/schedule_info_test.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import pytest
 
 from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.crypto.key_list import KeyList
 from hiero_sdk_python.crypto.private_key import PrivateKey
 from hiero_sdk_python.hapi.services.basic_types_pb2 import KeyList as KeyListProto
 from hiero_sdk_python.hapi.services.schedulable_transaction_body_pb2 import (
@@ -158,6 +159,19 @@ def test_from_proto_none_raises_error():
     """Test the from_proto method of the ScheduleInfo class with a None proto"""
     with pytest.raises(ValueError, match="Schedule info proto is None"):
         ScheduleInfo._from_proto(None)
+
+
+def test_admin_key_key_list_round_trip():
+    """Test serializing and deserializing a key-list schedule admin key."""
+    admin_key = KeyList(
+        [PrivateKey.generate().public_key(), PrivateKey.generate().public_key()],
+        threshold=1,
+    )
+
+    restored_info = ScheduleInfo._from_proto(ScheduleInfo(admin_key=admin_key)._to_proto())
+
+    assert isinstance(restored_info.admin_key, KeyList)
+    assert restored_info.admin_key.to_proto_key() == admin_key.to_proto_key()
 
 
 def test_to_proto(schedule_info):

--- a/tests/unit/schedule_info_test.py
+++ b/tests/unit/schedule_info_test.py
@@ -174,6 +174,14 @@ def test_admin_key_key_list_round_trip():
     assert restored_info.admin_key.to_proto_key() == admin_key.to_proto_key()
 
 
+def test_str_safely_formats_generic_admin_keys():
+    """Test string formatting supports key lists without exposing private keys."""
+    private_key = PrivateKey.generate_ed25519()
+
+    assert private_key.to_string_raw() not in str(ScheduleInfo(admin_key=private_key))
+    assert "admin_key=keyList(...)" in str(ScheduleInfo(admin_key=KeyList([private_key.public_key()])))
+
+
 def test_to_proto(schedule_info):
     """Test the to_proto method of the ScheduleInfo class"""
     proto = schedule_info._to_proto()


### PR DESCRIPTION
**Description**:
This pull request refactors the SDK to standardize the handling of admin keys across contract and schedule transaction modules. The main change is to use the more generic `Key` class instead of `PublicKey` for admin keys, improving flexibility and consistency. All relevant type annotations, docstrings, and serialization/deserialization logic are updated to support this change.

**Key type migration and API updates:**

* Replaced all occurrences of `PublicKey` with `Key` for `admin_key` attributes, parameters, and return types in contract and schedule transaction classes (`contract_create_transaction.py`, `contract_update_transaction.py`, `contract_info.py`, `schedule_create_transaction.py`, `schedule_info.py`). [[1]](diffhunk://#diff-4282e8963006e9c68dad9c880ce24970fde3020278f7262e8929d3ffe88a4b72L13-R13) [[2]](diffhunk://#diff-d575d624e69ccbbdb58072a71d27aa5a9eb2a096965b898f090bb4385103a48cL12-R12) [[3]](diffhunk://#diff-aa62de4dfcdcedaaf97d3bf55c68b9637db010f7b7e0dda5c8cccd8d181cc9b2L14-R14) [[4]](diffhunk://#diff-9bf2f98e2a2532c980dc5a7f0dabfed1a27d355f98b07e0d030491fdbe330bd9L9-R9) [[5]](diffhunk://#diff-3aef0eea750e6e1b13699575b0503054656721c983271ab267737ec686ba0031R11)
* Updated docstrings and type hints to reflect the new `Key` type for admin keys. [[1]](diffhunk://#diff-4282e8963006e9c68dad9c880ce24970fde3020278f7262e8929d3ffe88a4b72L39-R39) [[2]](diffhunk://#diff-d575d624e69ccbbdb58072a71d27aa5a9eb2a096965b898f090bb4385103a48cL29-R29) [[3]](diffhunk://#diff-aa62de4dfcdcedaaf97d3bf55c68b9637db010f7b7e0dda5c8cccd8d181cc9b2L34-R34) [[4]](diffhunk://#diff-9bf2f98e2a2532c980dc5a7f0dabfed1a27d355f98b07e0d030491fdbe330bd9L30-R30) [[5]](diffhunk://#diff-3aef0eea750e6e1b13699575b0503054656721c983271ab267737ec686ba0031L42-R43)

**Serialization/Deserialization logic:**

* Changed all serialization to use `to_proto_key()` instead of `_to_proto()` for admin keys, and deserialization to use `Key.from_proto_key` instead of `PublicKey._from_proto`. This ensures correct handling of various key types. [[1]](diffhunk://#diff-4282e8963006e9c68dad9c880ce24970fde3020278f7262e8929d3ffe88a4b72L358-R358) [[2]](diffhunk://#diff-d575d624e69ccbbdb58072a71d27aa5a9eb2a096965b898f090bb4385103a48cL79-R79) [[3]](diffhunk://#diff-d575d624e69ccbbdb58072a71d27aa5a9eb2a096965b898f090bb4385103a48cL106-R106) [[4]](diffhunk://#diff-aa62de4dfcdcedaaf97d3bf55c68b9637db010f7b7e0dda5c8cccd8d181cc9b2L267-R267) [[5]](diffhunk://#diff-9bf2f98e2a2532c980dc5a7f0dabfed1a27d355f98b07e0d030491fdbe330bd9L191-R191) [[6]](diffhunk://#diff-3aef0eea750e6e1b13699575b0503054656721c983271ab267737ec686ba0031L89-R90) [[7]](diffhunk://#diff-3aef0eea750e6e1b13699575b0503054656721c983271ab267737ec686ba0031L112-R113)

**Class and method signatures:**

* Updated all relevant constructors, setters, and class attributes to use the `Key` type for admin keys. [[1]](diffhunk://#diff-4282e8963006e9c68dad9c880ce24970fde3020278f7262e8929d3ffe88a4b72L59-R59) [[2]](diffhunk://#diff-4282e8963006e9c68dad9c880ce24970fde3020278f7262e8929d3ffe88a4b72L99-R99) [[3]](diffhunk://#diff-4282e8963006e9c68dad9c880ce24970fde3020278f7262e8929d3ffe88a4b72L161-R166) [[4]](diffhunk://#diff-d575d624e69ccbbdb58072a71d27aa5a9eb2a096965b898f090bb4385103a48cL48-R48) [[5]](diffhunk://#diff-aa62de4dfcdcedaaf97d3bf55c68b9637db010f7b7e0dda5c8cccd8d181cc9b2L48-R48) [[6]](diffhunk://#diff-aa62de4dfcdcedaaf97d3bf55c68b9637db010f7b7e0dda5c8cccd8d181cc9b2L89-R89) [[7]](diffhunk://#diff-aa62de4dfcdcedaaf97d3bf55c68b9637db010f7b7e0dda5c8cccd8d181cc9b2L127-R132) [[8]](diffhunk://#diff-9bf2f98e2a2532c980dc5a7f0dabfed1a27d355f98b07e0d030491fdbe330bd9L41-R41) [[9]](diffhunk://#diff-9bf2f98e2a2532c980dc5a7f0dabfed1a27d355f98b07e0d030491fdbe330bd9L73-R73) [[10]](diffhunk://#diff-9bf2f98e2a2532c980dc5a7f0dabfed1a27d355f98b07e0d030491fdbe330bd9L167-R172) [[11]](diffhunk://#diff-3aef0eea750e6e1b13699575b0503054656721c983271ab267737ec686ba0031L57-R58)

This change makes the SDK more robust and future-proof by allowing for a broader range of key types to be used as admin keys.
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #2531 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
