### PR TITLE
chore(typing): add type hints to SubscriptionHandle

### DIFF
--- a/src/hiero_sdk_python/utils/subscription_handle.py
+++ b/src/hiero_sdk_python/utils/subscription_handle.py
@@ -11,13 +11,13 @@ class SubscriptionHandle:
     Calling .cancel() will signal the subscription thread to stop.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._cancelled = threading.Event()
         self._thread: threading.Thread | None = None
         self._call: Any | None = None
         self._lock = threading.Lock()
 
-    def _set_call(self, call: Any):
+    def _set_call(self, call: Any) -> None:
         """Sets the active gRPC call so it can be cancelled."""
         should_cancel = False
 
@@ -27,10 +27,10 @@ class SubscriptionHandle:
             if call is not None and self._cancelled.is_set():
                 should_cancel = True
 
-        if should_cancel:
+        if should_cancel and self._call is not None:
             self._call.cancel()
 
-    def cancel(self):
+    def cancel(self) -> None:
         """Signals to cancel the subscription."""
         should_cancel = False
 
@@ -40,18 +40,22 @@ class SubscriptionHandle:
             if self._call is not None:
                 should_cancel = True
 
-        if should_cancel:
+        if should_cancel and self._call is not None:
             self._call.cancel()
 
     def is_cancelled(self) -> bool:
         """Returns True if this subscription is already cancelled."""
         return self._cancelled.is_set()
 
-    def set_thread(self, thread: threading.Thread):
+    def set_thread(self, thread: threading.Thread) -> None:
         """(Optional) Store the thread object for reference."""
         self._thread = thread
 
-    def join(self, timeout=None):
-        """(Optional) Wait for the subscription thread to end."""
+    def join(self, timeout: float | None = None) -> None:
+        """(Optional) Wait for the subscription thread to end.
+
+        Args:
+            timeout (float | None): Wait time in seconds.
+        """
         if self._thread:
             self._thread.join(timeout)


### PR DESCRIPTION
**Description**:

Add complete type annotations to the SubscriptionHandle class methods to improve editor autocomplete and static analysis.

- Add return type hints to all missing methods

- Add parameter type hint for join(timeout)

- Add Google-style docstring explaining the timeout parameter

**Related issue(s)**:

Fixes #2560

**Notes for reviewer**:
All existing unit tests pass unchanged. As requested, here is the clean MyPy output verifying the types-only change:
Success: no issues found in 1 source file

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
