### PR TITLE
feat(topic): add add_fee_exempt_key to TopicUpdateTransaction

### DIFF
--- a/src/hiero_sdk_python/consensus/topic_update_transaction.py
+++ b/src/hiero_sdk_python/consensus/topic_update_transaction.py
@@ -234,6 +234,27 @@ class TopicUpdateTransaction(Transaction):
         self.custom_fees.append(custom_fee)
         return self
 
+    def add_fee_exempt_key(self, key: Key) -> TopicUpdateTransaction:
+        """
+        Adds a single fee exempt key to the transaction's fee exempt key list.
+
+        Args:
+            key (Key): The fee exempt key to add.
+
+        Returns:
+            TopicUpdateTransaction: The current instance for method chaining.
+        """
+        self._require_not_frozen()
+
+        if not isinstance(key, Key):
+            raise TypeError("key must be a Key")
+
+        if self.fee_exempt_keys is None:
+            self.fee_exempt_keys = []
+
+        self.fee_exempt_keys.append(key)
+        return self
+
     def clear_custom_fees(self) -> TopicUpdateTransaction:
         """
         Clears the custom fees for the topic update transaction and

--- a/tests/unit/topic_update_transaction_test.py
+++ b/tests/unit/topic_update_transaction_test.py
@@ -486,3 +486,49 @@ def test_add_custom_fee_type_error():
     with pytest.raises(TypeError, match="custom_fee must be a CustomFixedFee"):
         tx.add_custom_fee(None)  # type: ignore
     assert tx.custom_fees is None, "Invalid input must not change custom_fees"
+
+
+def test_add_fee_exempt_key():
+    """Test adding a fee exempt key to the transaction."""
+    tx = TopicUpdateTransaction()
+
+    key1 = PrivateKey.generate().public_key()
+    key2 = PrivateKey.generate().public_key()
+
+    result = tx.add_fee_exempt_key(key1)
+
+    assert len(tx.fee_exempt_keys) == 1
+    assert tx.fee_exempt_keys[0] == key1
+    assert result is tx
+
+    tx.add_fee_exempt_key(key2)
+
+    assert len(tx.fee_exempt_keys) == 2
+    assert tx.fee_exempt_keys[0] == key1
+    assert tx.fee_exempt_keys[1] == key2
+
+
+def test_add_fee_exempt_key_frozen(mock_client, topic_id):
+    """Test calling add_fee_exempt_key() after freezing raises an exception."""
+    tx = TopicUpdateTransaction()
+
+    tx.set_topic_id(topic_id)
+    tx.freeze_with(mock_client)
+
+    key = PrivateKey.generate().public_key()
+
+    with pytest.raises(Exception, match="Transaction is immutable; it has been frozen"):
+        tx.add_fee_exempt_key(key)
+
+
+def test_add_fee_exempt_key_type_error():
+    """Test passing None or a non-Key argument raises TypeError."""
+    tx = TopicUpdateTransaction()
+
+    with pytest.raises(TypeError, match="key must be a Key"):
+        tx.add_fee_exempt_key("this_is_a_string")  # type: ignore
+    assert tx.fee_exempt_keys is None, "Invalid input must not change fee_exempt_keys"
+
+    with pytest.raises(TypeError, match="key must be a Key"):
+        tx.add_fee_exempt_key(None)  # type: ignore
+    assert tx.fee_exempt_keys is None, "Invalid input must not change fee_exempt_keys"


### PR DESCRIPTION
**Description**:
Adds the `add_fee_exempt_key` convenience method to `TopicUpdateTransaction` to maintain API parity with other Hiero SDKs (such as Java).

* Add `add_fee_exempt_key` method to `TopicUpdateTransaction`
* Add unit tests verifying successful key addition, frozen state validation, and type checking

**Related issue(s)**:

Fixes #2448 

**Notes for reviewer**:
The implementation and test structures follow existing SDK conventions for validation, frozen-state checks, and method chaining. All unit tests (`pytest`) pass successfully locally.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)