### PR TITLE
test(unit): add unit tests for HbarUnit enum

### DIFF
--- a/tests/unit/hbar_unit_test.py
+++ b/tests/unit/hbar_unit_test.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pytest
+
+from hiero_sdk_python import HbarUnit
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    ("unit", "expected_symbol"),
+    [
+        (HbarUnit.TINYBAR, "tℏ"),
+        (HbarUnit.MICROBAR, "μℏ"),
+        (HbarUnit.MILLIBAR, "mℏ"),
+        (HbarUnit.HBAR, "ℏ"),
+        (HbarUnit.KILOBAR, "kℏ"),
+        (HbarUnit.MEGABAR, "Mℏ"),
+        (HbarUnit.GIGABAR, "Gℏ"),
+    ],
+)
+def test_member_symbols(unit: HbarUnit, expected_symbol: str) -> None:
+    assert unit.symbol == expected_symbol
+
+
+@pytest.mark.parametrize(
+    ("unit", "expected_tinybar"),
+    [
+        (HbarUnit.TINYBAR, 1),
+        (HbarUnit.MICROBAR, 10**2),
+        (HbarUnit.MILLIBAR, 10**5),
+        (HbarUnit.HBAR, 10**8),
+        (HbarUnit.KILOBAR, 10**11),
+        (HbarUnit.MEGABAR, 10**14),
+        (HbarUnit.GIGABAR, 10**17),
+    ],
+)
+def test_member_tinybar_factors(unit: HbarUnit, expected_tinybar: int) -> None:
+    assert unit.tinybar == expected_tinybar
+
+
+@pytest.mark.parametrize(
+    ("symbol", "expected_unit"),
+    [
+        ("tℏ", HbarUnit.TINYBAR),
+        ("μℏ", HbarUnit.MICROBAR),
+        ("mℏ", HbarUnit.MILLIBAR),
+        ("ℏ", HbarUnit.HBAR),
+        ("kℏ", HbarUnit.KILOBAR),
+        ("Mℏ", HbarUnit.MEGABAR),
+        ("Gℏ", HbarUnit.GIGABAR),
+    ],
+)
+def test_from_string_valid(symbol: str, expected_unit: HbarUnit) -> None:
+    assert HbarUnit.from_string(symbol) == expected_unit
+
+
+@pytest.mark.parametrize("invalid_symbol", ["", "h", "xyz"])
+def test_from_string_invalid(invalid_symbol: str) -> None:
+    with pytest.raises(ValueError, match=f"^Invalid Hbar unit symbol: {invalid_symbol}$"):
+        HbarUnit.from_string(invalid_symbol)
+
+
+def test_name() -> None:
+    assert len(list(HbarUnit)) == 7
+    assert HbarUnit.TINYBAR.name == "TINYBAR"
+    assert HbarUnit.MICROBAR.name == "MICROBAR"
+    assert HbarUnit.MILLIBAR.name == "MILLIBAR"
+    assert HbarUnit.HBAR.name == "HBAR"
+    assert HbarUnit.KILOBAR.name == "KILOBAR"
+    assert HbarUnit.MEGABAR.name == "MEGABAR"
+    assert HbarUnit.GIGABAR.name == "GIGABAR"

--- a/tests/unit/hbar_unit_test.py
+++ b/tests/unit/hbar_unit_test.py
@@ -21,7 +21,9 @@ pytestmark = pytest.mark.unit
     ],
 )
 def test_member_symbols(unit: HbarUnit, expected_symbol: str) -> None:
-    assert unit.symbol == expected_symbol
+    assert unit.symbol == expected_symbol, (
+        f"Wrong symbol for {unit.name}: expected {expected_symbol!r}, got {unit.symbol!r}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -37,7 +39,9 @@ def test_member_symbols(unit: HbarUnit, expected_symbol: str) -> None:
     ],
 )
 def test_member_tinybar_factors(unit: HbarUnit, expected_tinybar: int) -> None:
-    assert unit.tinybar == expected_tinybar
+    assert unit.tinybar == expected_tinybar, (
+        f"Wrong tinybar factor for {unit.name}: expected {expected_tinybar}, got {unit.tinybar}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -53,7 +57,13 @@ def test_member_tinybar_factors(unit: HbarUnit, expected_tinybar: int) -> None:
     ],
 )
 def test_from_string_valid(symbol: str, expected_unit: HbarUnit) -> None:
-    assert HbarUnit.from_string(symbol) == expected_unit
+    result = HbarUnit.from_string(symbol)
+    assert isinstance(result, HbarUnit), (
+        f"Expected HbarUnit.from_string({symbol!r}) to return HbarUnit"
+    )
+    assert result is expected_unit, (
+        f"Wrong unit for {symbol!r}: expected {expected_unit.name}, got {result.name}"
+    )
 
 
 @pytest.mark.parametrize("invalid_symbol", ["", "h", "xyz"])
@@ -63,11 +73,26 @@ def test_from_string_invalid(invalid_symbol: str) -> None:
 
 
 def test_name() -> None:
-    assert len(list(HbarUnit)) == 7
-    assert HbarUnit.TINYBAR.name == "TINYBAR"
-    assert HbarUnit.MICROBAR.name == "MICROBAR"
-    assert HbarUnit.MILLIBAR.name == "MILLIBAR"
-    assert HbarUnit.HBAR.name == "HBAR"
-    assert HbarUnit.KILOBAR.name == "KILOBAR"
-    assert HbarUnit.MEGABAR.name == "MEGABAR"
-    assert HbarUnit.GIGABAR.name == "GIGABAR"
+    members = list(HbarUnit)
+    assert len(members) == 7, f"Expected 7 members in HbarUnit, found {len(members)}"
+    assert HbarUnit.TINYBAR.name == "TINYBAR", (
+        f"Expected TINYBAR.name to be 'TINYBAR', got {HbarUnit.TINYBAR.name!r}"
+    )
+    assert HbarUnit.MICROBAR.name == "MICROBAR", (
+        f"Expected MICROBAR.name to be 'MICROBAR', got {HbarUnit.MICROBAR.name!r}"
+    )
+    assert HbarUnit.MILLIBAR.name == "MILLIBAR", (
+        f"Expected MILLIBAR.name to be 'MILLIBAR', got {HbarUnit.MILLIBAR.name!r}"
+    )
+    assert HbarUnit.HBAR.name == "HBAR", (
+        f"Expected HBAR.name to be 'HBAR', got {HbarUnit.HBAR.name!r}"
+    )
+    assert HbarUnit.KILOBAR.name == "KILOBAR", (
+        f"Expected KILOBAR.name to be 'KILOBAR', got {HbarUnit.KILOBAR.name!r}"
+    )
+    assert HbarUnit.MEGABAR.name == "MEGABAR", (
+        f"Expected MEGABAR.name to be 'MEGABAR', got {HbarUnit.MEGABAR.name!r}"
+    )
+    assert HbarUnit.GIGABAR.name == "GIGABAR", (
+        f"Expected GIGABAR.name to be 'GIGABAR', got {HbarUnit.GIGABAR.name!r}"
+    )

--- a/tests/unit/hbar_unit_test.py
+++ b/tests/unit/hbar_unit_test.py
@@ -21,6 +21,7 @@ pytestmark = pytest.mark.unit
     ],
 )
 def test_member_symbols(unit: HbarUnit, expected_symbol: str) -> None:
+    """Verify that each HbarUnit enum member returns its expected unit symbol string."""
     assert unit.symbol == expected_symbol, (
         f"Wrong symbol for {unit.name}: expected {expected_symbol!r}, got {unit.symbol!r}"
     )
@@ -39,6 +40,7 @@ def test_member_symbols(unit: HbarUnit, expected_symbol: str) -> None:
     ],
 )
 def test_member_tinybar_factors(unit: HbarUnit, expected_tinybar: int) -> None:
+    """Verify that each HbarUnit enum member returns its expected tinybar conversion factor."""
     assert unit.tinybar == expected_tinybar, (
         f"Wrong tinybar factor for {unit.name}: expected {expected_tinybar}, got {unit.tinybar}"
     )
@@ -57,42 +59,31 @@ def test_member_tinybar_factors(unit: HbarUnit, expected_tinybar: int) -> None:
     ],
 )
 def test_from_string_valid(symbol: str, expected_unit: HbarUnit) -> None:
+    """Verify that HbarUnit.from_string converts valid symbol strings to the expected HbarUnit member."""
     result = HbarUnit.from_string(symbol)
-    assert isinstance(result, HbarUnit), (
-        f"Expected HbarUnit.from_string({symbol!r}) to return HbarUnit"
-    )
-    assert result is expected_unit, (
-        f"Wrong unit for {symbol!r}: expected {expected_unit.name}, got {result.name}"
-    )
+    assert isinstance(result, HbarUnit), f"Expected HbarUnit.from_string({symbol!r}) to return HbarUnit"
+    assert result is expected_unit, f"Wrong unit for {symbol!r}: expected {expected_unit.name}, got {result.name}"
 
 
 @pytest.mark.parametrize("invalid_symbol", ["", "h", "xyz"])
 def test_from_string_invalid(invalid_symbol: str) -> None:
+    """Verify that HbarUnit.from_string raises a ValueError for invalid symbol strings."""
     with pytest.raises(ValueError, match=f"^Invalid Hbar unit symbol: {invalid_symbol}$"):
         HbarUnit.from_string(invalid_symbol)
 
 
 def test_name() -> None:
+    """Verify that HbarUnit enum has all expected members and correct member name attributes."""
     members = list(HbarUnit)
     assert len(members) == 7, f"Expected 7 members in HbarUnit, found {len(members)}"
-    assert HbarUnit.TINYBAR.name == "TINYBAR", (
-        f"Expected TINYBAR.name to be 'TINYBAR', got {HbarUnit.TINYBAR.name!r}"
-    )
+    assert HbarUnit.TINYBAR.name == "TINYBAR", f"Expected TINYBAR.name to be 'TINYBAR', got {HbarUnit.TINYBAR.name!r}"
     assert HbarUnit.MICROBAR.name == "MICROBAR", (
         f"Expected MICROBAR.name to be 'MICROBAR', got {HbarUnit.MICROBAR.name!r}"
     )
     assert HbarUnit.MILLIBAR.name == "MILLIBAR", (
         f"Expected MILLIBAR.name to be 'MILLIBAR', got {HbarUnit.MILLIBAR.name!r}"
     )
-    assert HbarUnit.HBAR.name == "HBAR", (
-        f"Expected HBAR.name to be 'HBAR', got {HbarUnit.HBAR.name!r}"
-    )
-    assert HbarUnit.KILOBAR.name == "KILOBAR", (
-        f"Expected KILOBAR.name to be 'KILOBAR', got {HbarUnit.KILOBAR.name!r}"
-    )
-    assert HbarUnit.MEGABAR.name == "MEGABAR", (
-        f"Expected MEGABAR.name to be 'MEGABAR', got {HbarUnit.MEGABAR.name!r}"
-    )
-    assert HbarUnit.GIGABAR.name == "GIGABAR", (
-        f"Expected GIGABAR.name to be 'GIGABAR', got {HbarUnit.GIGABAR.name!r}"
-    )
+    assert HbarUnit.HBAR.name == "HBAR", f"Expected HBAR.name to be 'HBAR', got {HbarUnit.HBAR.name!r}"
+    assert HbarUnit.KILOBAR.name == "KILOBAR", f"Expected KILOBAR.name to be 'KILOBAR', got {HbarUnit.KILOBAR.name!r}"
+    assert HbarUnit.MEGABAR.name == "MEGABAR", f"Expected MEGABAR.name to be 'MEGABAR', got {HbarUnit.MEGABAR.name!r}"
+    assert HbarUnit.GIGABAR.name == "GIGABAR", f"Expected GIGABAR.name to be 'GIGABAR', got {HbarUnit.GIGABAR.name!r}"


### PR DESCRIPTION
**Description**:
Add unit tests for the `HbarUnit` enum to ensure full test coverage of unit symbols, tinybar conversion factors, string parsing, and error handling.

* Add unit tests for `HbarUnit` enum member symbols and tinybar scale factors
* Add tests for `HbarUnit.from_string()` with valid symbols and invalid inputs
* Add assertions for `HbarUnit` member count and `.name` attributes

Fixes #2554 

**Notes for reviewer**:
All 25 unit tests in `tests/unit/hbar_unit_test.py` pass cleanly. No production code was modified.
