### PR TITLE
feat: add add_custom_fee to TopicUpdateTransaction

### DIFF
--- a/src/hiero_sdk_python/consensus/topic_update_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_update_transaction.py
@@ -213,6 +213,24 @@ class TopicUpdateTransaction(Transaction):
         self.fee_exempt_keys = keys
         return self
 
+    def add_custom_fee(self, custom_fee: CustomFixedFee) -> TopicUpdateTransaction:
+        """
+        Adds a single custom fixed fee to the transaction's custom fee list.
+
+        Args:
+            custom_fee (CustomFixedFee): The custom fixed fee to add.
+
+        Returns:
+            TopicUpdateTransaction: The current instance for method chaining.
+        """
+
+        self._require_not_frozen()
+
+        if self.custom_fees is None:
+            self.custom_fees = []
+        self.custom_fees.append(custom_fee)
+        return self
+
     def clear_custom_fees(self) -> TopicUpdateTransaction:
         """
         Clears the custom fees for the topic update transaction and

--- a/src/hiero_sdk_python/consensus/topic_update_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_update_transaction.py
@@ -226,6 +226,9 @@ class TopicUpdateTransaction(Transaction):
 
         self._require_not_frozen()
 
+        if not isinstance(custom_fee, CustomFixedFee):
+            raise TypeError("custom_fee must be a CustomFixedFee")
+
         if self.custom_fees is None:
             self.custom_fees = []
         self.custom_fees.append(custom_fee)

--- a/tests/unit/topic_update_transaction_test.py
+++ b/tests/unit/topic_update_transaction_test.py
@@ -479,8 +479,10 @@ def test_add_custom_fee_type_error():
     """Test passing None or a non-CustomFixedFee argument raises TypeError."""
     tx = TopicUpdateTransaction()
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="custom_fee must be a CustomFixedFee"):
         tx.add_custom_fee("this_is_a_string")  # type: ignore
+    assert tx.custom_fees is None, "Invalid input must not change custom_fees"
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="custom_fee must be a CustomFixedFee"):
         tx.add_custom_fee(None)  # type: ignore
+    assert tx.custom_fees is None, "Invalid input must not change custom_fees"

--- a/tests/unit/topic_update_transaction_test.py
+++ b/tests/unit/topic_update_transaction_test.py
@@ -441,3 +441,35 @@ def test_auto_renew_period_omitted_when_unset(
     body = tx.build_transaction_body().consensusUpdateTopic
 
     assert not body.HasField("autoRenewPeriod")
+
+
+def test_add_custom_fee():
+    """Test adding a custom fee to the transaction."""
+    tx = TopicUpdateTransaction()
+    fee1 = CustomFixedFee(100, fee_collector_account_id=AccountId(0, 0, 123))
+    fee2 = CustomFixedFee(200, fee_collector_account_id=AccountId(0, 0, 456))
+
+    result = tx.add_custom_fee(fee1)
+
+    assert len(tx.custom_fees) == 1
+    assert tx.custom_fees[0] == fee1
+    assert result is tx
+
+    tx.add_custom_fee(fee2)
+
+    assert len(tx.custom_fees) == 2
+    assert tx.custom_fees[0] == fee1
+    assert tx.custom_fees[1] == fee2
+
+
+def test_add_custom_fee_frozen(mock_client, topic_id):
+    """Test calling add_custom_fee() after freezing raises an exception."""
+    tx = TopicUpdateTransaction()
+
+    tx.set_topic_id(topic_id)
+    tx.freeze_with(mock_client)
+
+    fee = CustomFixedFee(100, fee_collector_account_id=AccountId(0, 0, 123))
+
+    with pytest.raises(Exception, match="Transaction is immutable; it has been frozen"):
+        tx.add_custom_fee(fee)

--- a/tests/unit/topic_update_transaction_test.py
+++ b/tests/unit/topic_update_transaction_test.py
@@ -473,3 +473,14 @@ def test_add_custom_fee_frozen(mock_client, topic_id):
 
     with pytest.raises(Exception, match="Transaction is immutable; it has been frozen"):
         tx.add_custom_fee(fee)
+
+
+def test_add_custom_fee_type_error():
+    """Test passing None or a non-CustomFixedFee argument raises TypeError."""
+    tx = TopicUpdateTransaction()
+
+    with pytest.raises(TypeError):
+        tx.add_custom_fee("this_is_a_string")  # type: ignore
+
+    with pytest.raises(TypeError):
+        tx.add_custom_fee(None)  # type: ignore


### PR DESCRIPTION
**Description**:
Adds the `add_custom_fee()` convenience method to `TopicUpdateTransaction` to maintain API consistency across the SDKs. This allows appending a single `CustomFixedFee` to the transaction's custom fee list easily.

* Add `add_custom_fee()` method to `TopicUpdateTransaction`
* Validate transaction mutability using `_require_not_frozen()` prior to modifying state
* Handle `None` state initialization to safely distinguish between unmodified and cleared network states
* Add unit tests verifying successful fee appending, method chaining, and frozen state exception handling

**Related issue(s)**:

Fixes #2447

**Notes for reviewer**:
Implemented following the pattern established in the Java SDK. Tested locally to ensure `TypeError` is avoided on uninitialized lists and that transaction immutability is respected. 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)