### PR TITLE
chore: update Hedera protobufs to v0.76.1

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1249,12 +1249,12 @@ reviews:
         2. Extract the module name before `_pb2`
            (e.g. `transaction_record` from `transaction_record_pb2`)
         3. Build the canonical URL:
-           `https://github.com/hashgraph/hedera-protobufs/blob/v0.72.0-rc.2/<path>/<module>.proto`
+           `https://github.com/hashgraph/hedera-protobufs/blob/v0.76.1/<path>/<module>.proto`
 
         **Example:**
         ```
         Import:  from hiero_sdk_python.hapi.services import transaction_record_pb2
-        Schema:  https://github.com/hashgraph/hedera-protobufs/blob/v0.72.0-rc.2/services/transaction_record.proto
+        Schema:  https://github.com/hashgraph/hedera-protobufs/blob/v0.76.1/services/transaction_record.proto
         ```
 
         ### Step 3 — Compare the SDK class against the proto schema

--- a/.github/workflows/pr-check-secondary-examples.yml
+++ b/.github/workflows/pr-check-secondary-examples.yml
@@ -77,7 +77,7 @@ jobs:
           installMirrorNode: true
           soloVersion: v0.79.1
           mirrorNodeVersion: v0.153.0
-          hieroVersion: v0.73.0
+          hieroVersion: v0.76.1
 
       - name: Run Examples
         env:

--- a/.github/workflows/pr-check-secondary-unit-integration-test.yml
+++ b/.github/workflows/pr-check-secondary-unit-integration-test.yml
@@ -134,7 +134,7 @@ jobs:
           installMirrorNode: true
           soloVersion: v0.79.1
           mirrorNodeVersion: v0.153.0
-          hieroVersion: v0.73.0
+          hieroVersion: v0.76.1
 
       - name: Run integration tests
         id: integration

--- a/examples/nodes/node_create_transaction.py
+++ b/examples/nodes/node_create_transaction.py
@@ -66,9 +66,10 @@ def node_create():
 
     # Node account ID - this should be an existing account
     # that will be associated with the node
+    node_account_key = PrivateKey.generate_ecdsa()
     account_id = (
         AccountCreateTransaction()
-        .set_key_without_alias(PrivateKey.generate_ecdsa())
+        .set_key_without_alias(node_account_key)
         .freeze_with(client)
         .execute(client)
         .account_id
@@ -103,6 +104,7 @@ def node_create():
         .set_decline_reward(True)
         .freeze_with(client)
         .sign(admin_key)  # Sign with the admin key
+        .sign(node_account_key)  # Sign with the node account key
         .execute(client)
     )
 

--- a/examples/nodes/node_delete_transaction.py
+++ b/examples/nodes/node_delete_transaction.py
@@ -65,9 +65,10 @@ def create_node(client):
     """Create a node on the network and return its ID and admin key."""
     # Node account ID - this should be an existing account
     # that will be associated with the node
-    account_id = account_id = (
+    node_account_key = PrivateKey.generate_ecdsa()
+    account_id = (
         AccountCreateTransaction()
-        .set_key_without_alias(PrivateKey.generate_ecdsa())
+        .set_key_without_alias(node_account_key)
         .freeze_with(client)
         .execute(client)
         .account_id
@@ -102,6 +103,7 @@ def create_node(client):
         .set_decline_reward(True)
         .freeze_with(client)
         .sign(admin_key)  # Sign with the admin key
+        .sign(node_account_key)  # Sign with the node account key
         .execute(client)
     )
 

--- a/examples/nodes/node_update_transaction.py
+++ b/examples/nodes/node_update_transaction.py
@@ -61,7 +61,7 @@ def setup_client():
     return client
 
 
-def create_node(client, account_id):
+def create_node(client, account_id, node_account_private_key):
     """Create a node on the network and return its ID and admin key."""
     # Node description
     description = "Example node"
@@ -92,6 +92,7 @@ def create_node(client, account_id):
         .set_decline_reward(True)
         .freeze_with(client)
         .sign(admin_key)  # Sign with the admin key
+        .sign(node_account_private_key)  # Sign with the node account key
         .execute(client)
     )
 
@@ -168,7 +169,7 @@ def node_update():
     )
 
     # Create a new node and get its ID and admin key
-    node_id, admin_key = create_node(client, node_account_id)
+    node_id, admin_key = create_node(client, node_account_id, node_account_private_key)
 
     # Update the newly created node with modified parameters
     update_node(client, node_account_id, node_account_private_key, node_id, admin_key)

--- a/generate_proto.py
+++ b/generate_proto.py
@@ -34,7 +34,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 
-VERSION = "v0.73.0"
+VERSION = "v0.76.1"
 SOURCES = [
     {
         "name": "hedera-protobufs",

--- a/generate_proto.py
+++ b/generate_proto.py
@@ -55,6 +55,13 @@ SOURCES = [
 OUTPUT_DIR = "src/hiero_sdk_python/hapi"
 CACHE_DIR = ".protos"
 
+# Protos that must be skipped during compilation as they are
+# not used by the SDK and have broken imports that cannot be resolved
+
+EXCLUDED_PROTOS = {
+    "blocks/publish_stream_request_bytes.proto",
+}
+
 # Map common broken imports in mirror/platform proto
 REPLACEMENTS = {
     'import "basic_types.proto";': 'import "services/basic_types.proto";',
@@ -169,7 +176,9 @@ def run_protoc(proto_root: Path, output_root: Path) -> None:
     from grpc_tools import protoc
 
     google_include = str(Path(grpc_tools.__file__).parent / "_proto")
-    all_protos = [p.as_posix() for p in proto_root.rglob("*.proto")]
+    all_protos = [
+        p.as_posix() for p in proto_root.rglob("*.proto") if p.relative_to(proto_root).as_posix() not in EXCLUDED_PROTOS
+    ]
 
     args = [
         "protoc",

--- a/tests/integration/associated_registered_nodes_e2e_test.py
+++ b/tests/integration/associated_registered_nodes_e2e_test.py
@@ -35,9 +35,10 @@ def _setup_client():
 
 def _create_consensus_node(client, admin_key, associated_ids=None):
     """Helper: create a consensus node with optional associated_registered_nodes."""
+    node_account_key = PrivateKey.generate_ecdsa()
     account_id = (
         AccountCreateTransaction()
-        .set_key_without_alias(PrivateKey.generate_ecdsa())
+        .set_key_without_alias(node_account_key)
         .freeze_with(client)
         .execute(client)
         .account_id
@@ -61,7 +62,7 @@ def _create_consensus_node(client, admin_key, associated_ids=None):
     if associated_ids is not None:
         tx.set_associated_registered_nodes(associated_ids)
 
-    receipt = tx.freeze_with(client).sign(admin_key).execute(client)
+    receipt = tx.freeze_with(client).sign(admin_key).sign(node_account_key).execute(client)
     assert receipt.status == ResponseCode.SUCCESS, f"Node create failed: {ResponseCode(receipt.status).name}"
     return receipt.node_id
 


### PR DESCRIPTION
**Description**:
This pull request updates the Hedera protobuf and Hiero SDK versions used throughout the project to `v0.76.1`.

**Version updates:**

* Updated the protobuf schema documentation in `.coderabbit.yaml` to reference `hedera-protobufs` version `v0.76.1` instead of `v0.72.0-rc.2`.
* Updated the `hieroVersion` in the GitHub Actions workflows (`pr-check-secondary-examples.yml` and `pr-check-secondary-unit-integration-test.yml`) to `v0.76.1`. * Updated the `VERSION` constant in `generate_proto.py` to `v0.76.1`.
**Related issue(s)**:

Fixes #2588 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
