### PR TITLE
feat: Deprecate AccountBalanceQuery

### DIFF
--- a/docs/sdk_users/running_examples.md
+++ b/docs/sdk_users/running_examples.md
@@ -92,14 +92,26 @@ You can choose either syntax or even mix both styles in your projects.
 
 ### Querying Account Balance
 
+> **Deprecated:** `CryptoGetAccountBalanceQuery` is no longer supported.
+> The `CryptoGetBalance` endpoint is scheduled for removal with consensus
+> node release 77 (estimated September 2026). Use the Mirror Node REST API
+> instead, for example `GET /api/v1/accounts/{accountId}`.
+
+The following examples demonstrate the deprecated SDK call path and will
+raise an error when executed.
+
 #### Pythonic Syntax:
-```
-balance = CryptoGetAccountBalanceQuery(account_id=some_account_id).execute(client) print(f"Account balance: {balance.hbars} hbars")
+```python
+balance = CryptoGetAccountBalanceQuery(account_id=some_account_id).execute(client)
 ```
 
 #### Method Chaining:
 ```
-balance = ( CryptoGetAccountBalanceQuery() .set_account_id(some_account_id) .execute(client) ) print(f"Account balance: {balance.hbars} hbars")
+balance = (
+    CryptoGetAccountBalanceQuery()
+    .set_account_id(some_account_id)
+    .execute(client)
+)
 ```
 
 ### Creating an Account

--- a/examples/query/account_balance_query.py
+++ b/examples/query/account_balance_query.py
@@ -1,18 +1,12 @@
 """
-
-
 Query Balance Example.
 
-This script demonstrates how to:
-1. Set up a client connection to the Hedera network
-2. Create a new account with an initial balance
-3. Query account balance
-4. Transfer HBAR between accounts
+.. deprecated::
+   CryptoGetAccountBalanceQuery is no longer supported. Use the Mirror Node
+   REST API, for example GET /api/v1/accounts/{accountId}, to retrieve
+   account balances.
 
-Run with:
-  uv run examples/query/account_balance_query.py
-  python examples/query/account_balance_query.py
-
+...
 """
 
 import sys
@@ -88,23 +82,16 @@ def create_account(client, operator_key, initial_balance=Hbar(10)):
 
 def get_balance(client, account_id):
     """
-    Query and retrieve the HBAR balance of an account.
+    Demonstrate the deprecated account balance query.
 
-    Args:
-        client (Client): The Hiero SDK client.
-        account_id (AccountId): The account ID to query.
-
-    Returns:
-        Hbar: The account's current balance in HBAR.
+    .. deprecated::
+        CryptoGetAccountBalanceQuery is no longer supported. Use the
+        Mirror Node REST API, for example GET /api/v1/accounts/{accountId}.
     """
     print(f"Querying balance for account {account_id}...")
 
     balance_query = CryptoGetAccountBalanceQuery().set_account_id(account_id)
-    balance = balance_query.execute(client)
-
-    balance_hbar = balance.hbars.to_hbars()
-    print(f"✓ Balance retrieved: {balance_hbar} hbars\n")
-    return balance_hbar
+    return balance_query.execute(client)
 
 
 def transfer_hbars(client, operator_id, operator_key, recipient_id, amount):
@@ -157,6 +144,8 @@ def main():
         print("INITIAL BALANCE CHECK")
         print("=" * 60)
         initial_balance = get_balance(client, new_account_id)
+        if initial_balance is None:
+            print(f"Use the Mirror Node REST API instead, for example GET /api/v1/accounts/{new_account_id}.")
         print(f"Initial balance of new account: {initial_balance} hbars")
         print("=" * 60 + "\n")
 

--- a/examples/query/account_balance_query.py
+++ b/examples/query/account_balance_query.py
@@ -9,13 +9,16 @@ Query Balance Example.
 ...
 """
 
+import json
+import os
 import sys
 import time
+from urllib.request import Request, urlopen
 
 from hiero_sdk_python import (
     AccountCreateTransaction,
+    AccountId,
     Client,
-    CryptoGetAccountBalanceQuery,
     Hbar,
     PrivateKey,
     ResponseCode,
@@ -43,6 +46,22 @@ def setup_client():
     except ValueError as e:
         print(f"Error setting up client: {e}")
         sys.exit(1)
+
+
+def get_mirror_node_url():
+    """Return the Mirror Node URL for the configured Hedera network."""
+    network = os.getenv("HEDERA_NETWORK", "testnet").lower()
+
+    mirror_node_urls = {
+        "mainnet": "https://mainnet-public.mirrornode.hedera.com",
+        "testnet": "https://testnet.mirrornode.hedera.com",
+        "previewnet": "https://previewnet.mirrornode.hedera.com",
+    }
+
+    if network not in mirror_node_urls:
+        raise ValueError(f"Unsupported HEDERA_NETWORK: {network}. Expected mainnet, testnet, or previewnet.")
+
+    return mirror_node_urls[network]
 
 
 def create_account(client, operator_key, initial_balance=Hbar(10)):
@@ -80,18 +99,36 @@ def create_account(client, operator_key, initial_balance=Hbar(10)):
     return new_account_id, new_account_private_key
 
 
-def get_balance(client, account_id):
+def get_balance(account_id: AccountId):
     """
-    Demonstrate the deprecated account balance query.
+    Get an account balance using the Mirror Node REST API.
 
-    .. deprecated::
-        CryptoGetAccountBalanceQuery is no longer supported. Use the
-        Mirror Node REST API, for example GET /api/v1/accounts/{accountId}.
+    Args:
+        account_id (AccountId): The account whose balance should be retrieved.
+
+    Returns:
+        float: Account balance in HBAR.
     """
     print(f"Querying balance for account {account_id}...")
 
-    balance_query = CryptoGetAccountBalanceQuery().set_account_id(account_id)
-    return balance_query.execute(client)
+    mirror_node_url = get_mirror_node_url()
+    url = f"{mirror_node_url}/api/v1/accounts/{account_id}"
+
+    request = Request(
+        url,
+        headers={"Accept": "application/json"},
+    )
+
+    with urlopen(request, timeout=10) as response:
+        data = json.load(response)
+
+    balance_tinybars = data["balance"]
+    balance_hbars = balance_tinybars / 100_000_000
+
+    print("✓ Account balance retrieved successfully")
+    print(f"  HBAR balance: {balance_hbars} hbars")
+
+    return balance_hbars
 
 
 def transfer_hbars(client, operator_id, operator_key, recipient_id, amount):
@@ -143,9 +180,7 @@ def main():
         print("=" * 60)
         print("INITIAL BALANCE CHECK")
         print("=" * 60)
-        initial_balance = get_balance(client, new_account_id)
-        if initial_balance is None:
-            print(f"Use the Mirror Node REST API instead, for example GET /api/v1/accounts/{new_account_id}.")
+        initial_balance = get_balance(new_account_id)
         print(f"Initial balance of new account: {initial_balance} hbars")
         print("=" * 60 + "\n")
 
@@ -166,7 +201,7 @@ def main():
         print("=" * 60)
         print("UPDATED BALANCE CHECK")
         print("=" * 60)
-        updated_balance = get_balance(client, new_account_id)
+        updated_balance = get_balance(new_account_id)
         print(f"Updated balance of new account: {updated_balance} hbars")
         print("=" * 60 + "\n")
 

--- a/examples/query/account_balance_query.py
+++ b/examples/query/account_balance_query.py
@@ -122,7 +122,7 @@ def get_balance(account_id: AccountId):
     with urlopen(request, timeout=10) as response:
         data = json.load(response)
 
-    balance_tinybars = data["balance"]
+    balance_tinybars = data["balance"]["balance"]
     balance_hbars = balance_tinybars / 100_000_000
 
     print("✓ Account balance retrieved successfully")

--- a/examples/query/account_balance_query_2.py
+++ b/examples/query/account_balance_query_2.py
@@ -2,10 +2,10 @@
 # python examples/query/account_balance_query_2.py
 
 """
-
-Example: Use CryptoGetAccountBalanceQuery to retrieve an account's.
-
-HBAR and token balances, including minting NFTs to the account.
+.. deprecated::
+   CryptoGetAccountBalanceQuery is no longer supported. Use the Mirror Node
+   REST API, for example GET /api/v1/accounts/{accountId}, to retrieve
+   account balances.
 """
 
 import os

--- a/examples/query/account_balance_query_2.py
+++ b/examples/query/account_balance_query_2.py
@@ -128,7 +128,7 @@ def get_account_balance(account_id: AccountId):
         with urlopen(request, timeout=10) as response:
             data = json.load(response)
 
-        hbar_balance = data["balance"] / 100_000_000
+        hbar_balance = data["balance"]["balance"] / 100_000_000
 
         print("✅ Account balance retrieved successfully!")
         print(f"💰 HBAR Balance for {account_id}: {hbar_balance} hbars")
@@ -149,17 +149,16 @@ def get_token_balance(balance_data, token_id: TokenId):
     return 0
 
 
-# OPTIONAL comparison function
-def compare_token_balances(client, treasury_id: AccountId, receiver_id: AccountId, token_id: TokenId):
+def compare_token_balances(treasury_id: AccountId, receiver_id: AccountId, token_id: TokenId):
     """Compare token balances between two accounts."""
     print(f"\n🔎 Comparing token balances for Token ID {token_id} between accounts {treasury_id} and {receiver_id}...")
-    # retrieve balances for both accounts
-    treasury_balance = get_account_balance(client, treasury_id)
-    receiver_balance = get_account_balance(client, receiver_id)
-    # extract token balances
-    treasury_token_balance = treasury_balance.token_balances.get(token_id, 0)
-    receiver_token_balance = receiver_balance.token_balances.get(token_id, 0)
-    # print results
+
+    treasury_balance = get_account_balance(treasury_id)
+    receiver_balance = get_account_balance(receiver_id)
+
+    treasury_token_balance = get_token_balance(treasury_balance, token_id)
+    receiver_token_balance = get_token_balance(receiver_balance, token_id)
+
     print(f"🏷️ Token balance for Treasury ({treasury_id}): {treasury_token_balance}")
     print(f"🏷️ Token balance for Receiver ({receiver_id}): {receiver_token_balance}")
 
@@ -181,7 +180,7 @@ def main():
     # will be owned by the test account and show up in its token balances.
     token_id = create_and_mint_token(test_account_id, test_account_key, client)
     # Retrieve and display account balance for the test account
-    get_account_balance(client, test_account_id)
+    get_account_balance(test_account_id)
     # OPTIONAL comparison of token balances between test account and operator account
     compare_token_balances(client, test_account_id, client.operator_account_id, token_id)
 

--- a/examples/query/account_balance_query_2.py
+++ b/examples/query/account_balance_query_2.py
@@ -182,7 +182,7 @@ def main():
     # Retrieve and display account balance for the test account
     get_account_balance(test_account_id)
     # OPTIONAL comparison of token balances between test account and operator account
-    compare_token_balances(client, test_account_id, client.operator_account_id, token_id)
+    compare_token_balances(test_account_id, client.operator_account_id, token_id)
 
 
 if __name__ == "__main__":

--- a/examples/query/account_balance_query_2.py
+++ b/examples/query/account_balance_query_2.py
@@ -8,8 +8,10 @@
    account balances.
 """
 
+import json
 import os
 import sys
+from urllib.request import Request, urlopen
 
 from hiero_sdk_python import (
     AccountCreateTransaction,
@@ -23,7 +25,6 @@ from hiero_sdk_python import (
     TokenMintTransaction,
     TokenType,
 )
-from hiero_sdk_python.query.account_balance_query import CryptoGetAccountBalanceQuery
 from hiero_sdk_python.tokens.token_id import TokenId
 
 
@@ -39,6 +40,22 @@ def setup_client():
     except ValueError as e:
         print(f"Error setting up client: {e}")
         sys.exit(1)
+
+
+def get_mirror_node_url():
+    """Return the Mirror Node URL for the configured Hedera network."""
+    network = os.getenv("HEDERA_NETWORK", "testnet").lower()
+
+    mirror_node_urls = {
+        "mainnet": "https://mainnet-public.mirrornode.hedera.com",
+        "testnet": "https://testnet.mirrornode.hedera.com",
+        "previewnet": "https://previewnet.mirrornode.hedera.com",
+    }
+
+    if network not in mirror_node_urls:
+        raise ValueError(f"Unsupported HEDERA_NETWORK: {network}. Expected mainnet, testnet, or previewnet.")
+
+    return mirror_node_urls[network]
 
 
 def create_account(client, name, initial_balance=Hbar(10)):
@@ -95,20 +112,41 @@ def create_and_mint_token(treasury_account_id, treasury_account_key, client):
         sys.exit(1)
 
 
-def get_account_balance(client: Client, account_id: AccountId):
-    """Get account balance using CryptoGetAccountBalanceQuery."""
-    print(f"Retrieving account balance for account id: {account_id}  ...")
+def get_account_balance(account_id: AccountId):
+    """Get account balance using the Mirror Node REST API."""
+    print(f"Retrieving account balance for account id: {account_id} ...")
+
+    mirror_node_url = get_mirror_node_url()
+    url = f"{mirror_node_url}/api/v1/accounts/{account_id}"
+
+    request = Request(
+        url,
+        headers={"Accept": "application/json"},
+    )
+
     try:
-        # Use CryptoGetAccountBalanceQuery to get the account balance
-        account_balance = CryptoGetAccountBalanceQuery().set_account_id(account_id).execute(client)
+        with urlopen(request, timeout=10) as response:
+            data = json.load(response)
+
+        hbar_balance = data["balance"] / 100_000_000
+
         print("✅ Account balance retrieved successfully!")
-        # Print account balance with account_id context
-        print(f"💰 HBAR Balance for {account_id}: {account_balance.hbars} hbars")
-        # Alternatively, you can use: print(account_balance)
-        return account_balance
-    except (ValueError, TypeError, RuntimeError, ConnectionError) as error:
-        print(f"Error retrieving account balance: {error}")
+        print(f"💰 HBAR Balance for {account_id}: {hbar_balance} hbars")
+
+        return data
+
+    except Exception as error:
+        print(f"❌ Error retrieving account balance: {error}")
         sys.exit(1)
+
+
+def get_token_balance(balance_data, token_id: TokenId):
+    """Get a token balance from a Mirror Node account response."""
+    for token in balance_data.get("balance", {}).get("tokens", []):
+        if token["token_id"] == str(token_id):
+            return token["balance"]
+
+    return 0
 
 
 # OPTIONAL comparison function

--- a/src/hiero_sdk_python/query/account_balance_query.py
+++ b/src/hiero_sdk_python/query/account_balance_query.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import Any
 
 from hiero_sdk_python.account.account_balance import AccountBalance
@@ -18,10 +19,12 @@ logger = logging.getLogger(__name__)
 
 class CryptoGetAccountBalanceQuery(Query):
     """
-    A query to retrieve the balance of a specific account from the Hedera network.
+    Query an account's balance.
 
-    This class constructs and executes a query to obtain the balance of an account,
-    including hbars and tokens.
+    .. deprecated::
+        The CryptoGetBalance endpoint is scheduled for removal with the
+        consensus node release 77 (estimated September 2026). Use the Mirror
+        Node REST API to retrieve account balances instead.
     """
 
     def __init__(
@@ -29,13 +32,11 @@ class CryptoGetAccountBalanceQuery(Query):
         account_id: AccountId | None = None,
         contract_id: ContractId | None = None,
     ) -> None:
-        """
-        Initializes a new instance of the CryptoGetAccountBalanceQuery class.
-
-        Args:
-            account_id (AccountId, optional): The ID of the account to retrieve the balance for.
-            contract_id (ContractId, optional): The ID of the contract to retrieve the balance for.
-        """
+        warnings.warn(
+            "Deprecated: AccountBalanceQuery will stop working when the Hedera network removes the CryptoGetBalance endpoint (estimated September 2026, consensus node release 77). Use the mirror node REST API to retrieve account balances.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__()
         self.account_id: AccountId | None = None
         self.contract_id: ContractId | None = None
@@ -133,25 +134,20 @@ class CryptoGetAccountBalanceQuery(Query):
 
     def execute(self, client: Client, timeout: int | float | None = None) -> AccountBalance:
         """
-        Executes the account balance query.
+        Execute the account balance query.
 
-        This function delegates the core logic to `_execute()`, and may propagate exceptions raised by it.
-
-        Sends the query to the Hedera network and processes the response
-        to return an AccountBalance object.
-
-        Args:
-            client (Client): The client instance to use for execution
-            timeout (Optional[Union[int, float]]): The total execution timeout (in seconds) for this execution.
-
-        Returns:
-            AccountBalance: The account balance from the network
+        .. deprecated::
+            The CryptoGetBalance endpoint is scheduled for removal with the
+            consensus node release 77 (estimated September 2026). Use the Mirror
+            Node REST API to retrieve account balances instead.
 
         Raises:
-            PrecheckError: If the query fails with a non-retryable error
-            MaxAttemptsError: If the query fails after the maximum number of attempts
-            ReceiptStatusError: If the query fails with a receipt status error
+            RuntimeError: Always, because the AccountBalanceQuery is no longer
+                supported.
         """
+        raise RuntimeError(
+            "Error: AccountBalanceQuery is no longer supported. Use the mirror node REST API to retrieve account balances."
+        )
         self._before_execute(client)
         response = self._execute(client, timeout)
 

--- a/tck/handlers/account.py
+++ b/tck/handlers/account.py
@@ -266,7 +266,10 @@ def delete_account(params: DeleteAccountParams) -> DeleteAccountResponse:
 
 @rpc_method("getAccountBalance")
 def get_account_balance(params: GetAccountBalanceParams) -> GetAccountBalanceResponse:
-    """Get account balance for an account."""
+    """Get account balance for an account.
+
+    Deprecated: use the Mirror Node REST API instead.
+    """
     client = get_client(params.sessionId)
 
     query = CryptoGetAccountBalanceQuery().set_grpc_deadline(DEFAULT_GRPC_TIMEOUT)
@@ -276,7 +279,14 @@ def get_account_balance(params: GetAccountBalanceParams) -> GetAccountBalanceRes
     if params.contractId is not None:
         query.set_contract_id(ContractId.from_string(params.contractId))
 
-    account_balance = query.execute(client)
+    try:
+        account_balance = query.execute(client)
+    except RuntimeError as exc:
+        raise RuntimeError(
+            "Error: AccountBalanceQuery is no longer supported. "
+            "Use the mirror node REST API to retrieve account balances."
+        ) from exc
+
     return map_account_balance_response(account_balance)
 
 

--- a/tests/integration/account_balance_query_e2e_test.py
+++ b/tests/integration/account_balance_query_e2e_test.py
@@ -1,116 +1,91 @@
 from __future__ import annotations
 
+import re
+
 import pytest
 
-from examples.contract.contracts import SIMPLE_CONTRACT_BYTECODE
-from hiero_sdk_python.contract.contract_create_transaction import ContractCreateTransaction
-from hiero_sdk_python.contract.contract_delete_transaction import ContractDeleteTransaction
+from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.contract.contract_id import ContractId
-from hiero_sdk_python.exceptions import PrecheckError
 from hiero_sdk_python.query.account_balance_query import CryptoGetAccountBalanceQuery
-from hiero_sdk_python.response_code import ResponseCode
-from tests.integration.utils import IntegrationTestEnv
 
 
 pytestmark = pytest.mark.integration
 
+DEPRECATION_MESSAGE = (
+    "Deprecated: AccountBalanceQuery will stop working when the Hedera network "
+    "removes the CryptoGetBalance endpoint (estimated September 2026, consensus "
+    "node release 77). Use the mirror node REST API to retrieve account balances."
+)
 
-def _create_test_contract(env: IntegrationTestEnv) -> ContractId:
-    bytecode = bytes.fromhex(SIMPLE_CONTRACT_BYTECODE)
-
-    receipt = (
-        ContractCreateTransaction()
-        .set_bytecode(bytecode)
-        .set_gas(2_000_000)
-        .set_contract_memo("integration test: contract balance query")
-        .execute(env.client)
-    )
-
-    if ResponseCode(receipt.status) != ResponseCode.SUCCESS:
-        raise RuntimeError(f"ContractCreateTransaction failed with status: {ResponseCode(receipt.status).name}")
-
-    if receipt.contract_id is None:
-        raise RuntimeError("ContractCreateTransaction succeeded but receipt.contract_id is None")
-
-    return receipt.contract_id
+UNSUPPORTED_OPERATION_MESSAGE = (
+    "Error: AccountBalanceQuery is no longer supported. Use the mirror node REST API to retrieve account balances."
+)
 
 
-def _delete_contract_best_effort(env: IntegrationTestEnv, contract_id: ContractId) -> None:
-    """
-    Best-effort cleanup: delete contract and transfer any remaining hbars to the operator account.
-    Cleanup failures should not fail the test run (avoid flakes).
-    """
-    try:
-        receipt = (
-            ContractDeleteTransaction()
-            .set_contract_id(contract_id)
-            .set_transfer_account_id(env.operator_id)
-            .execute(env.client)
-        )
+def test_integration_account_balance_query_raises_unsupported_operation():
+    """Account balance query should warn on construction and fail before networking."""
+    with pytest.warns(
+        DeprecationWarning,
+        match=re.escape(DEPRECATION_MESSAGE),
+    ):
+        query = CryptoGetAccountBalanceQuery(account_id=AccountId(0, 0, 2))
 
-        if ResponseCode(receipt.status) != ResponseCode.SUCCESS:
-            print(
-                f"[cleanup] ContractDeleteTransaction failed for {contract_id} "
-                f"with status: {ResponseCode(receipt.status).name}"
-            )
-    except Exception as e:
-        print(f"[cleanup] Exception while deleting contract {contract_id}: {e}")
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape(UNSUPPORTED_OPERATION_MESSAGE),
+    ):
+        query.execute(None)
 
 
-def test_integration_account_balance_query_can_execute():
-    env = IntegrationTestEnv()
-    try:
-        balance = CryptoGetAccountBalanceQuery(account_id=env.operator_id).execute(env.client)
-        assert balance is not None
-        assert hasattr(balance, "hbars")
-        assert balance.hbars is not None
-        assert balance.hbars.to_tinybars() >= 0
-    finally:
-        env.close()
+def test_integration_contract_balance_query_raises_unsupported_operation():
+    """Contract balance query should warn on construction and fail before networking."""
+    with pytest.warns(
+        DeprecationWarning,
+        match=re.escape(DEPRECATION_MESSAGE),
+    ):
+        query = CryptoGetAccountBalanceQuery(contract_id=ContractId(0, 0, 1234))
+
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape(UNSUPPORTED_OPERATION_MESSAGE),
+    ):
+        query.execute(None)
 
 
-def test_integration_contract_balance_query_can_execute():
-    env = IntegrationTestEnv()
-    contract_id: ContractId | None = None
-    try:
-        contract_id = _create_test_contract(env)
+def test_integration_balance_query_raises_unsupported_operation_when_neither_source_set():
+    """Execution should fail before validating account/contract source."""
+    with pytest.warns(
+        DeprecationWarning,
+        match=re.escape(DEPRECATION_MESSAGE),
+    ):
+        query = CryptoGetAccountBalanceQuery()
 
-        balance = CryptoGetAccountBalanceQuery().set_contract_id(contract_id).execute(env.client)
-
-        assert balance is not None
-        assert hasattr(balance, "hbars")
-        assert balance.hbars is not None
-        assert balance.hbars.to_tinybars() >= 0
-    finally:
-        if contract_id is not None:
-            _delete_contract_best_effort(env, contract_id)
-        env.close()
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape(UNSUPPORTED_OPERATION_MESSAGE),
+    ):
+        query.execute(None)
 
 
-def test_integration_balance_query_raises_when_neither_source_set():
-    env = IntegrationTestEnv()
-    try:
-        with pytest.raises(PrecheckError) as err:
-            CryptoGetAccountBalanceQuery().execute(env.client)
+def test_integration_balance_query_invalid_account_id_still_raises_type_error():
+    """Setter validation should still happen before execution."""
+    with pytest.warns(
+        DeprecationWarning,
+        match=re.escape(DEPRECATION_MESSAGE),
+    ):
+        query = CryptoGetAccountBalanceQuery()
 
-        assert err.value.status == ResponseCode.INVALID_ACCOUNT_ID
-    finally:
-        env.close()
-
-
-def test_integration_balance_query_with_invalid_account_id_raises():
-    env = IntegrationTestEnv()
-    try:
-        with pytest.raises(TypeError, match=r"account_id must be an AccountId\."):
-            CryptoGetAccountBalanceQuery().set_account_id("0.0.12345").execute(env.client)
-    finally:
-        env.close()
+    with pytest.raises(TypeError, match=r"account_id must be an AccountId\."):
+        query.set_account_id("0.0.12345")
 
 
-def test_integration_balance_query_with_invalid_contract_id_raises():
-    env = IntegrationTestEnv()
-    try:
-        with pytest.raises(TypeError, match=r"contract_id must be a ContractId\."):
-            CryptoGetAccountBalanceQuery().set_contract_id("0.0.12345").execute(env.client)
-    finally:
-        env.close()
+def test_integration_balance_query_invalid_contract_id_still_raises_type_error():
+    """Setter validation should still happen before execution."""
+    with pytest.warns(
+        DeprecationWarning,
+        match=re.escape(DEPRECATION_MESSAGE),
+    ):
+        query = CryptoGetAccountBalanceQuery()
+
+    with pytest.raises(TypeError, match=r"contract_id must be a ContractId\."):
+        query.set_contract_id("0.0.12345")

--- a/tests/unit/account_balance_query_test.py
+++ b/tests/unit/account_balance_query_test.py
@@ -2,69 +2,73 @@
 
 from __future__ import annotations
 
+import re
+import warnings
+
 import pytest
 
 from hiero_sdk_python.account.account_id import AccountId
 from hiero_sdk_python.contract.contract_id import ContractId
-from hiero_sdk_python.hapi.services import (
-    basic_types_pb2,
-    response_header_pb2,
-    response_pb2,
-)
-from hiero_sdk_python.hapi.services.crypto_get_account_balance_pb2 import (
-    CryptoGetAccountBalanceResponse,
-)
-from hiero_sdk_python.hapi.services.query_header_pb2 import ResponseType
 from hiero_sdk_python.query.account_balance_query import CryptoGetAccountBalanceQuery
-from hiero_sdk_python.response_code import ResponseCode
-from tests.unit.mock_server import mock_hedera_servers
 
 
 pytestmark = pytest.mark.unit
+
+DEPRECATION_MESSAGE = (
+    "Deprecated: AccountBalanceQuery will stop working when the Hedera network "
+    "removes the CryptoGetBalance endpoint (estimated September 2026, consensus "
+    "node release 77). Use the mirror node REST API to retrieve account balances."
+)
+
+UNSUPPORTED_OPERATION_MESSAGE = (
+    "Error: AccountBalanceQuery is no longer supported. Use the mirror node REST API to retrieve account balances."
+)
 
 
 # This test uses fixture mock_account_ids as parameter
 def test_build_account_balance_query(mock_account_ids):
     """Test building a CryptoGetAccountBalanceQuery with a valid account ID."""
     account_id_sender, *_ = mock_account_ids
-    query = CryptoGetAccountBalanceQuery(account_id=account_id_sender)
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=re.escape(DEPRECATION_MESSAGE),
+    ):
+        query = CryptoGetAccountBalanceQuery(account_id=account_id_sender)
+
     assert query.account_id == account_id_sender
 
 
-def test_execute_account_balance_query():
-    """Test executing the CryptoGetAccountBalanceQuery with a mocked client."""
-    balance_response = response_pb2.Response(
-        cryptogetAccountBalance=CryptoGetAccountBalanceResponse(
-            header=response_header_pb2.ResponseHeader(
-                nodeTransactionPrecheckCode=ResponseCode.OK,
-                responseType=ResponseType.ANSWER_ONLY,
-                cost=0,
-            ),
-            accountID=basic_types_pb2.AccountID(shardNum=0, realmNum=0, accountNum=1800),
-            balance=2000,
-        )
-    )
+def test_execute_account_balance_query_raises_unsupported_operation():
+    """Test that executing the account balance query raises before network access."""
+    with pytest.warns(
+        DeprecationWarning,
+        match=re.escape(DEPRECATION_MESSAGE),
+    ):
+        query = CryptoGetAccountBalanceQuery().set_account_id(AccountId(0, 0, 1800))
 
-    response_sequences = [[balance_response]]
-
-    # Use the context manager to set up and tear down the mock environment
-    with mock_hedera_servers(response_sequences) as client:
-        # Create the query and verify no exceptions are raised
-        try:
-            CryptoGetAccountBalanceQuery().set_account_id(AccountId(0, 0, 1800)).execute(client)
-        except Exception as e:
-            pytest.fail(f"Unexpected exception raised: {e}")
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape(UNSUPPORTED_OPERATION_MESSAGE),
+    ):
+        query.execute(None)
 
 
 def test_account_balance_query_does_not_require_payment():
     """Test that the account balance query does not require payment."""
-    query = CryptoGetAccountBalanceQuery()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        query = CryptoGetAccountBalanceQuery()
+
     assert not query._is_payment_required()
 
 
 def test_set_account_id_returns_self_for_chaining():
     """set_account_id should return self to enable method chaining."""
-    query = CryptoGetAccountBalanceQuery()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        query = CryptoGetAccountBalanceQuery()
+
     account_id = AccountId(0, 0, 1800)
 
     result = query.set_account_id(account_id)
@@ -75,7 +79,10 @@ def test_set_account_id_returns_self_for_chaining():
 
 def test_set_contract_id_returns_self_for_chaining():
     """set_contract_id should return self to enable method chaining."""
-    query = CryptoGetAccountBalanceQuery()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        query = CryptoGetAccountBalanceQuery()
+
     contract_id = ContractId(0, 0, 1234)
 
     result = query.set_contract_id(contract_id)
@@ -85,14 +92,18 @@ def test_set_contract_id_returns_self_for_chaining():
 
 
 def test_set_account_id_with_invalid_type_raises():
-    query = CryptoGetAccountBalanceQuery()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        query = CryptoGetAccountBalanceQuery()
 
     with pytest.raises(TypeError, match=r"account_id must be an AccountId\."):
         query.set_account_id("ciao")
 
 
 def test_set_contract_id_with_invalid_type_raises():
-    query = CryptoGetAccountBalanceQuery()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        query = CryptoGetAccountBalanceQuery()
 
     with pytest.raises(TypeError, match=r"contract_id must be a ContractId\."):
         query.set_contract_id("ciao")
@@ -101,7 +112,13 @@ def test_set_contract_id_with_invalid_type_raises():
 def test_build_account_balance_query_with_contract_id():
     """Test building a CryptoGetAccountBalanceQuery with a valid contract ID."""
     contract_id = ContractId(0, 0, 1234)
-    query = CryptoGetAccountBalanceQuery(contract_id=contract_id)
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=re.escape(DEPRECATION_MESSAGE),
+    ):
+        query = CryptoGetAccountBalanceQuery(contract_id=contract_id)
+
     assert query.contract_id == contract_id
     assert query.account_id is None
     assert isinstance(query.contract_id, ContractId)
@@ -113,7 +130,11 @@ def test_set_contract_id_method_chaining_resets_account_id(mock_account_ids):
     account_id_sender, *_ = mock_account_ids
     contract_id = ContractId(0, 0, 1234)
 
-    query = CryptoGetAccountBalanceQuery().set_account_id(account_id_sender).set_contract_id(contract_id)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        query = CryptoGetAccountBalanceQuery()
+
+    query.set_account_id(account_id_sender).set_contract_id(contract_id)
 
     assert query.contract_id == contract_id
     assert query.account_id is None
@@ -122,19 +143,29 @@ def test_set_contract_id_method_chaining_resets_account_id(mock_account_ids):
 def test_last_wins_when_both_account_id_and_contract_id_are_set(
     mock_account_ids,
 ):
-    """_make_request should raise if both account_id and contract_id are set."""
+    """The last configured source should replace the previous one."""
     account_id_sender, *_ = mock_account_ids
     contract_id = ContractId(0, 0, 1234)
 
-    query = CryptoGetAccountBalanceQuery(account_id=account_id_sender, contract_id=contract_id)
+    with pytest.warns(
+        DeprecationWarning,
+        match=re.escape(DEPRECATION_MESSAGE),
+    ):
+        query = CryptoGetAccountBalanceQuery(
+            account_id=account_id_sender,
+            contract_id=contract_id,
+        )
 
     assert query.contract_id == contract_id
     assert query.account_id is None
 
 
 def test_make_request_when_neither_account_id_nor_contract_id_is_set():
-    """_make_request should create request without ids when neither account_id nor contract_id is set."""
-    query = CryptoGetAccountBalanceQuery()
+    """_make_request should create request without ids when neither is set."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        query = CryptoGetAccountBalanceQuery()
+
     proto = query._make_request()
 
     assert not proto.cryptogetAccountBalance.HasField("accountID")
@@ -144,15 +175,15 @@ def test_make_request_when_neither_account_id_nor_contract_id_is_set():
 def test_make_request_populates_contract_id_only():
     """_make_request should populate contractID when only contract_id is set."""
     contract_id = ContractId(0, 0, 1234)
-    query = CryptoGetAccountBalanceQuery().set_contract_id(contract_id)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        query = CryptoGetAccountBalanceQuery().set_contract_id(contract_id)
 
     req = query._make_request()
     balance_query = req.cryptogetAccountBalance
 
-    # contractID must match
     assert balance_query.contractID == contract_id._to_proto()
-
-    # accountID should be unset
     assert not balance_query.HasField("accountID")
 
 
@@ -160,12 +191,12 @@ def test_make_request_populates_account_id_only(mock_account_ids):
     """_make_request should populate accountID when only account_id is set."""
     account_id_sender, *_ = mock_account_ids
 
-    query = CryptoGetAccountBalanceQuery().set_account_id(account_id_sender)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        query = CryptoGetAccountBalanceQuery().set_account_id(account_id_sender)
+
     req = query._make_request()
     balance_query = req.cryptogetAccountBalance
 
-    # accountID must match
     assert balance_query.accountID == account_id_sender._to_proto()
-
-    # contractID should be unset
     assert not balance_query.HasField("contractID")

--- a/tests/unit/executable_test.py
+++ b/tests/unit/executable_test.py
@@ -16,7 +16,6 @@ from hiero_sdk_python.executable import (
 )
 from hiero_sdk_python.hapi.services import (
     basic_types_pb2,
-    crypto_get_account_balance_pb2,
     query_pb2,
     response_header_pb2,
     response_pb2,
@@ -427,58 +426,20 @@ def test_transaction_node_switching_body_bytes():
         )
 
 
-def test_query_retry_on_busy():
+def test_query_raises_when_account_balance_query_is_unsupported():
     """
-    Test query retry behavior when receiving BUSY response.
-
-    This test simulates two scenarios:
-    1. First node returns BUSY response
-    2. Second node returns OK response with the balance
-
-    Verifies that the query successfully retries on a different node after receiving BUSY,
-    that the balance is returned correctly and that time.sleep was called once for the retry delay.
+    Test that account balance queries raise an error because the
+    CryptoGetBalance endpoint is no longer supported.
     """
-    # Create a BUSY response to simulate a node being temporarily unavailable
-    # This response indicates the node cannot process the request at this time
-    busy_response = response_pb2.Response(
-        cryptogetAccountBalance=crypto_get_account_balance_pb2.CryptoGetAccountBalanceResponse(
-            header=response_header_pb2.ResponseHeader(nodeTransactionPrecheckCode=ResponseCode.BUSY)
-        )
-    )
-
-    # Create a successful OK response with a balance of 1 Hbar
-    # This simulates a successful account balance query response
-    ok_response = response_pb2.Response(
-        cryptogetAccountBalance=crypto_get_account_balance_pb2.CryptoGetAccountBalanceResponse(
-            header=response_header_pb2.ResponseHeader(nodeTransactionPrecheckCode=ResponseCode.OK),
-            balance=100000000,  # Balance in tinybars
-        )
-    )
-
-    # Set up response sequences for multiple nodes:
-    # First node returns BUSY, forcing a retry
-    # Second node returns OK with the balance
-    response_sequences = [
-        [busy_response, ok_response],
-        [ok_response],  # additional response to mimic additional node
-    ]
-
-    with (
-        mock_hedera_servers(response_sequences) as client,
-        patch("hiero_sdk_python.executable.time.sleep") as mock_sleep,
-    ):
+    with mock_hedera_servers([]) as client:
         query = CryptoGetAccountBalanceQuery()
         query.set_account_id(AccountId(0, 0, 1234))
 
-        balance = query.execute(client)
-
-        # Verify we slept once for the retry
-        assert mock_sleep.call_count == 1, "Should have retried once"
-
-        assert balance.hbars.to_tinybars() == 100000000
-        # Verify we switched to the second node
-        assert query._node_account_ids.index == 0
-        assert query._node_account_ids.current == AccountId(0, 0, 3), "Client should have switched to the second node"
+        with pytest.raises(
+            RuntimeError,
+            match="AccountBalanceQuery is no longer supported",
+        ):
+            query.execute(client)
 
 
 # Set max_attempts


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

-->

Deprecate and disable CryptoGetAccountBalanceQuery in preparation for the removal of the CryptoGetBalance endpoint from the Hedera network.

**Changes**:

* Mark CryptoGetAccountBalanceQuery as deprecated.
* Emit a DeprecationWarning when the query is constructed.
* Prevent CryptoGetAccountBalanceQuery.execute() from making network requests.
* Raise a RuntimeError when attempting to execute the query.
* Preserve existing account ID and contract ID setter validation and method chaining behavior.
* Preserve support for constructing queries with either an account ID or contract ID.
* Update unit and integration tests to validate the new deprecation and unsupported-operation behavior.
* Verify that execution fails before any network access is attempted.

**Deprecation**:

The CryptoGetBalance endpoint is scheduled for removal with consensus node release 77, currently estimated for September 2026.

Users should use the Mirror Node REST API to retrieve account balances instead.

**Related issue(s)**:

Fixes #2525 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
