### PR TITLE
feat: strip review queue labels from PRs converted to draft

### DIFF
--- a/.github/scripts/__tests__/jest/labels.test.js
+++ b/.github/scripts/__tests__/jest/labels.test.js
@@ -451,4 +451,23 @@ describe('stripQueueLabels', () => {
     expect(changed).toBe(true);
     expect(mock.calls.labelsRemoved).toHaveLength(0);
   });
+
+  test('non-404 removal error → propagates', async () => {
+    const mock = createMockGithub({
+      removeLabelServerError: ['queue:maintainers'],
+    });
+
+    await expect(
+      stripQueueLabels(
+        mock,
+        'o',
+        'r',
+        {
+          number: 1,
+          labels: [{ name: 'queue:maintainers' }],
+        },
+        false
+      )
+    ).rejects.toThrow('Internal server error');
+  });
 });

--- a/.github/scripts/__tests__/jest/labels.test.js
+++ b/.github/scripts/__tests__/jest/labels.test.js
@@ -8,6 +8,7 @@ const {
   determineLabel,
   ensureLabel,
   syncLabel,
+  stripQueueLabels,
 } = require('../../review-sync/helpers/labels');
 const {
   QUEUE_LABELS,
@@ -365,5 +366,89 @@ describe('syncLabel', () => {
     expect(changed).toBe(true);
     expect(mock.calls.labelsAdded)
       .toContain(COMMUNITY_REVIEW.name);
+  });
+});
+
+describe('stripQueueLabels', () => {
+  test('draft with queue + community labels → removes both', async () => {
+    const mock = createMockGithub({});
+
+    const changed = await stripQueueLabels(
+      mock,
+      'o',
+      'r',
+      {
+        number: 1,
+        labels: [
+          { name: 'queue:junior-committer' },
+          { name: COMMUNITY_REVIEW.name },
+        ],
+      },
+      false
+    );
+
+    expect(changed).toBe(true);
+    expect(mock.calls.labelsRemoved).toContain('queue:junior-committer');
+    expect(mock.calls.labelsRemoved).toContain(COMMUNITY_REVIEW.name);
+  });
+
+  test('draft with no managed labels → no-op', async () => {
+    const mock = createMockGithub({});
+
+    const changed = await stripQueueLabels(
+      mock,
+      'o',
+      'r',
+      {
+        number: 1,
+        labels: [{ name: 'some-unrelated-label' }],
+      },
+      false
+    );
+
+    expect(changed).toBe(false);
+    expect(mock.calls.labelsRemoved).toHaveLength(0);
+  });
+
+  test('404 on removal → tolerated, run continues', async () => {
+    const mock = createMockGithub({
+      removeLabelNotFound: ['queue:committers'],
+    });
+
+    const changed = await stripQueueLabels(
+      mock,
+      'o',
+      'r',
+      {
+        number: 1,
+        labels: [
+          { name: 'queue:committers' },
+          { name: COMMUNITY_REVIEW.name },
+        ],
+      },
+      false
+    );
+
+    expect(changed).toBe(true);
+    expect(mock.calls.labelsRemoved).not.toContain('queue:committers');
+    expect(mock.calls.labelsRemoved).toContain(COMMUNITY_REVIEW.name);
+  });
+
+  test('dry run → logs only, no mutations', async () => {
+    const mock = createMockGithub({});
+
+    const changed = await stripQueueLabels(
+      mock,
+      'o',
+      'r',
+      {
+        number: 1,
+        labels: [{ name: 'status: ready-to-merge' }],
+      },
+      true
+    );
+
+    expect(changed).toBe(true);
+    expect(mock.calls.labelsRemoved).toHaveLength(0);
   });
 });

--- a/.github/scripts/__tests__/jest/on-converted-to-draft.test.js
+++ b/.github/scripts/__tests__/jest/on-converted-to-draft.test.js
@@ -1,0 +1,150 @@
+// __tests__/jest/on-converted-to-draft.test.js
+//
+// Run from .github/scripts:
+// npm run test:js -- on-converted-to-draft.test.js
+
+const { createMockGithub } = require('./test-utils');
+const onConvertedToDraft = require('../../review-sync/on-converted-to-draft');
+const { COMMUNITY_REVIEW } = require('../../review-sync/helpers/constants');
+
+function createContext(pr) {
+  return {
+    repo: { owner: 'o', repo: 'r' },
+    payload: { pull_request: pr },
+  };
+}
+
+function createCore() {
+  return { setFailed: jest.fn() };
+}
+
+describe('on-converted-to-draft', () => {
+  afterEach(() => {
+    delete process.env.DRY_RUN;
+    delete process.env.PR_NUMBER;
+  });
+
+  test('draft PR with managed labels → strips them', async () => {
+    const mock = createMockGithub({});
+    const core = createCore();
+    const pr = {
+      number: 1,
+      draft: true,
+      labels: [{ name: 'queue:junior-committer' }, { name: COMMUNITY_REVIEW.name }],
+    };
+
+    await onConvertedToDraft({ github: mock, context: createContext(pr), core });
+
+    expect(mock.calls.labelsRemoved).toContain('queue:junior-committer');
+    expect(mock.calls.labelsRemoved).toContain(COMMUNITY_REVIEW.name);
+    expect(core.setFailed).not.toHaveBeenCalled();
+  });
+
+  test('non-draft PR in payload → skips cleanup', async () => {
+    const mock = createMockGithub({});
+    const core = createCore();
+    const pr = {
+      number: 2,
+      draft: false,
+      labels: [{ name: 'queue:committers' }],
+    };
+
+    await onConvertedToDraft({ github: mock, context: createContext(pr), core });
+
+    expect(mock.calls.labelsRemoved).toHaveLength(0);
+    expect(core.setFailed).not.toHaveBeenCalled();
+  });
+
+  test('no pull_request in payload and no PR_NUMBER → setFailed, no fetch', async () => {
+    const mock = createMockGithub({});
+    const core = createCore();
+
+    await onConvertedToDraft({ github: mock, context: createContext(undefined), core });
+
+    expect(core.setFailed).toHaveBeenCalledWith(
+      'No pull_request in payload and no PR_NUMBER provided.'
+    );
+    expect(mock.calls.pullsFetched).toHaveLength(0);
+  });
+
+  test('no pull_request in payload, PR_NUMBER set → fetches PR then cleans', async () => {
+    process.env.PR_NUMBER = '7';
+    const mock = createMockGithub({
+      prData: {
+        number: 7,
+        draft: true,
+        labels: [{ name: 'queue:maintainers' }],
+      },
+    });
+    const core = createCore();
+
+    await onConvertedToDraft({ github: mock, context: createContext(undefined), core });
+
+    expect(mock.calls.pullsFetched).toEqual([7]);
+    expect(mock.calls.labelsRemoved).toContain('queue:maintainers');
+    expect(core.setFailed).not.toHaveBeenCalled();
+  });
+
+  test('pulls.get rejects → setFailed with contextual message, no throw', async () => {
+    process.env.PR_NUMBER = '8';
+    const mock = createMockGithub({});
+    const core = createCore();
+
+    await onConvertedToDraft({ github: mock, context: createContext(undefined), core });
+
+    expect(mock.calls.pullsFetched).toEqual([8]);
+    expect(core.setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to clean draft PR #8')
+    );
+  });
+
+  test('fetched PR is not a draft → skips cleanup', async () => {
+    process.env.PR_NUMBER = '9';
+    const mock = createMockGithub({
+      prData: {
+        number: 9,
+        draft: false,
+        labels: [{ name: 'queue:committers' }],
+      },
+    });
+    const core = createCore();
+
+    await onConvertedToDraft({ github: mock, context: createContext(undefined), core });
+
+    expect(mock.calls.labelsRemoved).toHaveLength(0);
+    expect(core.setFailed).not.toHaveBeenCalled();
+  });
+
+  test('dry run → does not remove labels', async () => {
+    process.env.DRY_RUN = 'true';
+    const mock = createMockGithub({});
+    const core = createCore();
+    const pr = {
+      number: 3,
+      draft: true,
+      labels: [{ name: 'queue:committers' }],
+    };
+
+    await onConvertedToDraft({ github: mock, context: createContext(pr), core });
+
+    expect(mock.calls.labelsRemoved).toHaveLength(0);
+  });
+
+  test('cleanup failure → setFailed with contextual message', async () => {
+    const mock = createMockGithub({
+      removeLabelServerError: ['queue:committers'],
+    });
+    const core = createCore();
+    const pr = {
+      number: 4,
+      draft: true,
+      labels: [{ name: 'queue:committers' }],
+    };
+
+    await onConvertedToDraft({ github: mock, context: createContext(pr), core });
+
+    expect(core.setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to clean draft PR #4')
+    );
+  });
+});

--- a/.github/scripts/__tests__/jest/review-sync-drafts.test.js
+++ b/.github/scripts/__tests__/jest/review-sync-drafts.test.js
@@ -1,0 +1,161 @@
+// __tests__/jest/review-sync-drafts.test.js
+//
+// Run from .github/scripts:
+// npm run test:js -- review-sync-drafts.test.js
+//
+// Covers the draft-cleanup path of the Review Queue Label Sync cron job
+// (index.js steps 1, 2, 3, 5, 6): rate-limit guard, fetching + splitting
+// open PRs into draft/non-draft, and stripping managed labels off drafts.
+// Non-draft syncLabel logic itself is covered by labels.test.js.
+
+const { createMockGithub } = require('./test-utils');
+const reviewSync = require('../../review-sync');
+const { COMMUNITY_REVIEW, QUEUE_LABELS } = require('../../review-sync/helpers/constants');
+
+function createContext() {
+  return { repo: { owner: 'o', repo: 'r' } };
+}
+
+function createCore() {
+  return { setFailed: jest.fn() };
+}
+
+function draftPr(number, labelNames) {
+  return {
+    number,
+    draft: true,
+    labels: labelNames.map((name) => ({ name })),
+    head: { sha: `sha${number}` },
+    user: { type: 'User' },
+  };
+}
+
+function nonDraftPr(number, labelNames = []) {
+  return {
+    number,
+    draft: false,
+    labels: labelNames.map((name) => ({ name })),
+    head: { sha: `sha${number}` },
+    user: { type: 'User' },
+  };
+}
+
+describe('review-sync draft cleanup (index.js)', () => {
+  afterEach(() => {
+    delete process.env.DRY_RUN;
+  });
+
+  test('cleans managed labels off every draft PR', async () => {
+    const mock = createMockGithub({
+      existingLabels: {
+        [QUEUE_LABELS.JUNIOR.name]: true,
+        [QUEUE_LABELS.COMMITTERS.name]: true,
+        [QUEUE_LABELS.MAINTAINERS.name]: true,
+        [QUEUE_LABELS.MERGE.name]: true,
+        [COMMUNITY_REVIEW.name]: true,
+      },
+      prList: [
+        draftPr(1, ['queue:junior-committer', COMMUNITY_REVIEW.name]),
+        draftPr(2, ['queue:committers']),
+      ],
+    });
+    const core = createCore();
+
+    await reviewSync({ github: mock, context: createContext(), core });
+
+    expect(mock.calls.labelsRemoved).toEqual(
+      expect.arrayContaining(['queue:junior-committer', COMMUNITY_REVIEW.name, 'queue:committers'])
+    );
+    expect(core.setFailed).not.toHaveBeenCalled();
+  });
+
+  test('draft with no managed labels → no removals, no error', async () => {
+    const mock = createMockGithub({
+      existingLabels: { [COMMUNITY_REVIEW.name]: true },
+      prList: [draftPr(3, ['some-unrelated-label'])],
+    });
+    const core = createCore();
+
+    await reviewSync({ github: mock, context: createContext(), core });
+
+    expect(mock.calls.labelsRemoved).toHaveLength(0);
+    expect(core.setFailed).not.toHaveBeenCalled();
+  });
+
+  test('mixed draft + non-draft PRs → only the draft is stripped', async () => {
+    const mock = createMockGithub({
+      roles: {},
+      reviews: [],
+      existingLabels: {},
+      prList: [draftPr(4, ['queue:maintainers']), nonDraftPr(5)],
+    });
+    const core = createCore();
+
+    await reviewSync({ github: mock, context: createContext(), core });
+
+    expect(mock.calls.labelsRemoved).toContain('queue:maintainers');
+    expect(mock.calls.labelsAdded).toContain('queue:junior-committer');
+  });
+
+  test('404 on draft label removal → tolerated, run succeeds', async () => {
+    const mock = createMockGithub({
+      existingLabels: {},
+      removeLabelNotFound: ['queue:committers'],
+      prList: [draftPr(6, ['queue:committers'])],
+    });
+    const core = createCore();
+
+    await reviewSync({ github: mock, context: createContext(), core });
+
+    expect(mock.calls.labelsRemoved).not.toContain('queue:committers');
+    expect(core.setFailed).not.toHaveBeenCalled();
+  });
+
+  test('non-404 removal error on a draft → reported via setFailed', async () => {
+    const mock = createMockGithub({
+      existingLabels: {},
+      removeLabelServerError: ['queue:maintainers'],
+      prList: [draftPr(7, ['queue:maintainers'])],
+    });
+    const core = createCore();
+
+    await reviewSync({ github: mock, context: createContext(), core });
+
+    expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining('1 error(s)'));
+  });
+
+  test('dry run → logs only, no draft labels removed', async () => {
+    process.env.DRY_RUN = 'true';
+    const mock = createMockGithub({
+      existingLabels: {},
+      prList: [draftPr(8, ['queue:committers'])],
+    });
+    const core = createCore();
+
+    await reviewSync({ github: mock, context: createContext(), core });
+
+    expect(mock.calls.labelsRemoved).toHaveLength(0);
+  });
+
+  test('rate limit below floor → skips entirely, nothing fetched', async () => {
+    const mock = createMockGithub({ prList: [draftPr(9, ['queue:committers'])] });
+    mock.rest.rateLimit.get = async () => ({
+      data: { resources: { core: { remaining: 10 } } },
+    });
+    const core = createCore();
+
+    await reviewSync({ github: mock, context: createContext(), core });
+
+    expect(mock.calls.labelsRemoved).toHaveLength(0);
+    expect(mock.calls.labelsChecked).toHaveLength(0);
+  });
+
+  test('no open PRs at all → exits without ensuring labels', async () => {
+    const mock = createMockGithub({ prList: [] });
+    const core = createCore();
+
+    await reviewSync({ github: mock, context: createContext(), core });
+
+    expect(mock.calls.labelsChecked).toHaveLength(0);
+  });
+});

--- a/.github/scripts/__tests__/jest/test-utils.js
+++ b/.github/scripts/__tests__/jest/test-utils.js
@@ -23,6 +23,9 @@
  * @param {string[]} options.removeLabelNotFound
  *   Label names for which removeLabel() should throw a 404, simulating a
  *   label that's already gone (race condition or manual removal)
+ * @param {string[]} options.removeLabelServerError
+ *   Label names for which removeLabel() should throw a 500, simulating an
+ *   unexpected API failure that should NOT be swallowed
  * @returns {{ calls: object, rest: object, paginate: function }}
  */
 function createMockGithub(options = {}) {
@@ -32,6 +35,7 @@ function createMockGithub(options = {}) {
     existingLabels = {},
     checkRuns = [],
     removeLabelNotFound = [],
+    removeLabelServerError = [],
   } = options;
 
   const calls = {
@@ -80,6 +84,9 @@ function createMockGithub(options = {}) {
         removeLabel: async ({ name }) => {
           if (removeLabelNotFound.includes(name)) {
             throw Object.assign(new Error('Not found'), { status: 404 });
+          }
+          if (removeLabelServerError.includes(name)) {
+            throw Object.assign(new Error('Internal server error'), { status: 500 });
           }
           calls.labelsRemoved.push(name);
           return {};

--- a/.github/scripts/__tests__/jest/test-utils.js
+++ b/.github/scripts/__tests__/jest/test-utils.js
@@ -26,6 +26,12 @@
  * @param {string[]} options.removeLabelServerError
  *   Label names for which removeLabel() should throw a 500, simulating an
  *   unexpected API failure that should NOT be swallowed
+ * @param {object|null} options.prData
+ *   Single PR object returned by pulls.get(). Defaults to a 404, simulating
+ *   a PR number that doesn't exist.
+ * @param {Array} options.prList
+ *   Array of PR objects returned by pulls.list() (and therefore paginate()),
+ *   simulating the open-PR listing the review-sync cron job fetches.
  * @returns {{ calls: object, rest: object, paginate: function }}
  */
 function createMockGithub(options = {}) {
@@ -36,6 +42,8 @@ function createMockGithub(options = {}) {
     checkRuns = [],
     removeLabelNotFound = [],
     removeLabelServerError = [],
+    prData = null,
+    prList = [],
   } = options;
 
   const calls = {
@@ -44,6 +52,7 @@ function createMockGithub(options = {}) {
     labelsCreated: [],
     labelsChecked: [],
     permissionsChecked: [],
+    pullsFetched: [],
   };
 
   const mock = {
@@ -61,6 +70,14 @@ function createMockGithub(options = {}) {
       },
       pulls: {
         listReviews: async () => ({ data: reviews }),
+        list: async () => ({ data: prList }),
+        get: async ({ pull_number }) => {
+          calls.pullsFetched.push(pull_number);
+          if (!prData) {
+            throw Object.assign(new Error('Not found'), { status: 404 });
+          }
+          return { data: prData };
+        },
       },
       checks: {
         listForRef: async () => ({ data: { check_runs: checkRuns } }),

--- a/.github/scripts/__tests__/jest/test-utils.js
+++ b/.github/scripts/__tests__/jest/test-utils.js
@@ -20,6 +20,9 @@
  *   Array of review objects returned by pulls.listReviews
  * @param {Record<string, boolean>} options.existingLabels
  *   Map of label name → true (label exists in repo)
+ * @param {string[]} options.removeLabelNotFound
+ *   Label names for which removeLabel() should throw a 404, simulating a
+ *   label that's already gone (race condition or manual removal)
  * @returns {{ calls: object, rest: object, paginate: function }}
  */
 function createMockGithub(options = {}) {
@@ -28,6 +31,7 @@ function createMockGithub(options = {}) {
     reviews = [],
     existingLabels = {},
     checkRuns = [],
+    removeLabelNotFound = [],
   } = options;
 
   const calls = {
@@ -74,6 +78,9 @@ function createMockGithub(options = {}) {
           return {};
         },
         removeLabel: async ({ name }) => {
+          if (removeLabelNotFound.includes(name)) {
+            throw Object.assign(new Error('Not found'), { status: 404 });
+          }
           calls.labelsRemoved.push(name);
           return {};
         },

--- a/.github/scripts/review-sync/helpers/constants.js
+++ b/.github/scripts/review-sync/helpers/constants.js
@@ -43,12 +43,12 @@ const QUEUE_LABELS = {
 const ALL_QUEUE_LABEL_NAMES = Object.values(QUEUE_LABELS).map((l) => l.name);
 
 /**
- * The permanent community review label appended to all open PRs.
+ * The permanent community review label appended to all open non-draft PRs.
  */
 const COMMUNITY_REVIEW = {
   name: 'open to community review',
   color: '008672',
-  description: 'PR is open for community review and feedback',
+  description: 'PR is open for community review and feedback (non-draft only)',
 };
 
 module.exports = { RATE_LIMIT_FLOOR, QUEUE_LABELS, ALL_QUEUE_LABEL_NAMES, COMMUNITY_REVIEW };

--- a/.github/scripts/review-sync/helpers/labels.js
+++ b/.github/scripts/review-sync/helpers/labels.js
@@ -240,4 +240,63 @@ async function syncLabel(github, owner, repo, pr, dryRun) {
   return true;
 }
 
-module.exports = { ensureLabel, determineLabel, syncLabel, hasCIFailures };
+/**
+ * Strip all managed queue/community-review labels from a single PR.
+ *
+ * Used for draft PRs, where the goal is the opposite of syncLabel(): zero
+ * managed labels rather than exactly one queue label. Plain removal is fine
+ * here, so this does not need the add-before-remove ordering syncLabel uses.
+ *
+ * Skips countApprovals/hasCIFailures entirely — cleanup doesn't need approval
+ * or CI data, and skipping those calls protects the rate-limit budget.
+ *
+ * @param {object}  github - Octokit instance
+ * @param {string}  owner  - Repository owner
+ * @param {string}  repo   - Repository name
+ * @param {object}  pr     - Pull request object from the list API
+ * @param {boolean} dryRun - If true, log without making changes
+ * @returns {boolean} true if at least one managed label was targeted for removal
+ */
+async function stripQueueLabels(github, owner, repo, pr, dryRun) {
+  const prNumber = pr.number;
+  const currentLabels = (pr.labels || []).map((l) => l.name);
+
+  const managedLabels = currentLabels.filter(
+    (name) => ALL_QUEUE_LABEL_NAMES.includes(name) || name === COMMUNITY_REVIEW.name
+  );
+
+  if (managedLabels.length === 0) {
+    console.log(`  PR #${prNumber}: no managed labels present. No change needed.`);
+    return false;
+  }
+
+  if (dryRun) {
+    console.log(`  PR #${prNumber}: [DRY RUN] Would remove: ${managedLabels.join(', ')}.`);
+    return true;
+  }
+
+  for (const name of managedLabels) {
+    try {
+      await github.rest.issues.removeLabel({
+        owner,
+        repo,
+        issue_number: prNumber,
+        name,
+      });
+      console.log(`  PR #${prNumber}: - Removed "${name}".`);
+    } catch (error) {
+      // 404 = label was already removed (race condition or manual action)
+      if (error.status === 404) {
+        console.log(`  PR #${prNumber}: - Label "${name}" already gone (404). Skipping.`);
+      } else {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`  PR #${prNumber}: ✗ Failed to remove "${name}": ${message}`);
+        throw error;
+      }
+    }
+  }
+
+  return true;
+}
+
+module.exports = { ensureLabel, determineLabel, syncLabel, stripQueueLabels, hasCIFailures };

--- a/.github/scripts/review-sync/index.js
+++ b/.github/scripts/review-sync/index.js
@@ -6,16 +6,19 @@
 //
 // Responsibilities:
 //   1. Rate-limit guard — abort if remaining calls < 200
-//   2. Fetch all open non-draft PRs (paginated)
+//   2. Fetch all open PRs (paginated), split into non-draft and draft
 //   3. Ensure the four queue labels exist in the repo
-//   4. Sync the correct label on every PR via helpers
-//   5. Print a summary of what changed
+//   4. Sync the correct label on every non-draft PR via helpers
+//   5. Strip queue/community-review labels from every draft PR
+//   6. Print a summary of what changed
 //
-// Phase 1 of 4 — label sync only.
+// Draft PRs are cleaned rather than skipped, so a PR converted to draft never
+// keeps a stale queue label indefinitely. This is the cron backstop for the
+// converted_to_draft event workflow — it catches anything the event missed.
 
 const helpers = require('./helpers');
 const { QUEUE_LABELS, RATE_LIMIT_FLOOR, COMMUNITY_REVIEW } = helpers.constants;
-const { ensureLabel, syncLabel } = helpers.labels;
+const { ensureLabel, syncLabel, stripQueueLabels } = helpers.labels;
 
 module.exports = async ({ github, context, core }) => {
   const dryRun = (process.env.DRY_RUN || 'false').toLowerCase() === 'true';
@@ -36,7 +39,7 @@ module.exports = async ({ github, context, core }) => {
     return;
   }
 
-  // ── 2. Fetch all open non-draft PRs (paginated) ──────────────────────────
+  // ── 2. Fetch all open PRs (paginated) ────────────────────────────────────
   console.log('\n--- Fetching Open PRs ---');
   const allPRs = await github.paginate(github.rest.pulls.list, {
     owner,
@@ -46,12 +49,13 @@ module.exports = async ({ github, context, core }) => {
   });
 
   const prs = allPRs.filter((pr) => !pr.draft);
+  const draftPrs = allPRs.filter((pr) => pr.draft);
   console.log(`  Total open PRs: ${allPRs.length}`);
   console.log(`  Non-draft PRs to process: ${prs.length}`);
-  console.log(`  Draft PRs skipped: ${allPRs.length - prs.length}`);
+  console.log(`  Draft PRs to clean: ${draftPrs.length}`);
 
-  if (prs.length === 0) {
-    console.log('  No non-draft PRs found. Exiting.');
+  if (prs.length === 0 && draftPrs.length === 0) {
+    console.log('  No open PRs found. Exiting.');
     return;
   }
 
@@ -83,14 +87,38 @@ module.exports = async ({ github, context, core }) => {
     }
   }
 
-  // ── 5. Summary ───────────────────────────────────────────────────────────
+  // ── 5. Clean draft PRs ───────────────────────────────────────────────────
+  console.log('\n--- Cleaning Draft PRs ---');
+  let draftsCleaned = 0;
+  let draftsSkipped = 0;
+  let draftErrors = 0;
+
+  for (const pr of draftPrs) {
+    try {
+      const didClean = await stripQueueLabels(github, owner, repo, pr, dryRun);
+      if (didClean) {
+        draftsCleaned++;
+      } else {
+        draftsSkipped++;
+      }
+    } catch (error) {
+      draftErrors++;
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`  ✗ Error cleaning draft PR #${pr.number}: ${message}`);
+    }
+  }
+
+  // ── 6. Summary ───────────────────────────────────────────────────────────
   console.log('\n=== Summary ===');
-  console.log(`  PRs processed: ${prs.length}`);
+  console.log(`  Non-draft PRs processed: ${prs.length}`);
   console.log(`  Labels changed: ${changed}`);
   console.log(`  Labels already correct: ${skipped}`);
-  console.log(`  Errors: ${errors}`);
+  console.log(`  Draft PRs processed: ${draftPrs.length}`);
+  console.log(`  Drafts cleaned: ${draftsCleaned}`);
+  console.log(`  Drafts already clean: ${draftsSkipped}`);
+  console.log(`  Errors: ${errors + draftErrors}`);
 
-  if (errors > 0) {
-    core.setFailed(`Review sync completed with ${errors} error(s). Check logs above.`);
+  if (errors + draftErrors > 0) {
+    core.setFailed(`Review sync completed with ${errors + draftErrors} error(s). Check logs above.`);
   }
 };

--- a/.github/scripts/review-sync/on-converted-to-draft.js
+++ b/.github/scripts/review-sync/on-converted-to-draft.js
@@ -35,6 +35,11 @@ module.exports = async ({ github, context, core }) => {
     pr = data;
   }
 
+  if (pr.draft !== true) {
+    console.log(`PR #${pr.number}: not a draft. Skipping cleanup.`);
+    return;
+  }
+
   console.log(`Cleaning draft PR #${pr.number}...`);
 
   try {

--- a/.github/scripts/review-sync/on-converted-to-draft.js
+++ b/.github/scripts/review-sync/on-converted-to-draft.js
@@ -19,34 +19,35 @@ module.exports = async ({ github, context, core }) => {
   }
 
   let pr = context.payload.pull_request;
+  const prNumber = pr ? pr.number : Number(process.env.PR_NUMBER);
 
-  if (!pr) {
-    const prNumber = Number(process.env.PR_NUMBER);
-    if (!prNumber) {
-      core.setFailed('No pull_request in payload and no PR_NUMBER provided.');
-      return;
-    }
-    console.log(`No pull_request in payload. Fetching PR #${prNumber} directly.`);
-    const { data } = await github.rest.pulls.get({
-      owner,
-      repo,
-      pull_number: prNumber,
-    });
-    pr = data;
-  }
-
-  if (pr.draft !== true) {
-    console.log(`PR #${pr.number}: not a draft. Skipping cleanup.`);
+  if (!pr && !prNumber) {
+    core.setFailed('No pull_request in payload and no PR_NUMBER provided.');
     return;
   }
 
-  console.log(`Cleaning draft PR #${pr.number}...`);
-
   try {
+    if (!pr) {
+      console.log(`No pull_request in payload. Fetching PR #${prNumber} directly.`);
+      const { data } = await github.rest.pulls.get({
+        owner,
+        repo,
+        pull_number: prNumber,
+      });
+      pr = data;
+    }
+
+    if (pr.draft !== true) {
+      console.log(`PR #${pr.number}: not a draft. Skipping cleanup.`);
+      return;
+    }
+
+    console.log(`Cleaning draft PR #${pr.number}...`);
+
     const didClean = await stripQueueLabels(github, owner, repo, pr, dryRun);
     console.log(didClean ? `PR #${pr.number}: cleanup complete.` : `PR #${pr.number}: nothing to clean.`);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    core.setFailed(`Failed to clean draft PR #${pr.number}: ${message}`);
+    core.setFailed(`Failed to clean draft PR #${prNumber}: ${message}`);
   }
 };

--- a/.github/scripts/review-sync/on-converted-to-draft.js
+++ b/.github/scripts/review-sync/on-converted-to-draft.js
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// .github/scripts/review-sync/on-converted-to-draft.js
+//
+// Entry point for the immediate draft-cleanup event job.
+//
+// Fires on pull_request.converted_to_draft so a PR loses its queue and
+// community-review labels right away, instead of waiting for the next
+// review-sync cron run (up to 30 minutes later).
+
+const { stripQueueLabels } = require('./helpers/labels');
+
+module.exports = async ({ github, context, core }) => {
+  const dryRun = (process.env.DRY_RUN || 'false').toLowerCase() === 'true';
+  const { owner, repo } = context.repo;
+
+  if (dryRun) {
+    console.log('=== DRY RUN MODE — no labels will be modified ===\n');
+  }
+
+  let pr = context.payload.pull_request;
+
+  if (!pr) {
+    const prNumber = Number(process.env.PR_NUMBER);
+    if (!prNumber) {
+      core.setFailed('No pull_request in payload and no PR_NUMBER provided.');
+      return;
+    }
+    console.log(`No pull_request in payload. Fetching PR #${prNumber} directly.`);
+    const { data } = await github.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: prNumber,
+    });
+    pr = data;
+  }
+
+  console.log(`Cleaning draft PR #${pr.number}...`);
+
+  try {
+    const didClean = await stripQueueLabels(github, owner, repo, pr, dryRun);
+    console.log(didClean ? `PR #${pr.number}: cleanup complete.` : `PR #${pr.number}: nothing to clean.`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    core.setFailed(`Failed to clean draft PR #${pr.number}: ${message}`);
+  }
+};

--- a/.github/workflows/draft-label-cleanup.yml
+++ b/.github/workflows/draft-label-cleanup.yml
@@ -18,9 +18,9 @@ on:
         required: true
         type: number
       dry_run:
-        description: 'If true, log label changes without applying them.'
+        description: 'If true, log label changes without applying them. Default true for manual runs.'
         required: false
-        default: 'false'
+        default: 'true'
         type: string
 
 permissions:

--- a/.github/workflows/draft-label-cleanup.yml
+++ b/.github/workflows/draft-label-cleanup.yml
@@ -1,0 +1,60 @@
+# Strips review-queue and community-review labels from a PR the moment it is
+# converted to draft, so it doesn't sit around advertising a stale queue
+# label (or worse, "status: ready-to-merge") while the author reworks it.
+#
+# This is the immediate counterpart to the review-sync cron job, which now
+# also cleans drafts on every run as a backstop for anything this event misses.
+
+name: Draft PR Label Cleanup
+
+on:
+  pull_request:
+    types:
+      - converted_to_draft
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to process (for manual testing)'
+        required: true
+        type: number
+      dry_run:
+        description: 'If true, log label changes without applying them.'
+        required: false
+        default: 'false'
+        type: string
+
+permissions:
+  issues: write
+  pull-requests: read
+  contents: read
+
+concurrency:
+  group: draft-label-cleanup-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  cleanup:
+    runs-on: hl-sdk-py-lin-md
+    env:
+      DRY_RUN: ${{ inputs.dry_run || 'false' }}
+      PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout scripts
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: |
+            .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Strip queue labels
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fn = require('./.github/scripts/review-sync/on-converted-to-draft.js');
+            await fn({ github, context, core });

--- a/.github/workflows/draft-label-cleanup.yml
+++ b/.github/workflows/draft-label-cleanup.yml
@@ -5,14 +5,16 @@
 # This is the immediate counterpart to the review-sync cron job, which now
 # also cleans drafts on every run as a backstop for anything this event misses.
 #
-# The checkout is pinned to the default branch rather than the PR ref: this
-# job runs with issues: write, so it must never execute code from the PR
-# it's reacting to. Same pattern as on-review.yml.
+# Uses pull_request_target, not pull_request: fork and Dependabot PRs get a
+# read-only GITHUB_TOKEN under plain pull_request, so removeLabel would fail
+# for exactly the PRs this needs to work on. The checkout is still pinned to
+# the default branch rather than the PR ref, so this never runs PR-controlled
+# code even though it holds a write token. Same pattern as on-review.yml.
 
 name: Draft PR Label Cleanup
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - converted_to_draft
   workflow_dispatch:

--- a/.github/workflows/draft-label-cleanup.yml
+++ b/.github/workflows/draft-label-cleanup.yml
@@ -4,6 +4,10 @@
 #
 # This is the immediate counterpart to the review-sync cron job, which now
 # also cleans drafts on every run as a backstop for anything this event misses.
+#
+# The checkout is pinned to the default branch rather than the PR ref: this
+# job runs with issues: write, so it must never execute code from the PR
+# it's reacting to. Same pattern as on-review.yml.
 
 name: Draft PR Label Cleanup
 
@@ -48,6 +52,8 @@ jobs:
       - name: Checkout scripts
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
           sparse-checkout: |
             .github/scripts
           sparse-checkout-cone-mode: false


### PR DESCRIPTION
Draft PRs currently get filtered out of the review-sync cron entirely, so any queue label (or even `status: ready-to-merge`) they picked up before being converted to draft just stays there forever. This PR cleans that up.

**What changed**

- Added `stripQueueLabels()` in `helpers/labels.js` — removes any queue/community-review labels present on a PR. Plain removal (no add-before-remove ordering, since the goal for drafts is zero labels, not one).
- `index.js` now splits open PRs into drafts and non-drafts instead of dropping drafts. Non-draft PRs go through the existing `syncLabel` flow unchanged; drafts get run through `stripQueueLabels`. Summary output now reports both.
- Added `.github/workflows/draft-label-cleanup.yml` + `on-converted-to-draft.js`, triggered on `pull_request: converted_to_draft`, so labels come off immediately instead of waiting for the next cron run (up to 30 min). Also has a `workflow_dispatch` for manual testing with `pr_number`/`dry_run` inputs.
- Updated the `COMMUNITY_REVIEW` docstring/description in `constants.js` to say "non-draft" since that's now actually true.
- Added Jest tests for `stripQueueLabels`: removal, no-op when nothing to remove, 404 tolerance, and dry-run. Had to extend `createMockGithub` in `test-utils.js` with a `removeLabelNotFound` option since there wasn't a way to simulate a 404 on label removal before.

No restore logic needed — once a PR is marked ready again, the next cron pass just re-applies the correct label like it would for any other unlabeled PR.

Closes #2541
