### PR TITLE
Update dependencies: bump versions and tighten constraints

### DIFF
--- a/tck/handlers/file.py
+++ b/tck/handlers/file.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 from hiero_sdk_python.file.file_create_transaction import FileCreateTransaction
+from hiero_sdk_python.file.file_delete_transaction import FileDeleteTransaction
+from hiero_sdk_python.file.file_id import FileId
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.timestamp import Timestamp
 from hiero_sdk_python.transaction.transaction_receipt import TransactionReceipt
 from tck.errors import JsonRpcError
 from tck.handlers.registry import rpc_method
-from tck.param.file import CreateFileParams
-from tck.response.file import CreateFileResponse
+from tck.param.file import CreateFileParams, DeleteFileParams
+from tck.response.file import CreateFileResponse, DeleteFileResponse
 from tck.util.client_utils import get_client
 from tck.util.constants import DEFAULT_GRPC_TIMEOUT
 from tck.util.key_utils import get_key_from_string
@@ -53,3 +55,29 @@ def create_file(params: CreateFileParams) -> CreateFileResponse:
         file_id = str(receipt.file_id)
 
     return CreateFileResponse(file_id, ResponseCode(receipt.status).name)
+
+
+@rpc_method("deleteFile")
+def delete_file(params: DeleteFileParams) -> DeleteFileResponse:
+    """Delete a file."""
+    client = get_client(params.sessionId)
+
+    transaction = FileDeleteTransaction().set_grpc_deadline(DEFAULT_GRPC_TIMEOUT)
+
+    if params.fileId is not None:
+        transaction.set_file_id(FileId.from_string(params.fileId))
+    else:
+        # The JS reference leaves fileId unset and lets the node reject it, but
+        # the Python SDK raises ValueError("Missing required FileID") locally
+        # before the transaction is built. Send an explicit 0.0.0 so the request
+        # reaches the network, which resolves it to INVALID_FILE_ID -- matching
+        # the spec's expectation for an omitted fileId.
+        transaction.set_file_id(FileId(0, 0, 0))
+
+    if params.commonTransactionParams is not None:
+        params.commonTransactionParams.apply_common_params(transaction, client)
+
+    response = transaction.execute(client, wait_for_receipt=False)
+    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+
+    return DeleteFileResponse(ResponseCode(receipt.status).name)

--- a/tck/param/file.py
+++ b/tck/param/file.py
@@ -33,3 +33,21 @@ class CreateFileParams(BaseTransactionParams):
             sessionId=parse_session_id(params),
             commonTransactionParams=parse_common_transaction_params(params),
         )
+
+
+@dataclass
+class DeleteFileParams(BaseTransactionParams):
+    """Parameters for deleting a file. Extends BaseTransactionParams to include common transaction parameters."""
+
+    fileId: str | None = None
+
+    @classmethod
+    def parse_json_params(cls, params: dict) -> DeleteFileParams:
+        """Parse JSON-RPC params into a DeleteFileParams instance."""
+        # Spec's input table says "fileID" but every property test, the JSON
+        # example, and the JS reference handler use "fileId".
+        return cls(
+            fileId=params.get("fileId"),
+            sessionId=parse_session_id(params),
+            commonTransactionParams=parse_common_transaction_params(params),
+        )

--- a/tck/response/file.py
+++ b/tck/response/file.py
@@ -9,3 +9,10 @@ class CreateFileResponse:
 
     fileId: str | None = None
     status: str | None = None
+
+
+@dataclass
+class DeleteFileResponse:
+    """Response payload for deleteFile."""
+
+    status: str | None = None

--- a/tests/tck/file_handlers_test.py
+++ b/tests/tck/file_handlers_test.py
@@ -91,3 +91,4 @@ class TestDeleteFile:
 
         with pytest.raises(ValueError, match="[Ff]ile"):
             delete_file(params)
+

--- a/tests/tck/file_handlers_test.py
+++ b/tests/tck/file_handlers_test.py
@@ -1,0 +1,93 @@
+"""Test cases for the Hiero SDK TCK file-service handlers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hiero_sdk_python.response_code import ResponseCode
+from tck.handlers.file import delete_file
+from tck.param.file import DeleteFileParams
+
+
+pytestmark = pytest.mark.unit
+
+SESSION_ID = "test-session"
+
+
+@pytest.fixture(autouse=True)
+def mock_client():
+    """Patch get_client for every test in this module."""
+    with patch("tck.handlers.file.get_client") as get_client:
+        get_client.return_value = MagicMock()
+        yield
+
+
+def _success_receipt(transaction_cls):
+    """Wire the mocked transaction chain to return a SUCCESS receipt."""
+    receipt = MagicMock()
+    receipt.status = ResponseCode.SUCCESS
+    transaction = transaction_cls.return_value.set_grpc_deadline.return_value
+    transaction.execute.return_value.get_receipt.return_value = receipt
+    return transaction
+
+
+class TestDeleteFileParams:
+    def test_binds_camel_case_file_id(self):
+        """fileId should bind from the camelCase JSON key."""
+        params = DeleteFileParams.parse_json_params({"sessionId": SESSION_ID, "fileId": "0.0.15432"})
+
+        assert params.fileId == "0.0.15432", "Expected fileId to bind"
+
+    def test_empty_string_is_preserved(self):
+        """An empty fileId must stay distinct from an omitted one."""
+        params = DeleteFileParams.parse_json_params({"sessionId": SESSION_ID, "fileId": ""})
+
+        assert params.fileId == "", "Empty string collapsed to None"
+
+    def test_omitted_file_id_is_none(self):
+        """An omitted fileId should parse as None."""
+        params = DeleteFileParams.parse_json_params({"sessionId": SESSION_ID})
+
+        assert params.fileId is None, "Expected None for omitted fileId"
+
+
+class TestDeleteFile:
+    @patch("tck.handlers.file.FileDeleteTransaction")
+    def test_deletes_valid_file(self, transaction_cls):
+        """Spec test 1: a valid fileId is set on the transaction."""
+        transaction = _success_receipt(transaction_cls)
+
+        result = delete_file(DeleteFileParams.parse_json_params({"sessionId": SESSION_ID, "fileId": "0.0.15432"}))
+
+        assert result.status == "SUCCESS", "Expected SUCCESS status"
+        assert transaction.set_file_id.called, "Expected set_file_id to be called"
+
+    @patch("tck.handlers.file.FileDeleteTransaction")
+    def test_empty_file_id_raises(self, transaction_cls):
+        """Spec test 3: fileId="" raises, surfacing as an SDK internal error."""
+        _success_receipt(transaction_cls)
+        params = DeleteFileParams.parse_json_params({"sessionId": SESSION_ID, "fileId": ""})
+
+        with pytest.raises(ValueError, match="[Ff]ile"):
+            delete_file(params)
+
+    @patch("tck.handlers.file.FileDeleteTransaction")
+    def test_omitted_file_id_submits_zero_id(self, transaction_cls):
+        """Spec test 4: an omitted fileId still reaches the network as 0.0.0."""
+        transaction = _success_receipt(transaction_cls)
+
+        delete_file(DeleteFileParams.parse_json_params({"sessionId": SESSION_ID}))
+
+        set_id = transaction.set_file_id.call_args[0][0]
+        assert str(set_id) == "0.0.0", "Expected 0.0.0"
+
+    @patch("tck.handlers.file.FileDeleteTransaction")
+    def test_invalid_file_id_format_raises(self, transaction_cls):
+        """Spec test 9: a malformed fileId raises before the network call."""
+        _success_receipt(transaction_cls)
+        params = DeleteFileParams.parse_json_params({"sessionId": SESSION_ID, "fileId": "invalid.file.id"})
+
+        with pytest.raises(ValueError, match="[Ff]ile"):
+            delete_file(params)


### PR DESCRIPTION
**Description**:
## Description
Implements the `deleteFile` JSON-RPC method for the TCK server, wrapping
`FileDeleteTransaction`. Modelled on the existing `deleteTopic` handler.

**Related issue(s)**:

Fixes #2492

**Notes for reviewer**:
**1. Bound to `fileId`, not `fileID`.** The issue asked for the capital-ID
key verbatim, based on the spec's input table. But all nine property tests,
the JSON request example, and the JS reference handler use `fileId`. Binding
`fileID` would have broken driver parameter mapping. The spec's input table
looks like a typo — worth a docs fix upstream.

**2. Omitted `fileId` sends `0.0.0`.** The JS reference leaves the field
unset and lets the node return `INVALID_FILE_ID`. The Python SDK raises
`ValueError("Missing required FileID")` locally before the transaction is
built, so an explicit `0.0.0` is used to get the request to the network —
matching spec test 4's expectation.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
