### PR TITLE
fix : postComment Duplicate issue

### DIFF
--- a/.github/scripts/__tests__/jest/post-comment.test.js
+++ b/.github/scripts/__tests__/jest/post-comment.test.js
@@ -1,0 +1,95 @@
+// __tests__/jest/post-comment.test.js
+//
+// Run from .github/scripts:
+// npm run test:js -- post-comment.test.js
+
+const { postComment } = require('../../shared/helpers/pr-helpers');
+
+function createMockGithub({ shouldFail = false, errorMessage = 'API error' } = {}) {
+  const calls = {
+    createComment: [],
+  };
+
+  const github = {
+    calls,
+    rest: {
+      issues: {
+        createComment: jest.fn(async ({ owner, repo, issue_number, body }) => {
+          calls.createComment.push({ owner, repo, issue_number, body });
+          if (shouldFail) {
+            throw new Error(errorMessage);
+          }
+          return { data: { id: 101 } };
+        }),
+      },
+    },
+  };
+
+  return github;
+}
+
+function createMockCore() {
+  return {
+    info: jest.fn(),
+    error: jest.fn(),
+    warning: jest.fn(),
+    setFailed: jest.fn(),
+  };
+}
+
+describe('postComment helper', () => {
+  test('happy path: returns true and logs info when createComment resolves', async () => {
+    const github = createMockGithub();
+    const core = createMockCore();
+    const owner = 'hiero-ledger';
+    const repo = 'hiero-sdk-python';
+    const prNumber = 123;
+    const body = 'Great work on this PR!';
+
+    const result = await postComment(github, owner, repo, prNumber, body, core);
+
+    expect(result).toBe(true);
+    expect(github.rest.issues.createComment).toHaveBeenCalledTimes(1);
+    expect(github.rest.issues.createComment).toHaveBeenCalledWith({
+      owner,
+      repo,
+      issue_number: prNumber,
+      body,
+    });
+    expect(core.info).toHaveBeenCalledTimes(1);
+    expect(core.info).toHaveBeenCalledWith(`Posted recommendation comment to PR #${prNumber}`);
+    expect(core.error).not.toHaveBeenCalled();
+  });
+
+  test('failure path: returns false, logs error, and does not throw when createComment rejects', async () => {
+    const errorMessage = 'Network error: 500 Internal Server Error';
+    const github = createMockGithub({ shouldFail: true, errorMessage });
+    const core = createMockCore();
+    const owner = 'hiero-ledger';
+    const repo = 'hiero-sdk-python';
+    const prNumber = 456;
+    const body = 'Recommendation comment';
+
+    let result;
+    let thrownError = null;
+
+    try {
+      result = await postComment(github, owner, repo, prNumber, body, core);
+    } catch (err) {
+      thrownError = err;
+    }
+
+    expect(thrownError).toBeNull();
+    expect(result).toBe(false);
+    expect(github.rest.issues.createComment).toHaveBeenCalledTimes(1);
+    expect(github.rest.issues.createComment).toHaveBeenCalledWith({
+      owner,
+      repo,
+      issue_number: prNumber,
+      body,
+    });
+    expect(core.error).toHaveBeenCalledTimes(1);
+    expect(core.error).toHaveBeenCalledWith(`Failed to post comment: ${errorMessage}`);
+    expect(core.info).not.toHaveBeenCalled();
+  });
+});

--- a/.github/scripts/__tests__/jest/post-comment.test.js
+++ b/.github/scripts/__tests__/jest/post-comment.test.js
@@ -6,16 +6,10 @@
 const { postComment } = require('../../shared/helpers/pr-helpers');
 
 function createMockGithub({ shouldFail = false, errorMessage = 'API error' } = {}) {
-  const calls = {
-    createComment: [],
-  };
-
-  const github = {
-    calls,
+  return {
     rest: {
       issues: {
-        createComment: jest.fn(async ({ owner, repo, issue_number, body }) => {
-          calls.createComment.push({ owner, repo, issue_number, body });
+        createComment: jest.fn(async () => {
           if (shouldFail) {
             throw new Error(errorMessage);
           }
@@ -24,8 +18,6 @@ function createMockGithub({ shouldFail = false, errorMessage = 'API error' } = {
       },
     },
   };
-
-  return github;
 }
 
 function createMockCore() {
@@ -39,57 +31,77 @@ function createMockCore() {
 
 describe('postComment helper', () => {
   test('happy path: returns true and logs info when createComment resolves', async () => {
-    const github = createMockGithub();
-    const core = createMockCore();
-    const owner = 'hiero-ledger';
-    const repo = 'hiero-sdk-python';
-    const prNumber = 123;
-    const body = 'Great work on this PR!';
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    const result = await postComment(github, owner, repo, prNumber, body, core);
+    try {
+      const github = createMockGithub();
+      const core = createMockCore();
+      const owner = 'hiero-ledger';
+      const repo = 'hiero-sdk-python';
+      const prNumber = 123;
+      const body = 'Great work on this PR!';
 
-    expect(result).toBe(true);
-    expect(github.rest.issues.createComment).toHaveBeenCalledTimes(1);
-    expect(github.rest.issues.createComment).toHaveBeenCalledWith({
-      owner,
-      repo,
-      issue_number: prNumber,
-      body,
-    });
-    expect(core.info).toHaveBeenCalledTimes(1);
-    expect(core.info).toHaveBeenCalledWith(`Posted recommendation comment to PR #${prNumber}`);
-    expect(core.error).not.toHaveBeenCalled();
+      const result = await postComment(github, owner, repo, prNumber, body, core);
+
+      expect(result).toBe(true);
+      expect(github.rest.issues.createComment).toHaveBeenCalledTimes(1);
+      expect(github.rest.issues.createComment).toHaveBeenCalledWith({
+        owner,
+        repo,
+        issue_number: prNumber,
+        body,
+      });
+      expect(core.info).toHaveBeenCalledTimes(1);
+      expect(core.info).toHaveBeenCalledWith(`Posted recommendation comment to PR #${prNumber}`);
+      expect(core.error).not.toHaveBeenCalled();
+      expect(consoleLogSpy).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    } finally {
+      consoleLogSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   test('failure path: returns false, logs error, and does not throw when createComment rejects', async () => {
-    const errorMessage = 'Network error: 500 Internal Server Error';
-    const github = createMockGithub({ shouldFail: true, errorMessage });
-    const core = createMockCore();
-    const owner = 'hiero-ledger';
-    const repo = 'hiero-sdk-python';
-    const prNumber = 456;
-    const body = 'Recommendation comment';
-
-    let result;
-    let thrownError = null;
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     try {
-      result = await postComment(github, owner, repo, prNumber, body, core);
-    } catch (err) {
-      thrownError = err;
-    }
+      const errorMessage = 'Network error: 500 Internal Server Error';
+      const github = createMockGithub({ shouldFail: true, errorMessage });
+      const core = createMockCore();
+      const owner = 'hiero-ledger';
+      const repo = 'hiero-sdk-python';
+      const prNumber = 456;
+      const body = 'Recommendation comment';
 
-    expect(thrownError).toBeNull();
-    expect(result).toBe(false);
-    expect(github.rest.issues.createComment).toHaveBeenCalledTimes(1);
-    expect(github.rest.issues.createComment).toHaveBeenCalledWith({
-      owner,
-      repo,
-      issue_number: prNumber,
-      body,
-    });
-    expect(core.error).toHaveBeenCalledTimes(1);
-    expect(core.error).toHaveBeenCalledWith(`Failed to post comment: ${errorMessage}`);
-    expect(core.info).not.toHaveBeenCalled();
+      let result;
+      let thrownError = null;
+
+      try {
+        result = await postComment(github, owner, repo, prNumber, body, core);
+      } catch (err) {
+        thrownError = err;
+      }
+
+      expect(thrownError).toBeNull();
+      expect(result).toBe(false);
+      expect(github.rest.issues.createComment).toHaveBeenCalledTimes(1);
+      expect(github.rest.issues.createComment).toHaveBeenCalledWith({
+        owner,
+        repo,
+        issue_number: prNumber,
+        body,
+      });
+      expect(core.error).toHaveBeenCalledTimes(1);
+      expect(core.error).toHaveBeenCalledWith(`Failed to post comment: ${errorMessage}`);
+      expect(core.info).not.toHaveBeenCalled();
+      expect(consoleLogSpy).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    } finally {
+      consoleLogSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    }
   });
 });

--- a/.github/scripts/shared/api/github-api.js
+++ b/.github/scripts/shared/api/github-api.js
@@ -65,6 +65,18 @@ async function fetchIssuesBatch(github, repoConfig) {
   }
 }
 
+/**
+ * Returns the number of open issues currently assigned to `username` in the
+ * given repository. Pull requests are excluded because they do not consume
+ * assignment capacity. Returns null on API failure so callers can fail open.
+ *
+ * @param {object} params
+ * @param {import('@actions/github').GitHub} params.github
+ * @param {string} params.owner    - Repo owner.
+ * @param {string} params.repo     - Repo name.
+ * @param {string} params.username - GitHub login of the contributor.
+ * @returns {Promise<number|null>} Count of open issue assignments, or null on failure.
+ */
 async function getOpenAssignments({ github, owner, repo, username }) {
   try {
     const issues = await github.paginate(github.rest.issues.listForRepo, {
@@ -94,6 +106,14 @@ async function getOpenAssignments({ github, owner, repo, username }) {
  * Counts closed issues carrying `label` (in the given repo) assigned to
  * `username`. Returns null (rather than throwing) on unsafe input or API
  * error so callers can choose to fail open.
+ *
+ * @param {object} params
+ * @param {import('@actions/github').GitHub} params.github
+ * @param {string} params.owner    - Repo owner.
+ * @param {string} params.repo     - Repo name.
+ * @param {string} params.username - GitHub login of the contributor.
+ * @param {string} params.label    - Label string to filter by.
+ * @returns {Promise<number|null>} Issue count, or null on invalid input or API failure.
  */
 async function countCompletedIssuesWithLabel({ github, owner, repo, username, label }) {
   if (!isValidSearchToken(owner) || !isValidSearchToken(repo) || !isValidSearchToken(username)) {
@@ -133,12 +153,18 @@ async function countCompletedIssuesWithLabel({ github, owner, repo, username, la
 }
 
 /**
-
  * Determines whether a user has repository collaborator access.
  *
  * Repository owners are always considered collaborators.
  * GitHub returns 204 when the user is a collaborator and 404 otherwise.
  * Unexpected API failures are treated as non-collaborator access.
+ *
+ * @param {object} params
+ * @param {import('@actions/github').GitHub} params.github
+ * @param {string} params.owner    - Repo owner.
+ * @param {string} params.repo     - Repo name.
+ * @param {string} params.username - GitHub login to check.
+ * @returns {Promise<boolean>} True if the user is a collaborator, false otherwise.
  */
 async function isRepoCollaborator({ github, owner, repo, username }) {
   if (username === owner) {
@@ -176,16 +202,46 @@ async function isRepoCollaborator({ github, owner, repo, username }) {
   }
 }
 
+/**
+ * Posts a comment on an issue or pull request via the GitHub REST API.
+ * When `logLabel` is provided, logs the outcome to the console; when omitted,
+ * stays silent so the caller owns all logging. Re-throws any API error either
+ * way so callers can handle or propagate failures themselves.
+ *
+ * @param {object} params
+ * @param {import('@actions/github').GitHub} params.github
+ * @param {string} params.owner       - Repo owner.
+ * @param {string} params.repo        - Repo name.
+ * @param {number} params.issueNumber - Issue or PR number to comment on.
+ * @param {string} params.body        - Markdown body of the comment.
+ * @param {string} [logLabel]         - Optional human-readable label used in console output.
+ * @returns {Promise<void>}
+ * @throws {Error} Re-throws the Octokit error on API failure.
+ */
 async function postIssueComment({ github, owner, repo, issueNumber, body }, logLabel) {
   try {
     await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body });
-    console.log(`[github-api] Posted comment: ${logLabel}`);
+    if (logLabel) {
+      console.log(`[github-api] Posted comment: ${logLabel}`);
+    }
   } catch (error) {
-    console.error(`[github-api] Failed to post comment (${logLabel}):`, { message: error.message });
+    if (logLabel) {
+      console.error(`[github-api] Failed to post comment (${logLabel}):`, { message: error.message });
+    }
     throw error;
   }
 }
 
+/**
+ * Fetches all comments on an issue or pull request, paginating automatically.
+ *
+ * @param {object} params
+ * @param {import('@actions/github').GitHub} params.github
+ * @param {string} params.owner       - Repo owner.
+ * @param {string} params.repo        - Repo name.
+ * @param {number} params.issueNumber - Issue or PR number.
+ * @returns {Promise<Array<object>>} Array of comment objects from the GitHub API.
+ */
 async function fetchAllComments({ github, owner, repo, issueNumber }) {
   return github.paginate(github.rest.issues.listComments, {
     owner,
@@ -195,6 +251,17 @@ async function fetchAllComments({ github, owner, repo, issueNumber }) {
   });
 }
 
+/**
+ * Assigns a contributor to an issue.
+ *
+ * @param {object} params
+ * @param {import('@actions/github').GitHub} params.github
+ * @param {string} params.owner       - Repo owner.
+ * @param {string} params.repo        - Repo name.
+ * @param {number} params.issueNumber - Issue number to assign.
+ * @param {string} params.username    - GitHub login of the contributor to assign.
+ * @returns {Promise<void>}
+ */
 async function assignIssue({
     github,
     owner,

--- a/.github/scripts/shared/helpers/pr-helpers.js
+++ b/.github/scripts/shared/helpers/pr-helpers.js
@@ -3,6 +3,7 @@
 // ---------------------------------------------------------------------------
 
 const { CONFIG } = require('../config');
+const { postIssueComment } = require('../api/github-api');
 
 /**
  * Extracts the first linked issue number from a PR body using closing keywords.
@@ -71,7 +72,10 @@ async function alreadyCommented(github, owner, repo, prNumber) {
  */
 async function postComment(github, owner, repo, prNumber, body, core) {
   try {
-    await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+    await postIssueComment(
+      { github, owner, repo, issueNumber: prNumber, body },
+      'recommendation comment',
+    );
     core.info(`Posted recommendation comment to PR #${prNumber}`);
     return true;
   } catch (error) {

--- a/.github/scripts/shared/helpers/pr-helpers.js
+++ b/.github/scripts/shared/helpers/pr-helpers.js
@@ -72,10 +72,9 @@ async function alreadyCommented(github, owner, repo, prNumber) {
  */
 async function postComment(github, owner, repo, prNumber, body, core) {
   try {
-    await postIssueComment(
-      { github, owner, repo, issueNumber: prNumber, body },
-      'recommendation comment',
-    );
+    // No logLabel: this wrapper owns logging (via core), matching the
+    // pre-consolidation log output exactly.
+    await postIssueComment({ github, owner, repo, issueNumber: prNumber, body });
     core.info(`Posted recommendation comment to PR #${prNumber}`);
     return true;
   } catch (error) {


### PR DESCRIPTION
**Description**:
Consolidate comment posting onto the shared `postIssueComment` API helper and add unit-test coverage for the refactored `postComment` helper in `pr-helpers.js`. Complete JSDoc documentation for all exported functions in `github-api.js`.

* Rewrite `postComment` in `shared/helpers/pr-helpers.js` to delegate to `postIssueComment` from `shared/api/github-api.js`, removing the duplicated direct `github.rest.issues.createComment` call
* Add `__tests__/jest/post-comment.test.js` covering the happy path (returns `true`, logs via `core.info`) and failure path (returns `false`, logs via `core.error`, does not throw)
* Add full JSDoc (`@param`, `@returns`, `@throws`) to `getOpenAssignments`, `countCompletedIssuesWithLabel`, `isRepoCollaborator`, `postIssueComment`, `fetchAllComments`, and `assignIssue` in `shared/api/github-api.js`

**Related issue(s)**:

Fixes #2540

**Notes for reviewer**:
* `shared/core/issue-assign.js` is unchanged — it already calls `postIssueComment` correctly at all 5 call sites and lets thrown errors propagate
* `bot-next-issue-recommendation.js` is unchanged — it calls `postComment` with the same positional arguments and branches on the returned boolean to call `core.setFailed`
* The local `postComment` in `bot-contributor-lifecycle.js` and the inline `createComment` in `bot-mentor-assignment.js` are intentionally out of scope for this PR
* All 30 existing Jest tests pass (`issue-assign.test.js`: 28, `post-comment.test.js`: 2)

**Checklist**

- [x] Documented (JSDoc added to all 8 exported functions in `github-api.js`; existing JSDoc in `pr-helpers.js` retained)
- [x] Tested (unit tests added in `post-comment.test.js`; existing `issue-assign.test.js` suite confirmed passing)
