### PR TITLE
feat: implement client ping

### DIFF
--- a/src/hiero_sdk_python/client/client.py
+++ b/src/hiero_sdk_python/client/client.py
@@ -214,6 +214,23 @@ class Client:
             return [node._account_id for node in self.network.nodes]  # pylint: disable=W0212
         raise ValueError("No nodes available in the network configuration.")
 
+    def ping(self, node_account_id: AccountId) -> None:
+        """Probe one node with an unpaid COST_ANSWER account-info query."""
+        from hiero_sdk_python.query.account_info_query import AccountInfoQuery
+
+        node = self.network._get_node(node_account_id)
+        if node is None:
+            raise ValueError(f"Node account ID {node_account_id} is not in the client's network map")
+
+        query = AccountInfoQuery(AccountId(0, 0, 2)).set_node_account_ids([node_account_id])
+        query._execute_cost_probe(self)
+        self.network._reset_node_health(node)
+
+    def ping_all(self) -> None:
+        """Probe every node in the current network map sequentially."""
+        for node_account_id in self.get_node_account_ids():
+            self.ping(node_account_id)
+
     def close(self) -> None:
         """
         Closes any open gRPC channels and frees resources.

--- a/src/hiero_sdk_python/client/network.py
+++ b/src/hiero_sdk_python/client/network.py
@@ -422,6 +422,15 @@ class Network:
 
         node._decrease_backoff()
 
+    def _reset_node_health(self, node: _Node) -> None:
+        """Reset a node's health state and make it immediately selectable."""
+        if not isinstance(node, _Node):
+            raise TypeError("node must be of type _Node")
+
+        node._reset_backoff()
+        self._mark_node_healthy(node)
+        self._earliest_readmit_time = time.monotonic()
+
     def _mark_node_unhealthy(self, node: _Node) -> None:
         if not isinstance(node, _Node):
             raise TypeError("node must be of type _Node")

--- a/src/hiero_sdk_python/executable.py
+++ b/src/hiero_sdk_python/executable.py
@@ -398,7 +398,12 @@ class _Executable(ABC):
         self._node_account_ids.advance()
         return True
 
-    def _execute(self, client: Client, timeout: int | float | None = None):
+    def _execute(
+        self,
+        client: Client,
+        timeout: int | float | None = None,
+        allow_unhealthy_node: bool = False,
+    ):
         """
         Execute a transaction or query with retry logic.
 
@@ -409,6 +414,8 @@ class _Executable(ABC):
                 1. Explicitly set via set_request_timeout()
                 2. Timeout passed to execute()
                 3. Client default request_timeout
+            allow_unhealthy_node (bool): Whether to execute against a selected node even when it is in backoff.
+                Defaults to False; health probes use True to test an explicitly requested node.
 
         Returns:
             The response from executing the operation:
@@ -460,7 +467,7 @@ class _Executable(ABC):
             # Build the request using the executable's _make_request method
             proto_request = self._make_request()
 
-            if not node.is_healthy():
+            if not allow_unhealthy_node and not node.is_healthy():
                 self._handle_unhealthy_node(proto_request, attempt, logger, err_persistant)
                 continue
 

--- a/src/hiero_sdk_python/node.py
+++ b/src/hiero_sdk_python/node.py
@@ -303,3 +303,9 @@ class _Node:
     def _decrease_backoff(self) -> None:
         """Decrease the node's backoff duration after a successful operation."""
         self._current_backoff = max(self._current_backoff / 2, self._min_backoff)
+
+    def _reset_backoff(self) -> None:
+        """Reset node health after a successful health probe."""
+        self._current_backoff = self._min_backoff
+        self._readmit_time = time.monotonic()
+        self._bad_grpc_response_count = 0

--- a/src/hiero_sdk_python/query/account_info_query.py
+++ b/src/hiero_sdk_python/query/account_info_query.py
@@ -116,6 +116,10 @@ class AccountInfoQuery(Query):
 
         return AccountInfo._from_proto(response.cryptoGetInfo.accountInfo)
 
+    def _execute_cost_probe(self, client, timeout: int | float | None = None):
+        """Execute only the unpaid COST_ANSWER probe used by Client.ping()."""
+        return self._execute(client, timeout, allow_unhealthy_node=True)
+
     def _get_query_response(self, response):
         """
         Extracts the account info response from the full response.

--- a/tck/handlers/sdk.py
+++ b/tck/handlers/sdk.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from hiero_sdk_python import AccountId, Client, PrivateKey
+from hiero_sdk_python.exceptions import MaxAttemptsError
+from tck.errors import JsonRpcError
 from tck.handlers.registry import rpc_method
 from tck.param.base import BaseParams
-from tck.param.sdk import SetupParams
-from tck.response.sdk import SetupResponse
+from tck.param.sdk import PingParams, SetupParams
+from tck.response.sdk import PingResponse, SetupResponse
 from tck.util.client_utils import get_client, remove_client, store_client
 
 
@@ -53,3 +55,31 @@ def reset_handler(params: BaseParams) -> SetupResponse:
         client.close()
 
     return SetupResponse("Successfully reset client")
+
+
+@rpc_method("ping")
+def ping_handler(params: PingParams) -> PingResponse:
+    client = get_client(params.sessionId)
+    node_account_id = AccountId.from_string(params.nodeAccountId)
+
+    try:
+        client.ping(node_account_id)
+    except MaxAttemptsError as e:
+        raise JsonRpcError.internal_error() from e
+    except ValueError as e:
+        raise JsonRpcError.internal_error({"message": str(e)}) from e
+
+    return PingResponse(f"Successfully pinged node {params.nodeAccountId}.")
+
+
+@rpc_method("pingAll")
+def ping_all_handler(params: BaseParams) -> PingResponse:
+    client = get_client(params.sessionId)
+    try:
+        client.ping_all()
+    except MaxAttemptsError as e:
+        raise JsonRpcError.internal_error() from e
+    except ValueError as e:
+        raise JsonRpcError.internal_error({"message": str(e)}) from e
+
+    return PingResponse("Successfully pinged all nodes.")

--- a/tck/param/sdk.py
+++ b/tck/param/sdk.py
@@ -24,3 +24,19 @@ class SetupParams(BaseParams):
             mirrorNetworkIp=params.get("mirrorNetworkIp"),
             sessionId=parse_session_id(params),
         )
+
+
+@dataclass
+class PingParams(BaseParams):
+    nodeAccountId: str = None
+
+    @classmethod
+    def parse_json_params(cls, params: dict) -> PingParams:
+        if not isinstance(params, dict):
+            raise TypeError("params must be an object")
+
+        node_account_id = params.get("nodeAccountId")
+        if not isinstance(node_account_id, str) or not node_account_id.strip():
+            raise ValueError("nodeAccountId is required and must be a non-empty string")
+
+        return cls(nodeAccountId=node_account_id, sessionId=parse_session_id(params))

--- a/tck/response/sdk.py
+++ b/tck/response/sdk.py
@@ -11,3 +11,13 @@ class SetupResponse:
     def __init__(self, message: str):
         self.message = message
         self.status = "SUCCESS"
+
+
+@dataclass
+class PingResponse:
+    message: str = None
+    status: str = None
+
+    def __init__(self, message: str):
+        self.message = message
+        self.status = "SUCCESS"

--- a/tests/tck/client_ping_test.py
+++ b/tests/tck/client_ping_test.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from hiero_sdk_python.exceptions import MaxAttemptsError, PrecheckError
+from tck.errors import HIERO_ERROR, INTERNAL_ERROR
+from tck.handlers import sdk
+from tck.handlers.registry import dispatch, get_handler
+from tck.param.sdk import PingParams
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_ping_methods_are_registered():
+    assert get_handler("ping") is not None
+    assert get_handler("pingAll") is not None
+
+
+def test_ping_params_require_non_empty_node_account_id():
+    params = PingParams.parse_json_params({"sessionId": "s", "nodeAccountId": "0.0.3"})
+    assert params.nodeAccountId == "0.0.3"
+
+    with pytest.raises(ValueError):
+        PingParams.parse_json_params({"sessionId": "s"})
+    with pytest.raises(ValueError):
+        PingParams.parse_json_params({"sessionId": "s", "nodeAccountId": " "})
+    with pytest.raises(ValueError):
+        PingParams.parse_json_params({"nodeAccountId": "0.0.3"})
+    with pytest.raises(TypeError):
+        PingParams.parse_json_params([])
+
+
+def test_ping_dispatches_and_returns_exact_response():
+    client = Mock()
+    with patch.object(sdk, "get_client", return_value=client):
+        result = dispatch("ping", {"sessionId": "s", "nodeAccountId": "0.0.3"})
+
+    client.ping.assert_called_once()
+    assert result == {
+        "message": "Successfully pinged node 0.0.3.",
+        "status": "SUCCESS",
+    }
+
+
+def test_ping_all_dispatches_and_returns_exact_response():
+    client = Mock()
+    with patch.object(sdk, "get_client", return_value=client):
+        result = dispatch("pingAll", {"sessionId": "s"})
+
+    client.ping_all.assert_called_once_with()
+    assert result == {"message": "Successfully pinged all nodes.", "status": "SUCCESS"}
+
+
+def test_ping_max_attempts_is_internal_error_without_result():
+    client = Mock()
+    client.ping.side_effect = MaxAttemptsError("unreachable", node_id="0.0.3")
+    with patch.object(sdk, "get_client", return_value=client), pytest.raises(Exception) as error:
+        dispatch("ping", {"sessionId": "s", "nodeAccountId": "0.0.3"})
+    assert error.value.code == INTERNAL_ERROR
+
+
+def test_ping_all_max_attempts_is_internal_error_without_result():
+    client = Mock()
+    client.ping_all.side_effect = MaxAttemptsError("unreachable", node_id="0.0.3")
+    with patch.object(sdk, "get_client", return_value=client), pytest.raises(Exception) as error:
+        dispatch("pingAll", {"sessionId": "s"})
+    assert error.value.code == INTERNAL_ERROR
+
+
+def test_ping_unknown_node_is_internal_error():
+    client = Mock()
+    client.ping.side_effect = ValueError("Node account ID 0.0.999 is not in the client's network map")
+    with patch.object(sdk, "get_client", return_value=client), pytest.raises(Exception) as error:
+        dispatch("ping", {"sessionId": "s", "nodeAccountId": "0.0.999"})
+    assert error.value.code == INTERNAL_ERROR
+    assert error.value.data == {"message": "Node account ID 0.0.999 is not in the client's network map"}
+
+
+def test_ping_all_unknown_node_is_internal_error_with_message():
+    client = Mock()
+    client.ping_all.side_effect = ValueError("Node account ID 0.0.999 is not in the client's network map")
+    with patch.object(sdk, "get_client", return_value=client), pytest.raises(Exception) as error:
+        dispatch("pingAll", {"sessionId": "s"})
+    assert error.value.code == INTERNAL_ERROR
+    assert error.value.data == {"message": "Node account ID 0.0.999 is not in the client's network map"}
+
+
+def test_ping_precheck_remains_hiero_error_with_status():
+    client = Mock()
+    client.ping.side_effect = PrecheckError(status=1, transaction_id=None, message="failure")
+    with patch.object(sdk, "get_client", return_value=client), pytest.raises(Exception) as error:
+        dispatch("ping", {"sessionId": "s", "nodeAccountId": "0.0.3"})
+    assert error.value.code == HIERO_ERROR
+    assert error.value.data["status"] == "INVALID_TRANSACTION"

--- a/tests/unit/client_ping_test.py
+++ b/tests/unit/client_ping_test.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import grpc
+import pytest
+
+from hiero_sdk_python import AccountId, Client
+from hiero_sdk_python.client.network import Network
+from hiero_sdk_python.crypto.private_key import PrivateKey
+from hiero_sdk_python.exceptions import MaxAttemptsError, PrecheckError
+from hiero_sdk_python.hapi.services import (
+    basic_types_pb2,
+    crypto_get_info_pb2,
+    response_header_pb2,
+    response_pb2,
+)
+from hiero_sdk_python.hapi.services.query_header_pb2 import ResponseType
+from hiero_sdk_python.node import _Node
+from hiero_sdk_python.query.account_info_query import AccountInfoQuery
+from hiero_sdk_python.response_code import ResponseCode
+from tests.unit.mock_server import MockServer, RealRpcError
+
+
+pytestmark = pytest.mark.unit
+
+
+def _response(status=ResponseCode.OK, cost=0, account_info=False):
+    info = (
+        crypto_get_info_pb2.CryptoGetInfoResponse.AccountInfo(key=basic_types_pb2.Key(ed25519=b"\x00" * 32))
+        if account_info
+        else None
+    )
+    return response_pb2.Response(
+        cryptoGetInfo=crypto_get_info_pb2.CryptoGetInfoResponse(
+            header=response_header_pb2.ResponseHeader(
+                nodeTransactionPrecheckCode=status,
+                responseType=ResponseType.COST_ANSWER,
+                cost=cost,
+            ),
+            accountInfo=info,
+        )
+    )
+
+
+def _client(servers):
+    nodes = [_Node(AccountId(0, 0, index + 3), server.address, None) for index, server in enumerate(servers)]
+    network = Network(nodes=nodes)
+    network.set_transport_security(False)
+    network.set_verify_certificates(False)
+    client = Client(network).set_max_attempts(1).set_min_backoff(0).set_max_backoff(0)
+    return client, nodes
+
+
+def test_ping_sends_only_cost_answer_get_account_info_without_operator():
+    server = MockServer([_response(cost=0)])
+    client, _ = _client([server])
+    try:
+        client.ping(AccountId(0, 0, 3))
+        assert len(server.calls) == 1
+        assert server.calls[0][0] == "getAccountInfo"
+        request = server.calls[0][1]
+        assert request.cryptoGetInfo.accountID == AccountId(0, 0, 2)._to_proto()
+        assert request.cryptoGetInfo.header.responseType == ResponseType.COST_ANSWER
+        assert request.WhichOneof("query") == "cryptoGetInfo"
+    finally:
+        client.close()
+        server.close()
+
+
+def test_ping_is_pinned_and_unknown_node_does_not_fallback():
+    first = MockServer([_response()])
+    second = MockServer([_response()])
+    client, _ = _client([first, second])
+    try:
+        client.ping(AccountId(0, 0, 4))
+        assert not first.calls
+        assert len(second.calls) == 1
+        with pytest.raises(ValueError, match="not in the client's network map"):
+            client.ping(AccountId(0, 0, 999))
+        assert len(first.calls) == 0
+    finally:
+        client.close()
+        first.close()
+        second.close()
+
+
+def test_ping_transport_failure_marks_node_unhealthy_and_recovers():
+    server = MockServer(
+        [
+            RealRpcError(grpc.StatusCode.UNAVAILABLE, "unavailable"),
+            _response(),
+            _response(),
+            _response(account_info=True),
+            _response(account_info=True),
+        ]
+    )
+    client, nodes = _client([server])
+    node = nodes[0]
+    try:
+        with pytest.raises(MaxAttemptsError):
+            client.ping(node._account_id)
+        assert not node.is_healthy()
+        assert node not in client.network._healthy_nodes
+
+        client.ping(node._account_id)
+        assert node.is_healthy()
+        assert node in client.network._healthy_nodes
+        assert node._bad_grpc_response_count == 0
+        assert node._current_backoff == node._min_backoff
+
+        client.set_operator(AccountId(0, 0, 1800), PrivateKey.generate())
+        AccountInfoQuery(AccountId(0, 0, 2)).execute(client)
+        assert [call[1].cryptoGetInfo.header.responseType for call in server.calls[-2:]] == [
+            ResponseType.COST_ANSWER,
+            ResponseType.ANSWER_ONLY,
+        ]
+    finally:
+        client.close()
+        server.close()
+
+
+def test_normal_query_still_skips_a_node_in_backoff():
+    unhealthy = MockServer([])
+    healthy = MockServer([_response()])
+    client, nodes = _client([unhealthy, healthy])
+    try:
+        client.network._increase_backoff(nodes[0])
+        query = AccountInfoQuery(AccountId(0, 0, 2)).set_node_account_ids([nodes[0]._account_id, nodes[1]._account_id])
+        query.set_max_attempts(2)._execute(client)
+        assert not unhealthy.calls
+        assert len(healthy.calls) == 1
+    finally:
+        client.close()
+        unhealthy.close()
+        healthy.close()
+
+
+def test_ping_propagates_precheck_error():
+    server = MockServer([_response(ResponseCode.INVALID_ACCOUNT_ID)])
+    client, _ = _client([server])
+    try:
+        with pytest.raises(PrecheckError) as error:
+            client.ping(AccountId(0, 0, 3))
+        assert error.value.status == ResponseCode.INVALID_ACCOUNT_ID
+    finally:
+        client.close()
+        server.close()
+
+
+def test_ping_all_is_sequential_and_stops_at_first_failure():
+    servers = [
+        MockServer([_response()]),
+        MockServer([RealRpcError(grpc.StatusCode.UNAVAILABLE, "unavailable")]),
+        MockServer([_response()]),
+    ]
+    client, _ = _client(servers)
+    try:
+        with pytest.raises(MaxAttemptsError):
+            client.ping_all()
+        assert len(servers[0].calls) == 1
+        assert len(servers[1].calls) == 1
+        assert not servers[2].calls
+    finally:
+        client.close()
+        for server in servers:
+            server.close()
+
+
+def test_ping_all_probes_every_node_successfully():
+    servers = [MockServer([_response()]) for _ in range(3)]
+    client, _ = _client(servers)
+    try:
+        client.ping_all()
+
+        assert [len(server.calls) for server in servers] == [1, 1, 1]
+        for server in servers:
+            request = server.calls[0][1]
+            assert server.calls[0][0] == "getAccountInfo"
+            assert request.WhichOneof("query") == "cryptoGetInfo"
+            assert request.cryptoGetInfo.accountID == AccountId(0, 0, 2)._to_proto()
+            assert request.cryptoGetInfo.header.responseType == ResponseType.COST_ANSWER
+    finally:
+        client.close()
+        for server in servers:
+            server.close()

--- a/tests/unit/mock_server.py
+++ b/tests/unit/mock_server.py
@@ -34,6 +34,7 @@ class MockServer:
             responses (list): List of response objects to return in sequence
         """
         self.responses = responses
+        self.calls = []
         self._lock = threading.Lock()
         self.server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
 
@@ -99,6 +100,7 @@ class MockServer:
         """
         responses = self.responses
         lock = self._lock
+        calls = self.calls
 
         class MockServicer(servicer_class):
             def __getattribute__(self, name):
@@ -106,8 +108,9 @@ class MockServer:
                 if name in ("_next_response", "__class__"):
                     return super().__getattribute__(name)
 
-                def method_wrapper(_, context):
+                def method_wrapper(request, context):
                     with lock:
+                        calls.append((name, request))
                         if not responses:
                             return None
 


### PR DESCRIPTION
**Description**:

Add `Client.ping()` and `Client.ping_all()` and expose the corresponding TCK `ping` and `pingAll` JSON-RPC methods.

Use `CryptoService/getAccountInfo` for account `0.0.2` with `ResponseType.COST_ANSWER` as the health probe, avoiding the deprecated `CryptoService/cryptoGetBalance` endpoint.

* Add `Client.ping()` with a node-pinned `getAccountInfo` COST_ANSWER probe
* Add sequential, fail-fast `Client.ping_all()`
* Allow health probes to reach explicitly requested nodes while they are in backoff
* Reset node backoff and health state after a successful ping
* Add TCK `ping` and `pingAll` handlers, parameters, and responses
* Map unknown-node and transport failures to JSON-RPC `INTERNAL_ERROR`
* Preserve Hiero precheck error handling
* Add coverage for probe contents, backoff, recovery, unknown nodes, and `pingAll`

**Related issue(s)**:

Fixes #2607

**Notes for reviewer**:

Validation completed:

- Focused ping/TCK tests: 16 passed
- Affected regression tests: 234 passed
- Complete unit suite: 2936 passed
- `uv run ruff check .`: passed
- `uv run ruff format --check .`: passed
- `git diff --check`: passed

The tests verify that the ping probe uses:

- `CryptoService/getAccountInfo`
- account `0.0.2`
- `ResponseType.COST_ANSWER`
- no `CryptoService/cryptoGetBalance`

The external ClientPing TCK suite was also attempted. The Python JSON-RPC server started successfully and was reached by the TCK driver, but the end-to-end run was blocked because the local consensus and mirror network endpoints were unavailable.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)