### PR TITLE
feat(tck): implement deleteSchedule JSON-RPC method

### DIFF
--- a/src/hiero_sdk_python/schedule/schedule_delete_transaction.py
+++ b/src/hiero_sdk_python/schedule/schedule_delete_transaction.py
@@ -56,14 +56,11 @@ class ScheduleDeleteTransaction(Transaction):
 
         Returns:
             ScheduleDeleteTransactionBody: The protobuf body for this transaction.
-
-        Raises:
-            ValueError: If schedule_id is not set.
         """
-        if self.schedule_id is None:
-            raise ValueError("Missing required ScheduleID")
+        if self.schedule_id is not None:
+            return ScheduleDeleteTransactionBody(scheduleID=self.schedule_id._to_proto())
 
-        return ScheduleDeleteTransactionBody(scheduleID=self.schedule_id._to_proto())
+        return ScheduleDeleteTransactionBody()
 
     def build_transaction_body(self):
         """

--- a/tck/handlers/schedule.py
+++ b/tck/handlers/schedule.py
@@ -6,6 +6,8 @@ from typing import Any, cast
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.schedule.schedule_create_transaction import ScheduleCreateTransaction
+from hiero_sdk_python.schedule.schedule_delete_transaction import ScheduleDeleteTransaction
+from hiero_sdk_python.schedule.schedule_id import ScheduleId
 from hiero_sdk_python.timestamp import Timestamp
 from hiero_sdk_python.transaction.transaction import Transaction
 from hiero_sdk_python.transaction.transaction_receipt import TransactionReceipt
@@ -20,11 +22,11 @@ from tck.param.account import CreateAccountParams
 from tck.param.allowance import ApproveAllowanceParams
 from tck.param.base import BaseTransactionParams
 from tck.param.common import CommonTransactionParams
-from tck.param.schedule import CreateScheduleParams, ScheduledTransactionParams
+from tck.param.schedule import CreateScheduleParams, DeleteScheduleParams, ScheduledTransactionParams
 from tck.param.token import BurnTokenParams, MintTokenParams
 from tck.param.topic import CreateTopicParams, TopicMessageSubmitParams
 from tck.param.transfer import TransferCryptoParams
-from tck.response.schedule import CreateScheduleResponse
+from tck.response.schedule import CreateScheduleResponse, DeleteScheduleResponse
 from tck.util.client_utils import get_client
 from tck.util.constants import DEFAULT_GRPC_TIMEOUT
 from tck.util.key_utils import get_key_from_string
@@ -116,6 +118,16 @@ def _build_create_schedule_transaction(params: CreateScheduleParams) -> Schedule
     return transaction
 
 
+def _build_delete_schedule_transaction(params: DeleteScheduleParams) -> ScheduleDeleteTransaction:
+    """Builds a ScheduleDeleteTransaction from the provided parameters."""
+    transaction = ScheduleDeleteTransaction().set_grpc_deadline(DEFAULT_GRPC_TIMEOUT)
+
+    if params.scheduleId is not None:
+        transaction.set_schedule_id(ScheduleId.from_string(params.scheduleId))
+
+    return transaction
+
+
 @rpc_method("createSchedule")
 def create_schedule(params: CreateScheduleParams) -> CreateScheduleResponse:
     """Create a schedule."""
@@ -138,3 +150,19 @@ def create_schedule(params: CreateScheduleParams) -> CreateScheduleResponse:
             scheduled_transaction_id = str(receipt.scheduled_transaction_id)
 
     return CreateScheduleResponse(schedule_id, scheduled_transaction_id, ResponseCode(receipt.status).name)
+
+
+@rpc_method("deleteSchedule")
+def delete_schedule(params: DeleteScheduleParams) -> DeleteScheduleResponse:
+    """Handles the deleteSchedule JSON-RPC request."""
+
+    client = get_client(params.sessionId)
+    transaction = _build_delete_schedule_transaction(params)
+
+    if params.commonTransactionParams is not None:
+        params.commonTransactionParams.apply_common_params(transaction, client)
+
+    response = transaction.execute(client, wait_for_receipt=False)
+    receipt = response.get_receipt(client, validate_status=True)
+
+    return DeleteScheduleResponse(status=ResponseCode(receipt.status).name)

--- a/tck/param/schedule.py
+++ b/tck/param/schedule.py
@@ -62,3 +62,18 @@ class CreateScheduleParams(BaseTransactionParams):
             sessionId=parse_session_id(params),
             commonTransactionParams=parse_common_transaction_params(params),
         )
+
+
+@dataclass
+class DeleteScheduleParams(BaseTransactionParams):
+    """Parse JSON-RPC params into a DeleteScheduleParams instance."""
+
+    scheduleId: str | None = None
+
+    @classmethod
+    def parse_json_params(cls, params: dict) -> DeleteScheduleParams:
+        return cls(
+            scheduleId=params.get("scheduleId"),
+            sessionId=parse_session_id(params),
+            commonTransactionParams=parse_common_transaction_params(params),
+        )

--- a/tck/response/schedule.py
+++ b/tck/response/schedule.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from tck.response.base import StatusOnlyResponse
+
 
 @dataclass
 class CreateScheduleResponse:
@@ -10,3 +12,8 @@ class CreateScheduleResponse:
     scheduleId: str | None = None
     transactionId: str | None = None
     status: str | None = None
+
+
+@dataclass
+class DeleteScheduleResponse(StatusOnlyResponse):
+    """Response payload for deleteSchedule."""

--- a/tests/unit/schedule_delete_transaction_test.py
+++ b/tests/unit/schedule_delete_transaction_test.py
@@ -68,12 +68,18 @@ def test_build_transaction_body_with_valid_parameters(mock_account_ids, delete_p
     assert transaction_body.scheduleDelete.scheduleID == delete_params["schedule_id"]._to_proto()
 
 
-def test_build_transaction_body_missing_schedule_id():
-    """Test that build_transaction_body raises ValueError when schedule_id is missing."""
+def test_build_transaction_body_missing_schedule_id(mock_account_ids):
+    """Test building a schedule delete transaction body when schedule_id is missing."""
+    operator_id, _, node_account_id, _, _ = mock_account_ids
+
     delete_tx = ScheduleDeleteTransaction()
 
-    with pytest.raises(ValueError, match="Missing required ScheduleID"):
-        delete_tx.build_transaction_body()
+    delete_tx.operator_account_id = operator_id
+    delete_tx.set_node_account_ids([node_account_id])
+
+    transaction_body = delete_tx.build_transaction_body()
+
+    assert not transaction_body.scheduleDelete.HasField("scheduleID")
 
 
 def test_set_schedule_id(delete_params):
@@ -204,11 +210,12 @@ def test_build_proto_body_with_valid_schedule_id(delete_params):
 
 
 def test_build_proto_body_missing_schedule_id():
-    """Test that _build_proto_body raises ValueError when schedule_id is missing."""
+    """Test that _build_proto_body returns an empty body when schedule_id is missing."""
     delete_tx = ScheduleDeleteTransaction()
 
-    with pytest.raises(ValueError, match="Missing required ScheduleID"):
-        delete_tx._build_proto_body()
+    proto_body = delete_tx._build_proto_body()
+
+    assert not proto_body.HasField("scheduleID")
 
 
 def test_default_transaction_fee():


### PR DESCRIPTION
**Description**:
Implements the `deleteSchedule` JSON-RPC method for the TCK server, enabling the `ScheduleDeleteTransaction` TCK test suite to run successfully against the Python SDK. 

* Add `DeleteScheduleParams` dataclass to handle incoming JSON-RPC parameters.
* Implement `deleteSchedule` handler in `tck/handlers/schedule.py` wrapping `ScheduleDeleteTransaction`.
* Apply common transaction parameters safely.
* Handle missing and malformed schedule IDs natively to align with TCK driver error expectations.

**Related issue(s)**:

Fixes #2595

**Notes for reviewer**:
The implementation handles the strict validation checks required by the JS TCK driver, successfully differentiating between expected local SDK string-parsing crashes (for empty/invalid strings) and native network-level `INVALID_SCHEDULE_ID` rejections (for omitted IDs).

Tested locally against the `hiero-sdk-tck` driver. All 9 tests pass:

` ` `text
  ScheduleDeleteTransaction
    Schedule ID
      ✔ (#1) Deletes a scheduled transaction that is not yet executed
      ✔ (#2) Deletes a scheduled transaction without the admin key
      ✔ (#3) Deletes a scheduled transaction with a schedule ID the doesn't exist
      ✔ (#4) Deletes a scheduled transaction with an empty schedule ID
      ✔ (#5) Deletes a scheduled transaction with no schedule ID
      ✔ (#6) Deletes a scheduled transaction that has already been deleted
      ✔ (#7) Deletes a scheduled transaction without signing with the admin key
      ✔ (#8) Deletes a scheduled transaction that has already executed
      ✔ (#9) Deletes a scheduled transaction with invalid schedule ID

  9 passing 
` ` `

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
