### PR TITLE
refactor(tck): centralize transaction receipt validation in execute_validated helper

### DIFF
--- a/tck/handlers/account.py
+++ b/tck/handlers/account.py
@@ -41,6 +41,7 @@ from tck.response.account import (
 from tck.util.client_utils import get_client
 from tck.util.constants import DEFAULT_GRPC_TIMEOUT
 from tck.util.key_utils import get_key_from_string, key_to_string
+from tck.util.transaction_utils import execute_validated
 
 
 def _build_create_account_transaction(params: CreateAccountParams) -> AccountCreateTransaction:
@@ -89,17 +90,15 @@ def create_account(params: CreateAccountParams) -> CreateAccountResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     account_id = ""
-    if receipt.status == ResponseCode.SUCCESS:
-        account_id = str(receipt.account_id)
+    account_id = str(receipt.account_id)
 
     return CreateAccountResponse(
         account_id,
         ResponseCode(receipt.status).name,
-        str(response.transaction_id) if response.transaction_id is not None else None,
+        str(receipt.transaction_id) if receipt.transaction_id is not None else None,
     )
 
 
@@ -150,8 +149,7 @@ def update_account(params: UpdateAccountParams) -> UpdateAccountResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return UpdateAccountResponse(ResponseCode(receipt.status).name)
 
@@ -258,8 +256,7 @@ def delete_account(params: DeleteAccountParams) -> DeleteAccountResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return DeleteAccountResponse(status=ResponseCode(receipt.status).name)
 

--- a/tck/handlers/allowance.py
+++ b/tck/handlers/allowance.py
@@ -13,7 +13,6 @@ from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.tokens.nft_id import NftId
 from hiero_sdk_python.tokens.token_id import TokenId
-from hiero_sdk_python.transaction.transaction_receipt import TransactionReceipt
 from tck.handlers.registry import rpc_method
 from tck.param.allowance import (
     AllowanceEntry,
@@ -24,6 +23,7 @@ from tck.param.allowance import (
 from tck.response.allowance import ApproveAllowanceResponse, DeleteAllowanceResponse
 from tck.util.client_utils import get_client
 from tck.util.constants import DEFAULT_GRPC_TIMEOUT
+from tck.util.transaction_utils import execute_validated
 
 
 def _build_approve_allowance_transaction(
@@ -130,8 +130,7 @@ def approve_allowance(params: ApproveAllowanceParams) -> ApproveAllowanceRespons
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return ApproveAllowanceResponse(status=ResponseCode(receipt.status).name)
 
@@ -178,7 +177,6 @@ def delete_allowance(params: DeleteAllowanceParams) -> DeleteAllowanceResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return DeleteAllowanceResponse(status=ResponseCode(receipt.status).name)

--- a/tck/handlers/contract.py
+++ b/tck/handlers/contract.py
@@ -5,7 +5,6 @@ from hiero_sdk_python.contract.contract_create_transaction import ContractCreate
 from hiero_sdk_python.Duration import Duration
 from hiero_sdk_python.file.file_id import FileId
 from hiero_sdk_python.response_code import ResponseCode
-from hiero_sdk_python.transaction.transaction_receipt import TransactionReceipt
 from tck.errors import JsonRpcError
 from tck.handlers.registry import rpc_method
 from tck.param.contract import CreateContractParams
@@ -14,6 +13,7 @@ from tck.util.client_utils import get_client
 from tck.util.constants import DEFAULT_GRPC_TIMEOUT
 from tck.util.key_utils import get_key_from_string
 from tck.util.param_utils import decode_hex, to_int
+from tck.util.transaction_utils import execute_validated
 
 
 INT64_MIN = -(2**63)
@@ -99,11 +99,10 @@ def create_contract(params: CreateContractParams) -> CreateContractResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     contract_id = ""
-    if receipt.status == ResponseCode.SUCCESS and receipt.contract_id is not None:
+    if receipt.contract_id is not None:
         contract_id = str(receipt.contract_id)
 
     return CreateContractResponse(contract_id, ResponseCode(receipt.status).name)

--- a/tck/handlers/file.py
+++ b/tck/handlers/file.py
@@ -9,7 +9,6 @@ from hiero_sdk_python.file.file_info_query import FileInfoQuery
 from hiero_sdk_python.hbar import Hbar
 from hiero_sdk_python.response_code import ResponseCode
 from hiero_sdk_python.timestamp import Timestamp
-from hiero_sdk_python.transaction.transaction_receipt import TransactionReceipt
 from tck.errors import JsonRpcError
 from tck.handlers.registry import rpc_method
 from tck.param.file import CreateFileParams, DeleteFileParams, GetFileContentsParams, GetFileInfoParams
@@ -18,6 +17,7 @@ from tck.util.client_utils import get_client
 from tck.util.constants import DEFAULT_GRPC_TIMEOUT
 from tck.util.key_utils import get_key_from_string, key_to_string
 from tck.util.param_utils import to_int
+from tck.util.transaction_utils import execute_validated
 
 
 def _build_create_file_transaction(params: CreateFileParams) -> FileCreateTransaction:
@@ -51,11 +51,10 @@ def create_file(params: CreateFileParams) -> CreateFileResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     file_id = ""
-    if receipt.status == ResponseCode.SUCCESS and receipt.file_id is not None:
+    if receipt.file_id is not None:
         file_id = str(receipt.file_id)
 
     return CreateFileResponse(file_id, ResponseCode(receipt.status).name)
@@ -122,7 +121,6 @@ def delete_file(params: DeleteFileParams) -> DeleteFileResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return DeleteFileResponse(ResponseCode(receipt.status).name)

--- a/tck/handlers/schedule.py
+++ b/tck/handlers/schedule.py
@@ -11,7 +11,6 @@ from hiero_sdk_python.schedule.schedule_id import ScheduleId
 from hiero_sdk_python.schedule.schedule_sign_transaction import ScheduleSignTransaction
 from hiero_sdk_python.timestamp import Timestamp
 from hiero_sdk_python.transaction.transaction import Transaction
-from hiero_sdk_python.transaction.transaction_receipt import TransactionReceipt
 from tck.errors import JsonRpcError
 from tck.handlers.account import _build_create_account_transaction
 from tck.handlers.allowance import _build_approve_allowance_transaction
@@ -37,6 +36,7 @@ from tck.util.client_utils import get_client
 from tck.util.constants import DEFAULT_GRPC_TIMEOUT
 from tck.util.key_utils import get_key_from_string
 from tck.util.param_utils import to_int
+from tck.util.transaction_utils import execute_validated
 
 
 # Maps a scheduled transaction method name to its params class and builder.
@@ -154,16 +154,14 @@ def create_schedule(params: CreateScheduleParams) -> CreateScheduleResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     schedule_id = ""
     scheduled_transaction_id = None
-    if receipt.status == ResponseCode.SUCCESS:
-        if receipt.schedule_id is not None:
-            schedule_id = str(receipt.schedule_id)
-        if receipt.scheduled_transaction_id is not None:
-            scheduled_transaction_id = str(receipt.scheduled_transaction_id)
+    if receipt.schedule_id is not None:
+        schedule_id = str(receipt.schedule_id)
+    if receipt.scheduled_transaction_id is not None:
+        scheduled_transaction_id = str(receipt.scheduled_transaction_id)
 
     return CreateScheduleResponse(schedule_id, scheduled_transaction_id, ResponseCode(receipt.status).name)
 
@@ -188,8 +186,7 @@ def sign_schedule(params: SignScheduleParams) -> SignScheduleResponse:
     if common_params is not None:
         common_params.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return SignScheduleResponse(status=ResponseCode(receipt.status).name)
 
@@ -204,7 +201,6 @@ def delete_schedule(params: DeleteScheduleParams) -> DeleteScheduleResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return DeleteScheduleResponse(status=ResponseCode(receipt.status).name)

--- a/tck/handlers/token.py
+++ b/tck/handlers/token.py
@@ -42,7 +42,6 @@ from hiero_sdk_python.tokens.token_unfreeze_transaction import TokenUnfreezeTran
 from hiero_sdk_python.tokens.token_unpause_transaction import TokenUnpauseTransaction
 from hiero_sdk_python.tokens.token_update_transaction import TokenUpdateTransaction
 from hiero_sdk_python.tokens.token_wipe_transaction import TokenWipeTransaction
-from hiero_sdk_python.transaction.transaction_receipt import TransactionReceipt
 from tck.handlers.registry import rpc_method
 from tck.param.custom_fee import CustomFeeParams, FixedFeeParams
 from tck.param.token import (
@@ -94,6 +93,7 @@ from tck.util.client_utils import get_client
 from tck.util.constants import DEFAULT_GRPC_TIMEOUT
 from tck.util.key_utils import get_key_from_string
 from tck.util.param_utils import to_int
+from tck.util.transaction_utils import execute_validated
 
 
 def _parse_hex(value: str, field_name: str) -> bytes:
@@ -252,8 +252,7 @@ def create_token(params: CreateTokenParams) -> CreateTokenResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     token_id = str(receipt.token_id) if receipt.token_id else ""
 
@@ -305,8 +304,7 @@ def cancel_airdrop(params: CancelAirdropParams) -> CancelAirdropResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return CancelAirdropResponse(status=ResponseCode(receipt.status).name)
 
@@ -339,8 +337,7 @@ def mint_token(params: MintTokenParams) -> MintTokenResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     serial_numbers = [str(s) for s in receipt.serial_numbers] if receipt.serial_numbers else []
 
@@ -452,8 +449,7 @@ def associate_token(params: AssociateTokenParams) -> AssociateTokenResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return AssociateTokenResponse(status=ResponseCode(receipt.status).name)
 
@@ -468,8 +464,7 @@ def delete_token(params: DeleteTokenParams) -> DeleteTokenResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return DeleteTokenResponse(status=ResponseCode(receipt.status).name)
 
@@ -484,8 +479,7 @@ def dissociate_token(params: DissociateTokenParams) -> DissociateTokenResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return DissociateTokenResponse(status=ResponseCode(receipt.status).name)
 
@@ -515,8 +509,7 @@ def unfreeze_token(params: UnfreezeTokenParams) -> UnfreezeTokenResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return UnfreezeTokenResponse(status=ResponseCode(receipt.status).name)
 
@@ -531,8 +524,7 @@ def freeze_token(params: FreezeTokenParams) -> FreezeTokenResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return FreezeTokenResponse(status=ResponseCode(receipt.status).name)
 
@@ -547,8 +539,7 @@ def pause_token(params: PauseTokenParams) -> PauseTokenResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return PauseTokenResponse(status=ResponseCode(receipt.status).name)
 
@@ -563,8 +554,7 @@ def unpause_token(params: UnpauseTokenParams) -> UnpauseTokenResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return UnpauseTokenResponse(status=ResponseCode(receipt.status).name)
 
@@ -579,8 +569,7 @@ def grant_token_kyc(params: GrantTokenKycParams) -> GrantTokenKycResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return GrantTokenKycResponse(status=ResponseCode(receipt.status).name)
 
@@ -595,8 +584,7 @@ def revoke_token_kyc(params: RevokeTokenKycParams) -> RevokeTokenKycResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return RevokeTokenKycResponse(status=ResponseCode(receipt.status).name)
 
@@ -657,10 +645,7 @@ def airdrop_token(params: AirdropTokenParams) -> AirdropTokenResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(tx, client)
 
-    receipt = tx.execute(client, wait_for_receipt=False).get_receipt(
-        client,
-        validate_status=True,
-    )
+    receipt = execute_validated(tx, client)
 
     return AirdropTokenResponse(status=ResponseCode(receipt.status).name)
 
@@ -704,8 +689,7 @@ def claim_token(params: ClaimTokenParams) -> ClaimTokenResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return ClaimTokenResponse(status=ResponseCode(receipt.status).name)
 
@@ -897,8 +881,7 @@ def reject_token(params: RejectTokenParams) -> RejectTokenResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return RejectTokenResponse(
         status=ResponseCode(receipt.status).name,
@@ -973,8 +956,7 @@ def update_token(params: UpdateTokenParams) -> UpdateTokenResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return UpdateTokenResponse(status=ResponseCode(receipt.status).name)
 
@@ -1011,8 +993,7 @@ def wipe_token(params: WipeTokenParams) -> WipeTokenResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return WipeTokenResponse(status=ResponseCode(receipt.status).name)
 
@@ -1045,8 +1026,7 @@ def burn_token(params: BurnTokenParams) -> BurnTokenResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return BurnTokenResponse(
         newTotalSupply=str(receipt.new_total_supply),

--- a/tck/handlers/topic.py
+++ b/tck/handlers/topic.py
@@ -14,7 +14,6 @@ from hiero_sdk_python.timestamp import Timestamp
 from hiero_sdk_python.tokens.custom_fixed_fee import CustomFixedFee
 from hiero_sdk_python.tokens.token_id import TokenId
 from hiero_sdk_python.transaction.custom_fee_limit import CustomFeeLimit
-from hiero_sdk_python.transaction.transaction_receipt import TransactionReceipt
 from tck.handlers.registry import rpc_method
 from tck.param.custom_fee import CustomFeeLimitParams, CustomFeeParams
 from tck.param.topic import (
@@ -37,6 +36,7 @@ from tck.util.client_utils import get_client
 from tck.util.constants import DEFAULT_GRPC_TIMEOUT
 from tck.util.key_utils import get_key_from_string, key_to_string
 from tck.util.param_utils import to_int
+from tck.util.transaction_utils import execute_validated
 
 
 def _build_custom_fee(custom_fee_params: CustomFeeParams) -> CustomFixedFee:
@@ -133,11 +133,10 @@ def create_topic(params: CreateTopicParams) -> CreateTopicResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     topic_id = ""
-    if receipt.status == ResponseCode.SUCCESS and receipt.topic_id is not None:
+    if receipt.topic_id is not None:
         topic_id = str(receipt.topic_id)
 
     return CreateTopicResponse(topic_id, ResponseCode(receipt.status).name)
@@ -152,8 +151,7 @@ def update_topic(params: UpdateTopicParams) -> UpdateTopicResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return UpdateTopicResponse(ResponseCode(receipt.status).name)
 
@@ -171,8 +169,7 @@ def delete_topic(params: DeleteTopicParams) -> DeleteTopicResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return DeleteTopicResponse(ResponseCode(receipt.status).name)
 
@@ -233,8 +230,7 @@ def submit_topic_message(params: TopicMessageSubmitParams) -> TopicMessageSubmit
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(transaction, client)
 
-    response = transaction.execute(client, wait_for_receipt=False)
-    receipt: TransactionReceipt = response.get_receipt(client, validate_status=True)
+    receipt = execute_validated(transaction, client)
 
     return TopicMessageSubmitResponse(ResponseCode(receipt.status).name)
 

--- a/tck/handlers/transfer.py
+++ b/tck/handlers/transfer.py
@@ -12,6 +12,7 @@ from tck.param.transfer import TransferCryptoParams
 from tck.response.transfer import TransferCryptoResponse
 from tck.util.client_utils import get_client
 from tck.util.constants import DEFAULT_GRPC_TIMEOUT
+from tck.util.transaction_utils import execute_validated
 
 
 def _build_transfer_transaction(params: TransferCryptoParams) -> TransferTransaction:
@@ -80,9 +81,6 @@ def transfer_crypto(params: TransferCryptoParams) -> TransferCryptoResponse:
     if params.commonTransactionParams is not None:
         params.commonTransactionParams.apply_common_params(tx, client)
 
-    receipt = tx.execute(client, wait_for_receipt=False).get_receipt(
-        client,
-        validate_status=True,
-    )
+    receipt = execute_validated(tx, client)
 
     return TransferCryptoResponse(status=ResponseCode(receipt.status).name)

--- a/tck/util/transaction_utils.py
+++ b/tck/util/transaction_utils.py
@@ -1,0 +1,16 @@
+"""Shared utility for executing transactions and validating their receipts."""
+
+from __future__ import annotations
+
+from hiero_sdk_python import Client, Transaction, TransactionReceipt
+
+
+def execute_validated(transaction: Transaction, client: Client) -> TransactionReceipt:
+    """Execute a transaction and return its receipt, validated as SUCCESS.
+
+    The returned receipt always has SUCCESS status. Any other status raises
+    ReceiptStatusError, which the handle_sdk_errors decorator maps to a
+    JSON-RPC -32001 error.
+    """
+    response = transaction.execute(client, wait_for_receipt=False)
+    return response.get_receipt(client, validate_status=True)

--- a/tests/tck/transaction_utils_test.py
+++ b/tests/tck/transaction_utils_test.py
@@ -1,0 +1,54 @@
+"""Unit tests for the execute_validated transaction helper."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from hiero_sdk_python.exceptions import ReceiptStatusError
+from hiero_sdk_python.response_code import ResponseCode
+from tck.util.transaction_utils import execute_validated
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestExecuteValidated:
+    """Test the execute_validated helper's success and failure paths."""
+
+    def test_returns_receipt_on_success(self):
+        """Test that execute_validated returns the receipt when validation succeeds."""
+        mock_receipt = MagicMock()
+        mock_response = MagicMock()
+        mock_response.get_receipt.return_value = mock_receipt
+        mock_transaction = MagicMock()
+        mock_transaction.execute.return_value = mock_response
+        mock_client = MagicMock()
+
+        result = execute_validated(mock_transaction, mock_client)
+
+        if result is not mock_receipt:
+            raise AssertionError("Expected execute_validated to return the receipt from get_receipt")
+
+        mock_transaction.execute.assert_called_once_with(mock_client, wait_for_receipt=False)
+        mock_response.get_receipt.assert_called_once_with(mock_client, validate_status=True)
+
+    def test_raises_receipt_status_error_on_failure(self):
+        """Test that execute_validated propagates ReceiptStatusError without catching it."""
+        mock_transaction_id = MagicMock()
+        mock_receipt = MagicMock()
+        error = ReceiptStatusError(
+            status=ResponseCode.ACCOUNT_DELETED,
+            transaction_id=mock_transaction_id,
+            transaction_receipt=mock_receipt,
+        )
+
+        mock_response = MagicMock()
+        mock_response.get_receipt.side_effect = error
+        mock_transaction = MagicMock()
+        mock_transaction.execute.return_value = mock_response
+        mock_client = MagicMock()
+
+        with pytest.raises(ReceiptStatusError):
+            execute_validated(mock_transaction, mock_client)

--- a/tests/tck/transaction_utils_test.py
+++ b/tests/tck/transaction_utils_test.py
@@ -14,8 +14,8 @@ from tck.util.transaction_utils import execute_validated
 pytestmark = pytest.mark.unit
 
 
-class TestExecuteValidated:
-    """Test the execute_validated helper's success and failure paths."""
+class TestExecuteValidatedSuccess:
+    """Test the execute_validated helper's success path."""
 
     def test_returns_receipt_on_success(self):
         """Test that execute_validated returns the receipt when validation succeeds."""
@@ -34,6 +34,10 @@ class TestExecuteValidated:
         mock_transaction.execute.assert_called_once_with(mock_client, wait_for_receipt=False)
         mock_response.get_receipt.assert_called_once_with(mock_client, validate_status=True)
 
+
+class TestExecuteValidatedErrors:
+    """Test the execute_validated helper's failure path."""
+
     def test_raises_receipt_status_error_on_failure(self):
         """Test that execute_validated propagates ReceiptStatusError without catching it."""
         mock_transaction_id = MagicMock()
@@ -50,5 +54,8 @@ class TestExecuteValidated:
         mock_transaction.execute.return_value = mock_response
         mock_client = MagicMock()
 
-        with pytest.raises(ReceiptStatusError):
+        with pytest.raises(ReceiptStatusError) as exc_info:
             execute_validated(mock_transaction, mock_client)
+
+        if exc_info.value.status != ResponseCode.ACCOUNT_DELETED:
+            raise AssertionError("Expected the raised error's status to be preserved")


### PR DESCRIPTION
## Summary

This PR adds the `execute_validated` helper, along with unit tests, to clarify and centralize the use of validated transaction receipts. This is a pure structural refactor with no intended changes.

## Changes 

- All transaction handlers using the transaction execution → receipt validation pattern have been converted to use the helper, and the redundant `SUCCESS` guards have been removed.
- In `tck/handlers/account.py`, `create_account` now reads `receipt.transaction_id` instead of `response.transaction_id`, since `execute_validated` only returns the receipt. Verified these are equivalent — the receipt's query is seeded with `response.transaction_id`, so the value is the same.

## Testing

1.`transaction_utils_test.py` — tests for `execute_validated`, including successful and failed receipt handling.
<img width="1161" height="329" alt="WhatsApp Image 2026-09-09 at 18 21 27" src="https://github.com/user-attachments/assets/f5c970fb-50c9-4ab4-bd51-496c9da54a56" />

2. Full `TCK test suite`
<img width="1174" height="324" alt="WhatsApp Image 2026-09-09 at 23 15 20" src="https://github.com/user-attachments/assets/52d417d2-94ce-4175-8230-eea39cb0d37c" />


3. TCK server with mocked responses — verified that failed receipts are still surfaced as JSON-RPC errors as expected.
<img width="922" height="310" alt="WhatsApp Image 2026-09-09 at 23 17 25" src="https://github.com/user-attachments/assets/e012e026-3b66-4fc6-9162-0f45d85f7238" />



Also , Re-checked the codebase before opening the PR to ensure no transaction handlers using the validated receipt pattern were missed.

Fixes #2626

