### PR TITLE
chore: reuse shared contract_id fixture in contract update tests

### DIFF
--- a/tests/unit/contract_update_transaction_test.py
+++ b/tests/unit/contract_update_transaction_test.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import pytest
 
 from hiero_sdk_python.account.account_id import AccountId
-from hiero_sdk_python.contract.contract_id import ContractId
 from hiero_sdk_python.contract.contract_update_transaction import (
     ContractUpdateParams,
     ContractUpdateTransaction,
@@ -25,16 +24,10 @@ pytestmark = pytest.mark.unit
 
 
 @pytest.fixture
-def contract_id():
-    """Fixture for contract ID."""
-    return ContractId(0, 0, 123)
-
-
-@pytest.fixture
-def update_params():
+def update_params(contract_id):
     """Fixture for contract update parameters."""
     return {
-        "contract_id": ContractId(0, 0, 123),
+        "contract_id": contract_id,
         "memo": "Updated contract memo",
         "admin_key": PrivateKey.generate().public_key(),
         "auto_renew_period": Duration(7776000),  # 90 days


### PR DESCRIPTION
## Summary

Removes the duplicate local `contract_id` fixture from `tests/unit/contract_update_transaction_test.py` and reuses the shared fixture from `tests/unit/conftest.py`.

- Removed the local `contract_id` fixture (`ContractId(0, 0, 123)`)
- Updated the `update_params` fixture to accept and use the shared `contract_id` fixture
- Removed the unused `ContractId` import
- Confirmed all unit tests in this file pass (`26 passed`)

## Related issue

Fixes #2545

## Checklist

- [x] Worked from a branch up to date with `main`
- [x] No changes outside the scope of this issue
- [x] Commit is GPG-signed and includes DCO sign-off (`git commit -S -s`)
- [x] Issue is linked with `Fixes #2545`
- [x] Unit tests for the changed file pass