### PR TITLE
feat(tck): implement getScheduleInfo JSON-RPC method

### DIFF
--- a/tck/handlers/schedule.py
+++ b/tck/handlers/schedule.py
@@ -4,10 +4,13 @@ from collections.abc import Callable
 from typing import Any, cast
 
 from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.schedule.schedule_create_transaction import ScheduleCreateTransaction
 from hiero_sdk_python.schedule.schedule_delete_transaction import ScheduleDeleteTransaction
 from hiero_sdk_python.schedule.schedule_id import ScheduleId
+from hiero_sdk_python.schedule.schedule_info import ScheduleInfo
+from hiero_sdk_python.schedule.schedule_info_query import ScheduleInfoQuery
 from hiero_sdk_python.schedule.schedule_sign_transaction import ScheduleSignTransaction
 from hiero_sdk_python.timestamp import Timestamp
 from hiero_sdk_python.transaction.transaction import Transaction
@@ -26,16 +29,22 @@ from tck.param.common import CommonTransactionParams
 from tck.param.schedule import (
     CreateScheduleParams,
     DeleteScheduleParams,
+    GetScheduleInfoParams,
     ScheduledTransactionParams,
     SignScheduleParams,
 )
 from tck.param.token import BurnTokenParams, MintTokenParams
 from tck.param.topic import CreateTopicParams, TopicMessageSubmitParams
 from tck.param.transfer import TransferCryptoParams
-from tck.response.schedule import CreateScheduleResponse, DeleteScheduleResponse, SignScheduleResponse
+from tck.response.schedule import (
+    CreateScheduleResponse,
+    DeleteScheduleResponse,
+    ScheduleInfoResponse,
+    SignScheduleResponse,
+)
 from tck.util.client_utils import get_client
 from tck.util.constants import DEFAULT_GRPC_TIMEOUT
-from tck.util.key_utils import get_key_from_string
+from tck.util.key_utils import get_key_from_string, key_to_string
 from tck.util.param_utils import to_int
 
 
@@ -208,3 +217,50 @@ def delete_schedule(params: DeleteScheduleParams) -> DeleteScheduleResponse:
     receipt = response.get_receipt(client, validate_status=True)
 
     return DeleteScheduleResponse(status=ResponseCode(receipt.status).name)
+
+
+@rpc_method("getScheduleInfo")
+def get_schedule_info(params: GetScheduleInfoParams) -> ScheduleInfoResponse:
+    """Get schedule info."""
+    client = get_client(params.sessionId)
+
+    query = ScheduleInfoQuery().set_grpc_deadline(DEFAULT_GRPC_TIMEOUT)
+
+    if params.scheduleId is not None:
+        query.set_schedule_id(ScheduleId.from_string(params.scheduleId))
+
+    if params.queryPayment is not None:
+        query.set_query_payment(Hbar.from_tinybars(int(params.queryPayment)))
+
+    if params.maxQueryPayment is not None:
+        query.set_max_query_payment(Hbar.from_tinybars(int(params.maxQueryPayment)))
+
+    if params.getCost:
+        cost = query.get_cost(client)
+        return ScheduleInfoResponse(cost=str(cost.to_tinybars()))
+
+    schedule_info = query.execute(client)
+    return _map_schedule_info_response(schedule_info)
+
+
+def _map_schedule_info_response(schedule_info: ScheduleInfo) -> ScheduleInfoResponse:
+    """Map ScheduleInfo to JSON-RPC ScheduleInfoResponse."""
+    return ScheduleInfoResponse(
+        scheduleId=str(schedule_info.schedule_id) if schedule_info.schedule_id is not None else None,
+        creatorAccountId=(
+            str(schedule_info.creator_account_id) if schedule_info.creator_account_id is not None else None
+        ),
+        payerAccountId=str(schedule_info.payer_account_id) if schedule_info.payer_account_id is not None else None,
+        scheduledTransactionId=(
+            str(schedule_info.scheduled_transaction_id) if schedule_info.scheduled_transaction_id is not None else None
+        ),
+        signers=[key_to_string(signer) for signer in schedule_info.signers],
+        adminKey=key_to_string(schedule_info.admin_key) if schedule_info.admin_key is not None else None,
+        expirationTime=(
+            str(schedule_info.expiration_time.seconds) if schedule_info.expiration_time is not None else None
+        ),
+        executedAt=str(schedule_info.executed_at.seconds) if schedule_info.executed_at is not None else None,
+        deletedAt=str(schedule_info.deleted_at.seconds) if schedule_info.deleted_at is not None else None,
+        scheduleMemo=schedule_info.schedule_memo,
+        waitForExpiry=schedule_info.wait_for_expiry,
+    )

--- a/tck/handlers/schedule.py
+++ b/tck/handlers/schedule.py
@@ -39,6 +39,7 @@ from tck.param.transfer import TransferCryptoParams
 from tck.response.schedule import (
     CreateScheduleResponse,
     DeleteScheduleResponse,
+    ScheduleInfoCostResponse,
     ScheduleInfoResponse,
     SignScheduleResponse,
 )
@@ -220,7 +221,7 @@ def delete_schedule(params: DeleteScheduleParams) -> DeleteScheduleResponse:
 
 
 @rpc_method("getScheduleInfo")
-def get_schedule_info(params: GetScheduleInfoParams) -> ScheduleInfoResponse:
+def get_schedule_info(params: GetScheduleInfoParams) -> ScheduleInfoResponse | ScheduleInfoCostResponse:
     """Get schedule info."""
     client = get_client(params.sessionId)
 
@@ -237,7 +238,7 @@ def get_schedule_info(params: GetScheduleInfoParams) -> ScheduleInfoResponse:
 
     if params.getCost:
         cost = query.get_cost(client)
-        return ScheduleInfoResponse(cost=str(cost.to_tinybars()))
+        return ScheduleInfoCostResponse(cost=str(cost.to_tinybars()))
 
     schedule_info = query.execute(client)
     return _map_schedule_info_response(schedule_info)

--- a/tck/param/schedule.py
+++ b/tck/param/schedule.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from tck.param.base import BaseTransactionParams
+from tck.param.base import BaseParams, BaseTransactionParams
 from tck.util.param_utils import parse_common_transaction_params, parse_session_id, to_bool
 
 
@@ -92,4 +92,25 @@ class DeleteScheduleParams(BaseTransactionParams):
             scheduleId=params.get("scheduleId"),
             sessionId=parse_session_id(params),
             commonTransactionParams=parse_common_transaction_params(params),
+        )
+
+
+@dataclass
+class GetScheduleInfoParams(BaseParams):
+    """Request parameters for the getScheduleInfo endpoint."""
+
+    scheduleId: str | None = None
+    queryPayment: str | None = None
+    maxQueryPayment: str | None = None
+    getCost: bool | None = None
+
+    @classmethod
+    def parse_json_params(cls, params: dict) -> GetScheduleInfoParams:
+        """Parse JSON-RPC params into a GetScheduleInfoParams instance."""
+        return cls(
+            scheduleId=params.get("scheduleId"),
+            queryPayment=params.get("queryPayment"),
+            maxQueryPayment=params.get("maxQueryPayment"),
+            getCost=to_bool(params.get("getCost")),
+            sessionId=parse_session_id(params),
         )

--- a/tck/response/schedule.py
+++ b/tck/response/schedule.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from tck.response.base import StatusOnlyResponse
 
@@ -22,3 +22,21 @@ class SignScheduleResponse(StatusOnlyResponse):
 @dataclass
 class DeleteScheduleResponse(StatusOnlyResponse):
     """Response payload for deleteSchedule."""
+
+
+@dataclass
+class ScheduleInfoResponse:
+    """Response payload for getScheduleInfo."""
+
+    scheduleId: str | None = None
+    creatorAccountId: str | None = None
+    payerAccountId: str | None = None
+    scheduledTransactionId: str | None = None
+    signers: list[str] = field(default_factory=list)
+    adminKey: str | None = field(metadata={"nullable": True}, default=None)
+    expirationTime: str | None = None
+    executedAt: str | None = field(metadata={"nullable": True}, default=None)
+    deletedAt: str | None = field(metadata={"nullable": True}, default=None)
+    scheduleMemo: str | None = None
+    waitForExpiry: bool | None = None
+    cost: str | None = None

--- a/tck/response/schedule.py
+++ b/tck/response/schedule.py
@@ -39,4 +39,15 @@ class ScheduleInfoResponse:
     deletedAt: str | None = field(metadata={"nullable": True}, default=None)
     scheduleMemo: str | None = None
     waitForExpiry: bool | None = None
+
+
+@dataclass
+class ScheduleInfoCostResponse:
+    """Response payload for getScheduleInfo when getCost=true.
+
+    Spec (getCost) and the JS TCK reference return only the cost field, so this
+    is kept separate from ScheduleInfoResponse to avoid leaking its nullable
+    fields (adminKey/executedAt/deletedAt) as spurious nulls.
+    """
+
     cost: str | None = None

--- a/tests/tck/schedule_test.py
+++ b/tests/tck/schedule_test.py
@@ -1,0 +1,178 @@
+"""Test cases for the getScheduleInfo TCK handler and its parameter parsing."""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hiero_sdk_python.account.account_id import AccountId
+from hiero_sdk_python.exceptions import PrecheckError
+from hiero_sdk_python.hbar import Hbar
+from hiero_sdk_python.schedule.schedule_id import ScheduleId
+from hiero_sdk_python.transaction.transaction_id import TransactionId
+from tck.handlers import registry, schedule as schedule_handlers
+from tck.handlers.schedule import get_schedule_info
+from tck.param.schedule import GetScheduleInfoParams
+from tck.response.schedule import ScheduleInfoResponse
+
+
+pytestmark = pytest.mark.unit
+
+
+def _mock_schedule_info(**overrides):
+    """A MagicMock standing in for a populated ScheduleInfo."""
+    defaults = {
+        "schedule_id": ScheduleId(0, 0, 100),
+        "creator_account_id": AccountId(0, 0, 10),
+        "payer_account_id": AccountId(0, 0, 20),
+        "scheduled_transaction_id": TransactionId(AccountId(0, 0, 20), MagicMock(seconds=1700000000, nanos=0)),
+        "signers": [],
+        "admin_key": None,
+        "expiration_time": MagicMock(seconds=1700000500),
+        "executed_at": None,
+        "deleted_at": None,
+        "schedule_memo": "a memo",
+        "wait_for_expiry": True,
+    }
+    defaults.update(overrides)
+    return MagicMock(**defaults)
+
+
+def _mock_query():
+    """A MagicMock standing in for ScheduleInfoQuery's fluent setter chain."""
+    query = MagicMock()
+    query.set_grpc_deadline.return_value = query
+    query.set_schedule_id.return_value = query
+    query.set_query_payment.return_value = query
+    query.set_max_query_payment.return_value = query
+    return query
+
+
+def test_get_schedule_info_is_registered():
+    # Re-import to re-run the @rpc_method decorator, in case another test module's
+    # teardown (e.g. handlers_test.py) cleared the shared registry after this module
+    # was first imported.
+    importlib.reload(schedule_handlers)
+    handler = registry.get_handler("getScheduleInfo")
+    assert handler is not None and callable(handler)
+
+
+def test_parse_json_params():
+    params = GetScheduleInfoParams.parse_json_params(
+        {
+            "sessionId": "session-1",
+            "scheduleId": "0.0.100",
+            "queryPayment": "1000",
+            "maxQueryPayment": "5000",
+            "getCost": True,
+        }
+    )
+
+    assert params.scheduleId == "0.0.100"
+    assert params.queryPayment == "1000"
+    assert params.maxQueryPayment == "5000"
+    assert params.getCost is True
+
+    minimal = GetScheduleInfoParams.parse_json_params({"sessionId": "session-1"})
+    assert minimal.scheduleId is None
+    assert minimal.queryPayment is None
+    assert minimal.maxQueryPayment is None
+    assert minimal.getCost is None
+
+
+def test_get_schedule_info_maps_fields():
+    params = GetScheduleInfoParams(sessionId="session-1", scheduleId="0.0.100")
+    query = _mock_query()
+    query.execute.return_value = _mock_schedule_info()
+
+    with (
+        patch("tck.handlers.schedule.get_client", return_value=MagicMock()),
+        patch("tck.handlers.schedule.ScheduleInfoQuery", return_value=query),
+    ):
+        result = get_schedule_info(params)
+
+    query.set_schedule_id.assert_called_once_with(ScheduleId.from_string("0.0.100"))
+    assert isinstance(result, ScheduleInfoResponse)
+    assert result.scheduleId == "0.0.100"
+    assert result.creatorAccountId == "0.0.10"
+    assert result.payerAccountId == "0.0.20"
+    assert result.scheduledTransactionId == "0.0.20@1700000000.0"
+    assert result.expirationTime == "1700000500"
+    assert result.scheduleMemo == "a memo"
+    assert result.waitForExpiry is True
+    assert result.cost is None
+
+
+def test_get_schedule_info_keeps_nullable_fields_as_none():
+    """A pending, non-deleted schedule must keep executedAt/deletedAt as None, not empty strings."""
+    params = GetScheduleInfoParams(sessionId="session-1", scheduleId="0.0.100")
+    query = _mock_query()
+    query.execute.return_value = _mock_schedule_info(executed_at=None, deleted_at=None, admin_key=None)
+
+    with (
+        patch("tck.handlers.schedule.get_client", return_value=MagicMock()),
+        patch("tck.handlers.schedule.ScheduleInfoQuery", return_value=query),
+    ):
+        result = get_schedule_info(params)
+
+    assert result.executedAt is None
+    assert result.deletedAt is None
+    assert result.adminKey is None
+
+
+def test_get_schedule_info_applies_query_payments():
+    params = GetScheduleInfoParams(
+        sessionId="session-1", scheduleId="0.0.100", queryPayment="1000", maxQueryPayment="5000"
+    )
+    query = _mock_query()
+    query.execute.return_value = _mock_schedule_info()
+
+    with (
+        patch("tck.handlers.schedule.get_client", return_value=MagicMock()),
+        patch("tck.handlers.schedule.ScheduleInfoQuery", return_value=query),
+    ):
+        get_schedule_info(params)
+
+    query.set_query_payment.assert_called_once_with(Hbar.from_tinybars(1000))
+    query.set_max_query_payment.assert_called_once_with(Hbar.from_tinybars(5000))
+
+
+def test_get_schedule_info_get_cost_returns_cost_only():
+    """getCost=true must return only the cost, without executing the full query."""
+    params = GetScheduleInfoParams(sessionId="session-1", scheduleId="0.0.100", getCost=True)
+    query = _mock_query()
+    query.get_cost.return_value = Hbar.from_tinybars(250)
+
+    with (
+        patch("tck.handlers.schedule.get_client", return_value=MagicMock()),
+        patch("tck.handlers.schedule.ScheduleInfoQuery", return_value=query),
+    ):
+        result = get_schedule_info(params)
+
+    query.get_cost.assert_called_once()
+    query.execute.assert_not_called()
+    assert result == ScheduleInfoResponse(cost="250")
+
+
+def test_get_schedule_info_propagates_query_failure():
+    """A non-existent scheduleId (INVALID_SCHEDULE_ID) must surface, not be swallowed."""
+    params = GetScheduleInfoParams(sessionId="session-1", scheduleId="1000000.0.0")
+    query = _mock_query()
+    query.execute.side_effect = PrecheckError(status=1, transaction_id="0.0.1@1.1", message="INVALID_SCHEDULE_ID")
+
+    with (
+        patch("tck.handlers.schedule.get_client", return_value=MagicMock()),
+        patch("tck.handlers.schedule.ScheduleInfoQuery", return_value=query),
+        pytest.raises(PrecheckError),
+    ):
+        get_schedule_info(params)
+
+
+def test_get_schedule_info_invalid_schedule_id_raises():
+    """A malformed scheduleId should fail via ScheduleId.from_string before hitting the network."""
+    params = GetScheduleInfoParams(sessionId="session-1", scheduleId="not-a-schedule-id")
+
+    with patch("tck.handlers.schedule.get_client", return_value=MagicMock()), pytest.raises(ValueError):
+        get_schedule_info(params)

--- a/tests/tck/schedule_test.py
+++ b/tests/tck/schedule_test.py
@@ -13,9 +13,10 @@ from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.schedule.schedule_id import ScheduleId
 from hiero_sdk_python.transaction.transaction_id import TransactionId
 from tck.handlers import registry, schedule as schedule_handlers
+from tck.handlers.registry import parse_result
 from tck.handlers.schedule import get_schedule_info
 from tck.param.schedule import GetScheduleInfoParams
-from tck.response.schedule import ScheduleInfoResponse
+from tck.response.schedule import ScheduleInfoCostResponse, ScheduleInfoResponse
 
 
 pytestmark = pytest.mark.unit
@@ -102,7 +103,6 @@ def test_get_schedule_info_maps_fields():
     assert result.expirationTime == "1700000500"
     assert result.scheduleMemo == "a memo"
     assert result.waitForExpiry is True
-    assert result.cost is None
 
 
 def test_get_schedule_info_keeps_nullable_fields_as_none():
@@ -153,7 +153,11 @@ def test_get_schedule_info_get_cost_returns_cost_only():
 
     query.get_cost.assert_called_once()
     query.execute.assert_not_called()
-    assert result == ScheduleInfoResponse(cost="250")
+    assert result == ScheduleInfoCostResponse(cost="250")
+
+    # Dispatch-level: the JSON-RPC result must contain only "cost", not the
+    # ScheduleInfoResponse fields (e.g. adminKey/executedAt/deletedAt nulls).
+    assert parse_result(result) == {"cost": "250"}
 
 
 def test_get_schedule_info_propagates_query_failure():


### PR DESCRIPTION
## Summary
- Adds `GetScheduleInfoParams` and `ScheduleInfoResponse` following the `getTopicInfo`/`getTokenInfo` query-handler pattern
- Wires the new `getScheduleInfo` handler to the SDK's existing `ScheduleInfoQuery`, including a `getCost` path that returns only the tinybars cost without executing the query
- `adminKey`, `executedAt`, and `deletedAt` are marked nullable so a pending or non-deleted schedule serializes them as `null` per spec, instead of dropping the fields

Closes #2596

## Test plan
- [x] `pytest tests/tck` — 49 passed
- [x] `pytest tests/unit -k schedule` — 177 passed
- [x] `ruff check .` / `ruff format --check` clean