### PR TITLE
chore: update gfi assignment limit to 1

### DIFF
--- a/.github/scripts/shared/config.js
+++ b/.github/scripts/shared/config.js
@@ -58,7 +58,7 @@ const CONFIG = {
 
   // Maximum simultaneous assignments .
   assignmentLimits: {
-    [LEVEL_KEYS.GFI]: 2,
+    [LEVEL_KEYS.GFI]: 1,
     [LEVEL_KEYS.BEGINNER]: 2,
     [LEVEL_KEYS.INTERMEDIATE]: 2,
     [LEVEL_KEYS.ADVANCED]: 2,


### PR DESCRIPTION
**Description**:
Update the `/assign` bot configuration to limit simultaneous Good First Issue assignments to 1 per contributor, ensuring beginner-friendly issues remain available for new contributors.

* Limit GFI maximum simultaneous assignments from 2 to 1 in `CONFIG.assignmentLimits`
* Keep limits for beginner, intermediate, and advanced levels unchanged at 2
* Keep spam policy assignment limit unchanged at 1

**Related issue(s)**: 

Fixes #2561

**Notes for reviewer**:
Verified locally by running the Jest test suite in `.github/scripts/`:
- All 12 test suites (241 tests) passed successfully.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
