### PR TITLE
bug: add missing py-test marker

### DIFF
--- a/tests/unit/file_append_transaction_test.py
+++ b/tests/unit/file_append_transaction_test.py
@@ -29,6 +29,9 @@ from hiero_sdk_python.transaction.transaction_response import TransactionRespons
 from tests.unit.mock_server import mock_hedera_servers
 
 
+pytestmark = pytest.mark.unit
+
+
 def test_constructor_with_parameters():
     """Test creating a file append transaction with constructor parameters."""
     file_id = FileId(0, 0, 12345)

--- a/tests/unit/query_nodes_test.py
+++ b/tests/unit/query_nodes_test.py
@@ -8,6 +8,9 @@ from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.query.query import Query
 
 
+pytestmark = pytest.mark.unit
+
+
 def test_set_single_node_account_id():
     q = Query()
     node = AccountId(0, 0, 3)

--- a/tests/unit/subscription_handle_test.py
+++ b/tests/unit/subscription_handle_test.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from unittest.mock import Mock
 
+import pytest
+
 from hiero_sdk_python.utils.subscription_handle import SubscriptionHandle
+
+
+pytestmark = pytest.mark.unit
 
 
 def test_not_cancelled_by_default():

--- a/tests/unit/token_airdrop_pending_record_test.py
+++ b/tests/unit/token_airdrop_pending_record_test.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import pytest
+
 from hiero_sdk_python.hapi.services import basic_types_pb2, transaction_record_pb2
 from hiero_sdk_python.tokens.nft_id import NftId
 from hiero_sdk_python.tokens.token_airdrop_pending_id import PendingAirdropId
 from hiero_sdk_python.tokens.token_airdrop_pending_record import PendingAirdropRecord
+
+
+pytestmark = pytest.mark.unit
 
 
 def test_pending_airdrop_record_constructor(mock_account_ids):

--- a/tests/unit/transaction_nodes_test.py
+++ b/tests/unit/transaction_nodes_test.py
@@ -8,6 +8,9 @@ from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.transaction.transaction import Transaction
 
 
+pytestmark = pytest.mark.unit
+
+
 class DummyTransaction(Transaction):
     """
     Minimal subclass of Transaction for testing.


### PR DESCRIPTION
**Description**:
Add module-level `pytestmark = pytest.mark.unit` marker to five unit test files under `tests/unit/` so that running `uv run pytest -m unit` consistently selects and executes their tests.

* Add `pytestmark = pytest.mark.unit` marker to `tests/unit/file_append_transaction_test.py`
* Add `pytestmark = pytest.mark.unit` marker to `tests/unit/query_nodes_test.py`
* Add `pytestmark = pytest.mark.unit` marker to `tests/unit/transaction_nodes_test.py`
* Import `pytest` and add `pytestmark = pytest.mark.unit` marker to `tests/unit/subscription_handle_test.py`
* Import `pytest` and add `pytestmark = pytest.mark.unit` marker to `tests/unit/token_airdrop_pending_record_test.py`


**Related issue(s)**:

Fixes #2558 

**Notes for reviewer**:

Verified by running `uv run pytest -m unit` across the targeted test files. All 42 tests in these files (19 + 6 + 6 + 6 + 5) are now properly collected and pass under the `unit` marker filter:
```text
collected 42 items
tests/unit/file_append_transaction_test.py ...................           [ 45%]
tests/unit/query_nodes_test.py ......                                    [ 59%]
tests/unit/transaction_nodes_test.py ......                              [ 73%]
tests/unit/subscription_handle_test.py ......                            [ 88%]
tests/unit/token_airdrop_pending_record_test.py .....                    [100%]
============================== 42 passed in 0.48s ==============================

