### PR TITLE
Add complete type hints to SubscriptionHandle

### DIFF
--- a/src/hiero_sdk_python/utils/subscription_handle.py
+++ b/src/hiero_sdk_python/utils/subscription_handle.py
@@ -11,13 +11,13 @@ class SubscriptionHandle:
     Calling .cancel() will signal the subscription thread to stop.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._cancelled = threading.Event()
         self._thread: threading.Thread | None = None
         self._call: Any | None = None
         self._lock = threading.Lock()
 
-    def _set_call(self, call: Any):
+    def _set_call(self, call: Any) -> None:
         """Sets the active gRPC call so it can be cancelled."""
         should_cancel = False
 
@@ -30,7 +30,7 @@ class SubscriptionHandle:
         if should_cancel:
             self._call.cancel()
 
-    def cancel(self):
+    def cancel(self) -> None:
         """Signals to cancel the subscription."""
         should_cancel = False
 
@@ -47,11 +47,16 @@ class SubscriptionHandle:
         """Returns True if this subscription is already cancelled."""
         return self._cancelled.is_set()
 
-    def set_thread(self, thread: threading.Thread):
+    def set_thread(self, thread: threading.Thread) -> None:
         """(Optional) Store the thread object for reference."""
         self._thread = thread
 
-    def join(self, timeout=None):
-        """(Optional) Wait for the subscription thread to end."""
+    def join(self, timeout: float | None = None) -> None:
+        """(Optional) Wait for the subscription thread to end.
+
+        Args:
+            timeout: Maximum time to wait in seconds. ``None`` means
+                wait indefinitely.
+        """
         if self._thread:
             self._thread.join(timeout)


### PR DESCRIPTION
## Description

This PR adds complete type hints to the `SubscriptionHandle` class in `src/hiero_sdk_python/utils/subscription_handle.py`, as requested in #2560.

(This is a re-open of #2562 — the previous PR was accidentally closed when the branch was recreated with DCO sign-off and GPG signing as requested by @danielmarv.)

## Changes

This is a **types-only change** — no method bodies or behavior are modified.

- Added `-> None` return annotation to `__init__`
- Added `-> None` return annotation to `_set_call` (kept existing `call: Any` param annotation)
- Added `-> None` return annotation to `cancel`
- Added `-> None` return annotation to `set_thread` (kept existing `thread: threading.Thread` param annotation)
- Updated `join(self, timeout=None)` → `join(self, timeout: float | None = None) -> None`
  - Used `float | None` since the value passes directly to `threading.Thread.join(timeout)`, which takes seconds as a float or `None`
  - Added a Google-style `Args:` docstring block for `timeout`
- `is_cancelled` was already fully annotated — left unchanged

## Conventions

Follows the typing conventions in `docs/sdk_developers/types.md`:
- PEP 604 union syntax (`float | None`) over `Optional[float]`
- Inline type hints over repeating types in docstrings
- The file already has `from __future__ import annotations` at the top, so this union syntax works on Python 3.10

## DCO & GPG Sign-off

Commit includes:
- `Signed-off-by: Samir <as7111771-create@users.noreply.github.com>` (DCO)
- GPG signature

Closes #2560